### PR TITLE
Add seeded word scroller game

### DIFF
--- a/asl/js/scroller.js
+++ b/asl/js/scroller.js
@@ -1,0 +1,61 @@
+// Fetch session data and start the scroller once loaded
+document.addEventListener('DOMContentLoaded', () => {
+    fetch('scroller_game.php?action=data')
+        .then(resp => resp.json())
+        .then(startScroller)
+        .catch(err => console.error('Failed to load session data', err));
+});
+
+function startScroller(config) {
+    const { words, seed, wordCount, speed } = config;
+    const container = document.getElementById('scroller-container');
+    if (!container) return;
+
+    const sequence = shuffleWords(words, seed).slice(0, wordCount);
+    let index = 0;
+    const baseSpawn = 2000; // ms
+    const baseRise = 8000; // ms
+    const spawnInterval = baseSpawn / speed;
+    const riseDuration = baseRise / speed;
+
+    function spawn() {
+        if (index >= sequence.length) return;
+        const word = sequence[index++];
+        const el = document.createElement('div');
+        el.className = 'scroller-word rise';
+        el.textContent = word;
+        el.style.animationDuration = riseDuration + 'ms';
+        container.appendChild(el);
+
+        el.addEventListener('animationend', () => {
+            el.classList.remove('rise');
+            el.classList.add('blink');
+            el.addEventListener('animationend', () => el.remove(), { once: true });
+        }, { once: true });
+
+        setTimeout(spawn, spawnInterval);
+    }
+
+    spawn();
+}
+
+// Shuffle words with seeded RNG
+function shuffleWords(list, seed) {
+    const rng = mulberry32(seed);
+    const arr = list.slice();
+    for (let i = arr.length - 1; i > 0; i--) {
+        const j = Math.floor(rng() * (i + 1));
+        [arr[i], arr[j]] = [arr[j], arr[i]];
+    }
+    return arr;
+}
+
+// Mulberry32 PRNG for deterministic shuffling
+function mulberry32(a) {
+    return function() {
+        let t = a += 0x6D2B79F5;
+        t = Math.imul(t ^ t >>> 15, t | 1);
+        t ^= t + Math.imul(t ^ t >>> 7, t | 61);
+        return ((t ^ t >>> 14) >>> 0) / 4294967296;
+    };
+}

--- a/asl/scroller_game.php
+++ b/asl/scroller_game.php
@@ -1,0 +1,67 @@
+<?php
+session_start();
+require_once 'config.php';
+
+// When called with action=data, return JSON with active session details
+if (isset($_GET['action']) && $_GET['action'] === 'data') {
+    header('Content-Type: application/json');
+
+    try {
+        // Fetch the active session
+        $stmt = $pdo->query("SELECT id, seed, speed, word_count FROM scroller_sessions WHERE is_active = 1 LIMIT 1");
+        $session = $stmt ? $stmt->fetch(PDO::FETCH_ASSOC) : null;
+
+        if ($session) {
+            // Get all words associated with this session's word lists
+            $wordStmt = $pdo->prepare("SELECT w.word FROM scroller_session_words sw JOIN scroller_words w ON sw.word_id = w.id WHERE sw.session_id = ?");
+            $wordStmt->execute([$session['id']]);
+            $words = $wordStmt->fetchAll(PDO::FETCH_COLUMN);
+        } else {
+            $words = [];
+            $session = ['seed' => time(), 'speed' => 1.0, 'word_count' => 10];
+        }
+
+        echo json_encode([
+            'seed' => (int)$session['seed'],
+            'speed' => (float)$session['speed'],
+            'wordCount' => (int)$session['word_count'],
+            'words' => $words
+        ]);
+    } catch (Exception $e) {
+        echo json_encode([
+            'seed' => 1,
+            'speed' => 1.0,
+            'wordCount' => 0,
+            'words' => [],
+            'error' => $e->getMessage()
+        ]);
+    }
+    exit;
+}
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Scroller Game</title>
+    <style>
+        body { margin:0; overflow:hidden; background:#000; color:#fff; font-family:Arial, sans-serif; }
+        #scroller-container { position:relative; width:100%; height:100vh; overflow:hidden; }
+        .scroller-word { position:absolute; left:50%; transform:translateX(-50%); bottom:-10%; font-size:2.5rem; white-space:nowrap; }
+        .scroller-word.rise { animation-name:rise; animation-timing-function:linear; animation-fill-mode:forwards; }
+        @keyframes rise { from { bottom:-10%; } to { bottom:100%; } }
+        .scroller-word.blink { animation:blinkFade 1s forwards; }
+        @keyframes blinkFade {
+            0% { opacity:1; }
+            25% { opacity:0; }
+            50% { opacity:1; }
+            75% { opacity:0; }
+            100% { opacity:0; }
+        }
+    </style>
+</head>
+<body>
+    <div id="scroller-container"></div>
+    <script src="js/scroller.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `scroller_game.php` that serves the scrolling game and JSON data for active sessions
- create `scroller.js` to fetch session info, seed-based word selection, and animated scrolling display

## Testing
- `php -l asl/scroller_game.php`
- `node --check asl/js/scroller.js && echo "JS OK"`


------
https://chatgpt.com/codex/tasks/task_e_68957388664c832783ba409d23c0fcc4