### PR TITLE
Add looping word scroller with celebration and replay controls

### DIFF
--- a/asl/css/scroller.css
+++ b/asl/css/scroller.css
@@ -1,0 +1,54 @@
+body {
+  margin: 0;
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  font-family: Arial, sans-serif;
+  background: #f0f4f8;
+}
+
+.screen {
+  text-align: center;
+}
+
+.controls {
+  margin: 20px 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+#scroller {
+  position: relative;
+  width: 400px;
+  height: 80px;
+  overflow: hidden;
+  border: 2px solid #3182ce;
+  border-radius: 8px;
+  background: #fff;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.scroll-word {
+  position: absolute;
+  width: 100%;
+  text-align: center;
+  font-size: 2rem;
+  top: 100%;
+  animation-name: scrollUp;
+  animation-timing-function: linear;
+  animation-fill-mode: forwards;
+}
+
+@keyframes scrollUp {
+  from { top: 100%; }
+  to   { top: -100%; }
+}
+
+.hidden {
+  display: none;
+}

--- a/asl/js/scroller.js
+++ b/asl/js/scroller.js
@@ -1,0 +1,103 @@
+const WORDS = [
+  'apple','banana','cherry','dragon','eagle','forest','garden','harbor','island','jungle',
+  'kitten','lemon','mountain','nebula','ocean','puzzle','quantum','rocket','sunrise','turtle',
+  'unicorn','voyage','whisper','xylophone','yonder','zephyr','amber','breeze','crystal','dawn',
+  'ember','flame','goblin','horizon','illusion','jewel','kingdom','legend','meteor','nectar',
+  'oracle','phoenix','quiver','raven','saber','thunder','utopia','victory','wizard','yolk'
+];
+
+let currentWords = [];
+let lastWordElement = null;
+
+function updateDisplay(id, value) {
+  document.getElementById(id).textContent = value;
+}
+
+function getRandomWords(count) {
+  const shuffled = [...WORDS].sort(() => Math.random() - 0.5);
+  return shuffled.slice(0, count);
+}
+
+function startGame(speed, count) {
+  currentWords = getRandomWords(count);
+  const scroller = document.getElementById('scroller');
+  scroller.innerHTML = '';
+
+  currentWords.forEach((word, i) => {
+    const el = document.createElement('div');
+    el.className = 'scroll-word';
+    el.textContent = word;
+    el.style.animationDuration = `${speed}ms`;
+    el.style.animationDelay = `${i * speed}ms`;
+    scroller.appendChild(el);
+    if (i === currentWords.length - 1) {
+      lastWordElement = el;
+    }
+  });
+
+  if (lastWordElement) {
+    lastWordElement.addEventListener('animationend', onFinish, { once: true });
+  }
+
+  document.getElementById('setup').classList.add('hidden');
+  document.getElementById('summary').classList.add('hidden');
+  scroller.classList.remove('hidden');
+}
+
+function onFinish() {
+  launchConfetti();
+  showSummary();
+}
+
+function launchConfetti() {
+  const duration = 3000;
+  const end = Date.now() + duration;
+
+  (function frame() {
+    confetti({ particleCount: 2, angle: 60, spread: 55, origin: { x: 0 } });
+    confetti({ particleCount: 2, angle: 120, spread: 55, origin: { x: 1 } });
+    if (Date.now() < end) {
+      requestAnimationFrame(frame);
+    }
+  })();
+}
+
+function showSummary() {
+  const list = document.getElementById('summaryList');
+  list.innerHTML = '';
+  currentWords.forEach(w => {
+    const li = document.createElement('li');
+    li.textContent = w;
+    list.appendChild(li);
+  });
+
+  const scroller = document.getElementById('scroller');
+  scroller.classList.add('hidden');
+  document.getElementById('summary').classList.remove('hidden');
+}
+
+function init() {
+  const speedInput = document.getElementById('speed');
+  const countInput = document.getElementById('count');
+  const speedInput2 = document.getElementById('speed2');
+  const countInput2 = document.getElementById('count2');
+
+  speedInput.addEventListener('input', () => updateDisplay('speedVal', speedInput.value));
+  countInput.addEventListener('input', () => updateDisplay('countVal', countInput.value));
+  speedInput2.addEventListener('input', () => updateDisplay('speedVal2', speedInput2.value));
+  countInput2.addEventListener('input', () => updateDisplay('countVal2', countInput2.value));
+
+  document.getElementById('playBtn').addEventListener('click', () => {
+    speedInput2.value = speedInput.value;
+    countInput2.value = countInput.value;
+    updateDisplay('speedVal2', speedInput2.value);
+    updateDisplay('countVal2', countInput2.value);
+    startGame(Number(speedInput.value), Number(countInput.value));
+  });
+
+  document.getElementById('playAgainBtn').addEventListener('click', () => {
+    startGame(Number(speedInput2.value), Number(countInput2.value));
+  });
+}
+
+document.addEventListener('DOMContentLoaded', init);

--- a/asl/scroller.html
+++ b/asl/scroller.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Word Scroller</title>
+  <link rel="stylesheet" href="css/scroller.css">
+  <script src="https://cdn.jsdelivr.net/npm/canvas-confetti@1.6.0/dist/confetti.browser.min.js"></script>
+</head>
+<body>
+  <div id="setup" class="screen">
+    <h1>Word Scroller</h1>
+    <div class="controls">
+      <label>Speed (ms per word):
+        <input type="range" id="speed" min="200" max="2000" step="100" value="800">
+        <span id="speedVal">800</span>
+      </label>
+      <label>Word Count:
+        <input type="range" id="count" min="5" max="20" value="10">
+        <span id="countVal">10</span>
+      </label>
+    </div>
+    <button id="playBtn">Play</button>
+  </div>
+
+  <div id="scroller" class="screen hidden"></div>
+
+  <div id="summary" class="screen hidden">
+    <h2>Words Shown</h2>
+    <ul id="summaryList"></ul>
+    <div class="controls">
+      <label>Speed (ms per word):
+        <input type="range" id="speed2" min="200" max="2000" step="100" value="800">
+        <span id="speedVal2">800</span>
+      </label>
+      <label>Word Count:
+        <input type="range" id="count2" min="5" max="20" value="10">
+        <span id="countVal2">10</span>
+      </label>
+    </div>
+    <button id="playAgainBtn">Play Again</button>
+  </div>
+
+  <script src="js/scroller.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add standalone word scroller page with adjustable speed and word count
- Trigger confetti when the final word reaches the top and show words in order
- Provide play-again flow with controls to restart the scrolling routine

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68957388f0d883279ed7d2b5db0d7b8a