### PR TITLE
Add word list CRUD endpoints and dynamic scroller words

### DIFF
--- a/asl/add_wordlist.php
+++ b/asl/add_wordlist.php
@@ -1,0 +1,31 @@
+<?php
+session_start();
+require_once 'config.php';
+
+header('Content-Type: application/json');
+
+if (!isset($_SESSION['user_id']) || !isset($_SESSION['is_teacher']) || !$_SESSION['is_teacher']) {
+    echo json_encode(['success' => false, 'message' => 'Unauthorized']);
+    exit;
+}
+
+$name = trim($_POST['wordlist_name'] ?? '');
+$words_raw = trim($_POST['words'] ?? '');
+$speed = isset($_POST['speed']) ? floatval($_POST['speed']) : 1.0;
+$count = isset($_POST['word_count']) ? intval($_POST['word_count']) : 24;
+
+if ($name === '' || $words_raw === '') {
+    echo json_encode(['success' => false, 'message' => 'Missing required fields']);
+    exit;
+}
+
+$words = preg_split('/[\r\n,]+/', $words_raw, -1, PREG_SPLIT_NO_EMPTY);
+
+try {
+    $stmt = $pdo->prepare("INSERT INTO wordlists (teacher_id, wordlist_name, words, speed, word_count, created_at) VALUES (?, ?, ?, ?, ?, NOW())");
+    $stmt->execute([$_SESSION['user_id'], $name, json_encode($words), $speed, $count]);
+    echo json_encode(['success' => true]);
+} catch (PDOException $e) {
+    echo json_encode(['success' => false, 'message' => 'Error creating word list']);
+}
+?>

--- a/asl/database_setup.sql
+++ b/asl/database_setup.sql
@@ -68,3 +68,27 @@ INSERT INTO resources (skill_id, resource_name, resource_url, order_index) VALUE
 (2, 'Resource 1 for Skill Test 2', '#', 1),
 (2, 'Resource 2 for Skill Test 2', '#', 2);
 
+-- Word lists for scroller game
+CREATE TABLE IF NOT EXISTS wordlists (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    teacher_id INT NOT NULL,
+    wordlist_name VARCHAR(255) NOT NULL,
+    words TEXT NOT NULL,
+    speed FLOAT DEFAULT 1.0,
+    word_count INT DEFAULT 24,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (teacher_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
+-- Active scroller sessions
+CREATE TABLE IF NOT EXISTS scroller_sessions (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    teacher_id INT NOT NULL,
+    wordlist_ids TEXT NOT NULL,
+    speed_override FLOAT NULL,
+    word_count_override INT NULL,
+    seed INT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (teacher_id) REFERENCES users(id) ON DELETE CASCADE
+);
+

--- a/asl/delete_wordlist.php
+++ b/asl/delete_wordlist.php
@@ -1,0 +1,25 @@
+<?php
+session_start();
+require_once 'config.php';
+
+header('Content-Type: application/json');
+
+if (!isset($_SESSION['user_id']) || !isset($_SESSION['is_teacher']) || !$_SESSION['is_teacher']) {
+    echo json_encode(['success' => false, 'message' => 'Unauthorized']);
+    exit;
+}
+
+$id = isset($_POST['wordlist_id']) ? intval($_POST['wordlist_id']) : 0;
+if ($id <= 0) {
+    echo json_encode(['success' => false, 'message' => 'Invalid word list']);
+    exit;
+}
+
+try {
+    $stmt = $pdo->prepare("DELETE FROM wordlists WHERE id = ? AND teacher_id = ?");
+    $stmt->execute([$id, $_SESSION['user_id']]);
+    echo json_encode(['success' => true]);
+} catch (PDOException $e) {
+    echo json_encode(['success' => false, 'message' => 'Error deleting word list']);
+}
+?>

--- a/asl/edit_wordlist.php
+++ b/asl/edit_wordlist.php
@@ -1,0 +1,32 @@
+<?php
+session_start();
+require_once 'config.php';
+
+header('Content-Type: application/json');
+
+if (!isset($_SESSION['user_id']) || !isset($_SESSION['is_teacher']) || !$_SESSION['is_teacher']) {
+    echo json_encode(['success' => false, 'message' => 'Unauthorized']);
+    exit;
+}
+
+$id = isset($_POST['wordlist_id']) ? intval($_POST['wordlist_id']) : 0;
+$name = trim($_POST['wordlist_name'] ?? '');
+$words_raw = trim($_POST['words'] ?? '');
+$speed = isset($_POST['speed']) ? floatval($_POST['speed']) : 1.0;
+$count = isset($_POST['word_count']) ? intval($_POST['word_count']) : 24;
+
+if ($id <= 0 || $name === '' || $words_raw === '') {
+    echo json_encode(['success' => false, 'message' => 'Missing required fields']);
+    exit;
+}
+
+$words = preg_split('/[\r\n,]+/', $words_raw, -1, PREG_SPLIT_NO_EMPTY);
+
+try {
+    $stmt = $pdo->prepare("UPDATE wordlists SET wordlist_name = ?, words = ?, speed = ?, word_count = ? WHERE id = ? AND teacher_id = ?");
+    $stmt->execute([$name, json_encode($words), $speed, $count, $id, $_SESSION['user_id']]);
+    echo json_encode(['success' => true]);
+} catch (PDOException $e) {
+    echo json_encode(['success' => false, 'message' => 'Error updating word list']);
+}
+?>

--- a/asl/get_session_words.php
+++ b/asl/get_session_words.php
@@ -1,0 +1,51 @@
+<?php
+require_once 'config.php';
+header('Content-Type: application/json');
+
+$session_code = isset($_GET['session_code']) ? intval($_GET['session_code']) : 0;
+if ($session_code <= 0) {
+    echo json_encode(['words' => []]);
+    exit;
+}
+
+try {
+    $stmt = $pdo->prepare("SELECT wordlist_ids, speed_override, word_count_override, seed FROM scroller_sessions WHERE id = ?");
+    $stmt->execute([$session_code]);
+    $session = $stmt->fetch(PDO::FETCH_ASSOC);
+    if (!$session) {
+        echo json_encode(['words' => []]);
+        exit;
+    }
+
+    $wordlist_ids = json_decode($session['wordlist_ids'], true);
+    if (!is_array($wordlist_ids) || empty($wordlist_ids)) {
+        echo json_encode(['words' => []]);
+        exit;
+    }
+
+    $placeholders = implode(',', array_fill(0, count($wordlist_ids), '?'));
+    $stmt = $pdo->prepare("SELECT words FROM wordlists WHERE id IN ($placeholders)");
+    $stmt->execute($wordlist_ids);
+    $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
+    $all_words = [];
+    foreach ($rows as $row) {
+        $w = json_decode($row['words'], true);
+        if (is_array($w)) {
+            $all_words = array_merge($all_words, $w);
+        }
+    }
+
+    $seed = $session['seed'] ?? random_int(1, 2147483647);
+    $count = $session['word_count_override'] ?? count($all_words);
+    $speed = $session['speed_override'];
+
+    echo json_encode([
+        'words' => $all_words,
+        'seed' => $seed,
+        'word_count' => $count,
+        'speed' => $speed
+    ]);
+} catch (PDOException $e) {
+    echo json_encode(['words' => []]);
+}
+?>

--- a/asl/get_wordlists.php
+++ b/asl/get_wordlists.php
@@ -10,9 +10,14 @@ if (!isset($_SESSION['user_id']) || !isset($_SESSION['is_teacher']) || !$_SESSIO
 }
 
 try {
-    $stmt = $pdo->prepare("SELECT id, wordlist_name, speed, word_count FROM wordlists WHERE teacher_id = ? ORDER BY created_at DESC");
+    $stmt = $pdo->prepare("SELECT id, wordlist_name, words, speed, word_count FROM wordlists WHERE teacher_id = ? ORDER BY created_at DESC");
     $stmt->execute([$_SESSION['user_id']]);
     $lists = $stmt->fetchAll(PDO::FETCH_ASSOC);
+    // Decode words column before returning
+    foreach ($lists as &$list) {
+        $decoded = json_decode($list['words'], true);
+        $list['words'] = is_array($decoded) ? $decoded : [];
+    }
     echo json_encode(['wordlists' => $lists]);
 } catch (PDOException $e) {
     echo json_encode(['wordlists' => []]);

--- a/asl/teacher_dashboard.php
+++ b/asl/teacher_dashboard.php
@@ -523,7 +523,23 @@ try {
                     sessionContainer.innerHTML = '';
                     data.wordlists.forEach(list => {
                         const listDiv = document.createElement('div');
-                        listDiv.textContent = list.wordlist_name;
+                        listDiv.className = 'wordlist-item';
+                        const nameSpan = document.createElement('span');
+                        nameSpan.textContent = list.wordlist_name;
+                        listDiv.appendChild(nameSpan);
+
+                        const editBtn = document.createElement('button');
+                        editBtn.className = 'action-btn edit-btn';
+                        editBtn.textContent = 'Edit';
+                        editBtn.addEventListener('click', () => showEditWordlistModal(list));
+                        listDiv.appendChild(editBtn);
+
+                        const deleteBtn = document.createElement('button');
+                        deleteBtn.className = 'action-btn delete-btn';
+                        deleteBtn.textContent = 'Delete';
+                        deleteBtn.addEventListener('click', () => deleteWordlist(list.id));
+                        listDiv.appendChild(deleteBtn);
+
                         listContainer.appendChild(listDiv);
 
                         const label = document.createElement('label');
@@ -540,6 +556,92 @@ try {
                 })
                 .catch(error => {
                     console.error('Error loading word lists:', error);
+                });
+        }
+
+        function showAddWordlistForm() {
+            document.getElementById('add-wordlist-form').style.display = 'block';
+        }
+
+        function hideAddWordlistForm() {
+            document.getElementById('add-wordlist-form').style.display = 'none';
+            document.getElementById('new-wordlist-form').reset();
+        }
+
+        function refreshWordlists() {
+            loadWordlists();
+        }
+
+        function submitNewWordlist() {
+            const form = document.getElementById('new-wordlist-form');
+            const formData = new FormData(form);
+            fetch('add_wordlist.php', { method: 'POST', body: formData })
+                .then(response => response.json())
+                .then(data => {
+                    if (data.success) {
+                        showMessage('Word list created!', 'success');
+                        hideAddWordlistForm();
+                        loadWordlists();
+                    } else {
+                        showMessage(data.message || 'Error creating word list', 'error');
+                    }
+                })
+                .catch(error => {
+                    console.error('Error creating word list:', error);
+                    showMessage('Error creating word list. Please try again.', 'error');
+                });
+        }
+
+        function showEditWordlistModal(list) {
+            document.getElementById('edit-wordlist-id').value = list.id;
+            document.getElementById('edit-wordlist-name').value = list.wordlist_name;
+            document.getElementById('edit-words').value = (list.words || []).join('\n');
+            document.getElementById('edit-speed').value = list.speed;
+            document.getElementById('edit-word-count').value = list.word_count;
+            document.getElementById('edit-wordlist-modal').style.display = 'block';
+        }
+
+        function closeEditWordlistModal() {
+            document.getElementById('edit-wordlist-modal').style.display = 'none';
+        }
+
+        function submitEditWordlist() {
+            const form = document.getElementById('edit-wordlist-form');
+            const formData = new FormData(form);
+            fetch('edit_wordlist.php', { method: 'POST', body: formData })
+                .then(response => response.json())
+                .then(data => {
+                    if (data.success) {
+                        showMessage('Word list updated!', 'success');
+                        closeEditWordlistModal();
+                        loadWordlists();
+                    } else {
+                        showMessage(data.message || 'Error updating word list', 'error');
+                    }
+                })
+                .catch(error => {
+                    console.error('Error updating word list:', error);
+                    showMessage('Error updating word list. Please try again.', 'error');
+                });
+        }
+
+        function deleteWordlist(id) {
+            if (!confirm('Delete this word list?')) return;
+            const formData = new FormData();
+            formData.append('wordlist_id', id);
+            fetch('delete_wordlist.php', { method: 'POST', body: formData })
+                .then(response => response.json())
+                .then(data => {
+                    if (data.success) {
+                        showMessage('Word list deleted', 'success');
+                        loadWordlists();
+                    } else {
+                        showMessage(data.message || 'Error deleting word list', 'error');
+                    }
+                })
+                .catch(error => {
+                    console.error('Error deleting word list:', error);
+                    showMessage('Error deleting word list. Please try again.', 'error');
                 });
         }
 


### PR DESCRIPTION
## Summary
- add endpoints and schema for scroller word lists and sessions
- load and edit word lists from teacher dashboard
- fetch session words and shuffle deterministically in scroller game

## Testing
- `php -l asl/add_wordlist.php`
- `php -l asl/edit_wordlist.php`
- `php -l asl/delete_wordlist.php`
- `php -l asl/get_session_words.php`
- `php -l asl/get_wordlists.php`
- `php -l asl/teacher_dashboard.php`
- `php -l asl/create_session.php`


------
https://chatgpt.com/codex/tasks/task_e_689578f0a1dc8327b2a1d5127078d9a3