### PR TITLE
Add student deletion endpoints and UI controls

### DIFF
--- a/asl1/delete_student.php
+++ b/asl1/delete_student.php
@@ -1,0 +1,3 @@
+<?php
+require_once __DIR__ . '/config.php';
+require_once __DIR__ . '/../common/delete_student.php';

--- a/asl1/student_details.php
+++ b/asl1/student_details.php
@@ -338,9 +338,18 @@ $progress_percentage = $student['total_possible_points'] > 0 ?
             background: #e2e8f0;
             color: #4a5568;
         }
-        
+
         .btn-secondary:hover {
             background: #cbd5e0;
+        }
+
+        .btn-danger {
+            background: #f56565;
+            color: white;
+        }
+
+        .btn-danger:hover {
+            background: #c53030;
         }
     </style>
 </head>
@@ -421,6 +430,7 @@ $progress_percentage = $student['total_possible_points'] > 0 ?
                     <div class="button-group">
                         <button type="submit" class="form-button btn-primary">Update Student Details</button>
                         <a href="teacher_dashboard.php" class="form-button btn-secondary" style="text-decoration: none; display: inline-block; text-align: center;">Cancel</a>
+                        <button type="button" class="form-button btn-danger" id="delete-student-btn">Delete Student</button>
                     </div>
                 </form>
             </div>
@@ -448,5 +458,51 @@ $progress_percentage = $student['total_possible_points'] > 0 ?
             </div>
         </div>
     </div>
+
+    <script>
+        (function() {
+            const deleteButton = document.getElementById('delete-student-btn');
+            if (!deleteButton) {
+                return;
+            }
+
+            deleteButton.addEventListener('click', function() {
+                if (!confirm('Are you sure you want to delete this student? This action cannot be undone.')) {
+                    return;
+                }
+
+                const originalText = deleteButton.textContent;
+                deleteButton.disabled = true;
+                deleteButton.textContent = 'Deleting...';
+
+                const params = new URLSearchParams();
+                params.append('student_id', '<?php echo $student['id']; ?>');
+
+                fetch('delete_student.php', {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/x-www-form-urlencoded'
+                    },
+                    body: params.toString()
+                })
+                .then(response => response.json())
+                .then(data => {
+                    if (data.success) {
+                        window.location.href = 'teacher_dashboard.php';
+                        return;
+                    }
+
+                    alert(data.message || 'Unable to delete student. Please try again.');
+                    deleteButton.disabled = false;
+                    deleteButton.textContent = originalText;
+                })
+                .catch(() => {
+                    alert('An unexpected error occurred while deleting the student.');
+                    deleteButton.disabled = false;
+                    deleteButton.textContent = originalText;
+                });
+            });
+        })();
+    </script>
 </body>
 </html>

--- a/asl2/delete_student.php
+++ b/asl2/delete_student.php
@@ -1,0 +1,3 @@
+<?php
+require_once __DIR__ . '/config.php';
+require_once __DIR__ . '/../common/delete_student.php';

--- a/asl2/student_details.php
+++ b/asl2/student_details.php
@@ -338,9 +338,18 @@ $progress_percentage = $student['total_possible_points'] > 0 ?
             background: #e2e8f0;
             color: #4a5568;
         }
-        
+
         .btn-secondary:hover {
             background: #cbd5e0;
+        }
+
+        .btn-danger {
+            background: #f56565;
+            color: white;
+        }
+
+        .btn-danger:hover {
+            background: #c53030;
         }
     </style>
 </head>
@@ -421,6 +430,7 @@ $progress_percentage = $student['total_possible_points'] > 0 ?
                     <div class="button-group">
                         <button type="submit" class="form-button btn-primary">Update Student Details</button>
                         <a href="teacher_dashboard.php" class="form-button btn-secondary" style="text-decoration: none; display: inline-block; text-align: center;">Cancel</a>
+                        <button type="button" class="form-button btn-danger" id="delete-student-btn">Delete Student</button>
                     </div>
                 </form>
             </div>
@@ -448,5 +458,51 @@ $progress_percentage = $student['total_possible_points'] > 0 ?
             </div>
         </div>
     </div>
+
+    <script>
+        (function() {
+            const deleteButton = document.getElementById('delete-student-btn');
+            if (!deleteButton) {
+                return;
+            }
+
+            deleteButton.addEventListener('click', function() {
+                if (!confirm('Are you sure you want to delete this student? This action cannot be undone.')) {
+                    return;
+                }
+
+                const originalText = deleteButton.textContent;
+                deleteButton.disabled = true;
+                deleteButton.textContent = 'Deleting...';
+
+                const params = new URLSearchParams();
+                params.append('student_id', '<?php echo $student['id']; ?>');
+
+                fetch('delete_student.php', {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/x-www-form-urlencoded'
+                    },
+                    body: params.toString()
+                })
+                .then(response => response.json())
+                .then(data => {
+                    if (data.success) {
+                        window.location.href = 'teacher_dashboard.php';
+                        return;
+                    }
+
+                    alert(data.message || 'Unable to delete student. Please try again.');
+                    deleteButton.disabled = false;
+                    deleteButton.textContent = originalText;
+                })
+                .catch(() => {
+                    alert('An unexpected error occurred while deleting the student.');
+                    deleteButton.disabled = false;
+                    deleteButton.textContent = originalText;
+                });
+            });
+        })();
+    </script>
 </body>
 </html>

--- a/common/delete_student.php
+++ b/common/delete_student.php
@@ -1,0 +1,53 @@
+<?php
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
+
+header('Content-Type: application/json');
+
+function respondWithJson(int $statusCode, array $payload): void {
+    http_response_code($statusCode);
+    echo json_encode($payload);
+    exit;
+}
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    respondWithJson(405, ['success' => false, 'message' => 'Invalid request method.']);
+}
+
+if (!isset($_SESSION['user_id'], $_SESSION['is_teacher']) || !$_SESSION['is_teacher']) {
+    respondWithJson(403, ['success' => false, 'message' => 'Unauthorized.']);
+}
+
+if (!isset($pdo) || !($pdo instanceof PDO)) {
+    respondWithJson(500, ['success' => false, 'message' => 'Database connection is unavailable.']);
+}
+
+$studentId = filter_input(INPUT_POST, 'student_id', FILTER_VALIDATE_INT);
+
+if (!$studentId || $studentId <= 0) {
+    respondWithJson(400, ['success' => false, 'message' => 'Invalid student identifier.']);
+}
+
+try {
+    $pdo->beginTransaction();
+
+    $skillStmt = $pdo->prepare('DELETE FROM user_skills WHERE user_id = :student_id');
+    $skillStmt->execute(['student_id' => $studentId]);
+
+    $userStmt = $pdo->prepare('DELETE FROM users WHERE id = :student_id AND is_teacher = FALSE');
+    $userStmt->execute(['student_id' => $studentId]);
+
+    if ($userStmt->rowCount() === 0) {
+        $pdo->rollBack();
+        respondWithJson(404, ['success' => false, 'message' => 'Student not found.']);
+    }
+
+    $pdo->commit();
+    respondWithJson(200, ['success' => true]);
+} catch (PDOException $e) {
+    if ($pdo->inTransaction()) {
+        $pdo->rollBack();
+    }
+    respondWithJson(500, ['success' => false, 'message' => 'Failed to delete student.']);
+}


### PR DESCRIPTION
## Summary
- add a shared `common/delete_student.php` handler that validates the teacher session, removes user skill rows, and deletes the student record while returning JSON responses
- expose wrapper endpoints for ASL1 and ASL2 and add delete actions to each student detail screen that call the shared handler
- add delete shortcuts on both teacher dashboards with confirmation, request handling, and counter updates

## Testing
- php -l common/delete_student.php
- php -l asl1/delete_student.php
- php -l asl2/delete_student.php
- php -l asl1/student_details.php
- php -l asl2/student_details.php
- php -l asl1/teacher_dashboard.php
- php -l asl2/teacher_dashboard.php

------
https://chatgpt.com/codex/tasks/task_e_68c96ff2b3988327b3212358d0bdebc4