### PR TITLE
Add climbing other creatures and claw dirt rules

### DIFF
--- a/dnd/rules/universal-actions/index.html
+++ b/dnd/rules/universal-actions/index.html
@@ -210,6 +210,20 @@
                     <div class="action-text">
                         <strong>Burrow:</strong> Move through dirt horizontally at full speed (requires burrow speed).<br>
                         <strong>Dig:</strong> <span class="mechanic">Maneuver</span> to move vertically up to your <span class="mechanic">size</span> in squares (requires burrow speed ≥ size).
+                        <div class="ability-block">
+                            <strong>Claw Dirt</strong><br>
+                            <span class="keywords">Maneuver</span> • <span class="range">Self</span><br>
+                            Power Roll + Might:
+                            <div class="roll-results">
+                                <strong>11-:</strong> Move 1 square into, out of, or through burrowable ground you're touching and become <span class="mechanic">slowed</span> and <span class="mechanic">weakened</span> (EoT).<br>
+                                <strong>12-16:</strong> You can use your main action this turn to move 1 square into, out of, or through burrowable ground you're touching and become <span class="mechanic">slowed</span> (EoT).<br>
+                                <strong>17+:</strong> Move up to 1 square into, out of, or through burrowable ground you're touching.
+                            </div>
+                        </div>
+                        <div class="ability-block">
+                            <strong>Burrowing Forced Movement</strong><br>
+                            A burrowing creature that is completely beneath the ground ignores non-vertical forced movement and instead takes 1 damage per square it would have moved. Vertical forced movement moves the creature through the dirt as normal.
+                        </div>
                     </div>
                 </div>
 
@@ -217,6 +231,33 @@
                     <div class="action-name">CLIMB & SWIM</div>
                     <div class="action-text">
                         With special movement: full speed. Without: <span class="highlight">2 movement per square</span>. Difficult surfaces require <span class="mechanic">Might test</span> (failure wastes no movement).
+                    </div>
+                </div>
+
+                <div class="action">
+                    <div class="action-name">CLIMB OTHER CREATURES</div>
+                    <div class="action-text">
+                        You can attempt to climb a creature whose size is greater than yours. Climbing a willing creature requires no test.
+                        <div class="ability-block">
+                            <strong>Climb Unwilling Creature</strong><br>
+                            Power Roll + Might or Agility:
+                            <div class="roll-results">
+                                <strong>11-:</strong> You fail to climb the creature and it can make a <span class="mechanic">free strike</span> against you.<br>
+                                <strong>12-16:</strong> You fail to climb the creature.<br>
+                                <strong>17+:</strong> You climb the creature.
+                            </div>
+                        </div>
+                        While you climb or ride a creature, you gain <span class="bonus">edge</span> on melee abilities used against it. The creature can use a <span class="mechanic">maneuver</span> to attempt to knock you off, forcing the following test:
+                        <div class="ability-block">
+                            <strong>Hold On</strong><br>
+                            Power Roll + Might or Agility:
+                            <div class="roll-results">
+                                <strong>11-:</strong> You fall off into an unoccupied adjacent space of your choice, taking falling damage and landing <span class="mechanic">prone</span> as normal.<br>
+                                <strong>12-16:</strong> You slide down into an unoccupied adjacent space of your choice and don't land prone.<br>
+                                <strong>17+:</strong> You continue to hold on to the creature.
+                            </div>
+                        </div>
+                        If you are knocked prone while climbing or riding a creature, you fall into an adjacent space of your choice, taking the usual falling damage and landing <span class="mechanic">prone</span>.
                     </div>
                 </div>
 


### PR DESCRIPTION
## Summary
- add the Claw Dirt maneuver with standardized roll results alongside burrow and dig guidance
- document burrowing forced movement interactions for creatures underground
- add climbing other creatures rules with success tables for mounting and holding on

## Testing
- not run (HTML content only)


------
https://chatgpt.com/codex/tasks/task_e_68ca0a53c61483279612609e3e7b06cd