### PR TITLE
Add image preview modal for Strixhaven templates

### DIFF
--- a/dnd/strixhaven/templates/css/templates.css
+++ b/dnd/strixhaven/templates/css/templates.css
@@ -430,12 +430,29 @@
     border: 2px solid #ddd;
     border-radius: 8px;
     overflow: hidden;
+    transition: box-shadow 0.2s ease;
+}
+
+.image-container:focus-within {
+    box-shadow: 0 0 0 3px rgba(52, 152, 219, 0.35);
 }
 
 #template-image {
     width: 100%;
     height: 100%;
     object-fit: cover;
+    cursor: pointer;
+    transition: transform 0.2s ease;
+    outline: none;
+}
+
+#template-image:hover,
+#template-image:focus {
+    transform: scale(1.02);
+}
+
+#template-image:focus-visible {
+    outline: none;
 }
 
 .image-placeholder {
@@ -677,6 +694,91 @@
     padding: 10px 20px;
     border-radius: 5px;
     cursor: pointer;
+}
+
+/* Image preview modal */
+.image-modal-content {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    background: #ffffff;
+    padding: 25px;
+    border-radius: 10px;
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.35);
+    max-width: 90%;
+    max-height: 90%;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 20px;
+}
+
+.image-modal-close {
+    position: absolute;
+    top: 10px;
+    right: 15px;
+    background: transparent;
+    border: none;
+    font-size: 28px;
+    color: #333;
+    cursor: pointer;
+    line-height: 1;
+    padding: 5px;
+}
+
+.image-modal-close:hover,
+.image-modal-close:focus {
+    color: #000;
+}
+
+.image-modal-close:focus {
+    outline: 2px solid #3498db;
+    outline-offset: 2px;
+}
+
+#image-modal-img {
+    max-width: 100%;
+    max-height: 70vh;
+    border-radius: 8px;
+    box-shadow: 0 5px 15px rgba(0, 0, 0, 0.25);
+}
+
+.image-modal-actions {
+    display: flex;
+    gap: 15px;
+    flex-wrap: wrap;
+    justify-content: center;
+    width: 100%;
+}
+
+.image-modal-link {
+    padding: 10px 18px;
+    border-radius: 6px;
+    text-decoration: none;
+    font-weight: 600;
+    color: #ffffff;
+    background: #3498db;
+    transition: background 0.2s ease;
+}
+
+.image-modal-link:hover,
+.image-modal-link:focus {
+    background: #2c80b4;
+}
+
+.image-modal-link:focus-visible {
+    outline: 2px solid rgba(255, 255, 255, 0.7);
+    outline-offset: 2px;
+}
+
+.image-modal-download {
+    background: #27ae60;
+}
+
+.image-modal-download:hover,
+.image-modal-download:focus {
+    background: #1f8a4d;
 }
 
 .btn-secondary:hover {

--- a/dnd/strixhaven/templates/index.php
+++ b/dnd/strixhaven/templates/index.php
@@ -116,7 +116,7 @@ $templatesData = loadTemplatesData();
                             <div class="header-right">
                                 <div class="image-and-circle">
                                     <div class="image-container">
-                                        <img id="template-image" src="" alt="Template Image" style="display: none;">
+                                        <img id="template-image" src="" alt="Template Image" style="display: none;" tabindex="0" role="button" aria-label="View template image">
                                         <div id="image-placeholder" class="image-placeholder">
                                             <p>No Image</p>
                                             <?php if ($is_gm): ?>
@@ -212,6 +212,18 @@ $templatesData = loadTemplatesData();
             <div class="modal-buttons">
                 <button class="btn-danger" onclick="confirmDelete()">Delete</button>
                 <button class="btn-secondary" onclick="cancelDelete()">Cancel</button>
+            </div>
+        </div>
+    </div>
+
+    <!-- Image Preview Modal -->
+    <div id="image-modal" class="modal" style="display: none;" aria-hidden="true" role="dialog" aria-modal="true" aria-label="Template image preview">
+        <div class="image-modal-content">
+            <button type="button" id="image-modal-close" class="image-modal-close" aria-label="Close image preview">&times;</button>
+            <img id="image-modal-img" src="" alt="Template Image Preview">
+            <div class="image-modal-actions">
+                <a id="image-modal-open" class="image-modal-link" href="#" target="_blank" rel="noopener noreferrer">Open in new tab</a>
+                <a id="image-modal-download" class="image-modal-link image-modal-download" href="#" download>Download</a>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- make the template header image interactive with keyboard support and add an accessible preview modal
- style the modal and image container so the previewed portrait can be opened or downloaded easily
- extend the template scripts to manage the preview lifecycle and keep image metadata in sync after uploads

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68ca0ec7c7b48327b68ec3747e7e25ee