### PR TITLE
Improve creature card drag responsiveness

### DIFF
--- a/dnd/combat/css/combat.css
+++ b/dnd/combat/css/combat.css
@@ -266,7 +266,7 @@ body {
     border: 2px solid #fff;
     border-radius: 8px;
     box-shadow: 0 4px 15px rgba(0, 0, 0, 0.3);
-    transition: all 0.3s ease;
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
     z-index: 10;
     display: flex;
     flex-direction: column;
@@ -323,6 +323,7 @@ body {
     transform: rotate(1deg) scale(1.03);
     box-shadow: 0 15px 40px rgba(0, 0, 0, 0.6);
     z-index: 1000;
+    transition: none;
 }
 
 /* Player Mode - Read Only */


### PR DESCRIPTION
## Summary
- limit the creature card transition to transform and box-shadow animations
- disable transitions while a creature card is dragging so it follows the cursor precisely

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68ca12d6c73883278c039d2659d41cce