### PR TITLE
Add Christmas and Frunk dashboard themes

### DIFF
--- a/dnd/Christmas/theme.css
+++ b/dnd/Christmas/theme.css
@@ -1,0 +1,415 @@
+@import url('https://fonts.googleapis.com/css2?family=Mountains+of+Christmas:wght@400;700&family=Nunito:wght@400;600;700&display=swap');
+
+body.christmas-theme {
+    font-family: 'Nunito', 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+    background: linear-gradient(180deg, #0b3d91 0%, #0b1a3d 45%, #020915 100%);
+    color: #f5f9ff;
+    position: relative;
+    overflow-x: hidden;
+}
+
+body.christmas-theme::before {
+    content: '';
+    position: fixed;
+    inset: 0;
+    pointer-events: none;
+    background: radial-gradient(circle at 20% 20%, rgba(255, 255, 255, 0.22) 0%, rgba(255, 255, 255, 0) 45%),
+        radial-gradient(circle at 80% 25%, rgba(222, 34, 61, 0.18) 0%, rgba(222, 34, 61, 0) 40%),
+        radial-gradient(circle at 30% 75%, rgba(45, 191, 102, 0.22) 0%, rgba(45, 191, 102, 0) 50%),
+        radial-gradient(circle at 85% 70%, rgba(255, 255, 255, 0.18) 0%, rgba(255, 255, 255, 0) 55%);
+    z-index: -1;
+}
+
+body.christmas-theme::after {
+    content: '';
+    position: fixed;
+    inset: 0;
+    pointer-events: none;
+    background-image: linear-gradient(135deg, rgba(255, 255, 255, 0.12) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.12) 50%, rgba(255, 255, 255, 0.12) 75%, transparent 75%, transparent);
+    background-size: 220px 220px;
+    opacity: 0.15;
+    z-index: -1;
+}
+
+body.christmas-theme .top-nav {
+    background: rgba(10, 43, 20, 0.92);
+    border-bottom: 2px solid rgba(255, 255, 255, 0.35);
+    box-shadow: 0 18px 36px rgba(0, 0, 0, 0.55);
+}
+
+body.christmas-theme .nav-title {
+    font-family: 'Mountains of Christmas', cursive;
+    color: #e8f5ff;
+    text-shadow: 0 0 14px rgba(227, 245, 255, 0.65), 0 0 6px rgba(181, 237, 255, 0.35);
+    letter-spacing: 0.05em;
+}
+
+body.christmas-theme .nav-btn {
+    background: linear-gradient(145deg, #2dbf66, #1d8a46);
+    color: #f5f9ff;
+    border: 1px solid rgba(233, 255, 244, 0.35);
+    box-shadow: 0 8px 18px rgba(45, 191, 102, 0.45);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+}
+
+body.christmas-theme .nav-btn:hover {
+    background: linear-gradient(145deg, #35d476, #29a65c);
+    transform: translateY(-1px) scale(1.01);
+}
+
+body.christmas-theme .nav-btn.logout-btn {
+    background: linear-gradient(145deg, #de223d, #ab142a);
+    box-shadow: 0 8px 20px rgba(222, 34, 61, 0.45);
+}
+
+body.christmas-theme .nav-btn.logout-btn:hover {
+    background: linear-gradient(145deg, #f32d4a, #c61d35);
+}
+
+body.christmas-theme #theme-toggle-btn {
+    position: relative;
+    overflow: hidden;
+    box-shadow: 0 0 18px rgba(181, 237, 255, 0.4);
+}
+
+body.christmas-theme #theme-toggle-btn::before {
+    content: '🎄';
+    margin-right: 8px;
+}
+
+body.christmas-theme #theme-toggle-btn.theme-active::after {
+    content: '';
+    position: absolute;
+    inset: -30%;
+    background: radial-gradient(circle at 50% 50%, rgba(255, 255, 255, 0.35) 0%, rgba(255, 255, 255, 0) 65%);
+    mix-blend-mode: screen;
+    animation: christmas-glow 8s infinite alternate;
+    z-index: -1;
+}
+
+@keyframes christmas-glow {
+    from {
+        opacity: 0.45;
+        transform: scale(0.95);
+    }
+    to {
+        opacity: 0.85;
+        transform: scale(1.1);
+    }
+}
+
+body.christmas-theme .dropdown-content {
+    background: rgba(5, 26, 44, 0.92);
+    border: 1px solid rgba(232, 245, 255, 0.25);
+    box-shadow: 0 20px 45px rgba(0, 0, 0, 0.55);
+}
+
+body.christmas-theme .dropdown-content a {
+    color: #e8f5ff;
+}
+
+body.christmas-theme .dropdown-content a:hover {
+    background: rgba(45, 191, 102, 0.2);
+}
+
+body.christmas-theme .main-container {
+    max-width: 1400px;
+    margin: 30px auto;
+    padding: 0 20px 60px;
+}
+
+body.christmas-theme .character-tabs,
+body.christmas-theme .inventory-tabs {
+    background: rgba(7, 30, 56, 0.92);
+    border-radius: 18px 18px 0 0;
+    border: 1px solid rgba(232, 245, 255, 0.28);
+    box-shadow: 0 15px 45px rgba(0, 0, 0, 0.55);
+}
+
+body.christmas-theme .character-tab,
+body.christmas-theme .inventory-tab {
+    color: #e8f5ff;
+    text-transform: uppercase;
+}
+
+body.christmas-theme .character-tab:hover,
+body.christmas-theme .inventory-tab:hover {
+    background: rgba(45, 191, 102, 0.22);
+}
+
+body.christmas-theme .character-tab.active,
+body.christmas-theme .inventory-tab.active {
+    background: rgba(222, 34, 61, 0.3);
+    border-bottom-color: rgba(181, 237, 255, 0.7);
+}
+
+body.christmas-theme .content-wrapper,
+body.christmas-theme .inventory-container,
+body.christmas-theme .inventory-content-wrapper {
+    background: rgba(4, 20, 38, 0.85);
+    border: 1px solid rgba(181, 237, 255, 0.25);
+    border-radius: 0 0 20px 20px;
+    box-shadow: 0 30px 60px rgba(0, 0, 0, 0.65);
+}
+
+body.christmas-theme .section h2,
+body.christmas-theme .inventory-section h2 {
+    color: #f1f9ff;
+    border-bottom-color: rgba(181, 237, 255, 0.35);
+}
+
+body.christmas-theme input,
+body.christmas-theme textarea,
+body.christmas-theme select {
+    background: rgba(15, 53, 88, 0.7);
+    border: 1px solid rgba(181, 237, 255, 0.35);
+    color: #f1f9ff;
+}
+
+body.christmas-theme input:focus,
+body.christmas-theme textarea:focus,
+body.christmas-theme select:focus {
+    border-color: rgba(45, 191, 102, 0.7);
+    box-shadow: 0 0 0 3px rgba(45, 191, 102, 0.25);
+}
+
+body.christmas-theme .upload-btn {
+    background: linear-gradient(145deg, #de223d, #a40f25);
+    border-color: rgba(255, 255, 255, 0.35);
+    color: #fdfbfb;
+}
+
+body.christmas-theme .upload-btn:hover {
+    background: linear-gradient(145deg, #f32d4a, #c61d35);
+}
+
+body.christmas-theme .relationship-entry,
+body.christmas-theme .inventory-item {
+    background: rgba(15, 53, 88, 0.65);
+    border-color: rgba(181, 237, 255, 0.25);
+}
+
+body.christmas-theme .inventory-tab.gm {
+    color: #ffccd5;
+}
+
+body.christmas-theme .gm-allowed {
+    color: #ffdfdf;
+}
+
+body.christmas-theme .gm-restricted,
+body.christmas-theme .access-restricted {
+    color: rgba(255, 255, 255, 0.45);
+}
+
+body.christmas-theme .card,
+body.christmas-theme .inventory-card {
+    background: rgba(12, 47, 80, 0.75);
+    border: 1px solid rgba(181, 237, 255, 0.25);
+    box-shadow: 0 12px 28px rgba(0, 0, 0, 0.45);
+}
+
+body.christmas-theme .card:hover,
+body.christmas-theme .inventory-card:hover {
+    transform: translateY(-3px);
+    box-shadow: 0 18px 36px rgba(0, 0, 0, 0.5);
+}
+
+body.christmas-theme .save-status {
+    color: #b5edff;
+}
+
+body.christmas-theme .status-indicator[data-status="dirty"] {
+    color: #de223d;
+}
+
+body.christmas-theme .status-indicator[data-status="saving"] {
+    color: #f3d45c;
+}
+
+body.christmas-theme .status-indicator[data-status="saved"] {
+    color: #2dbf66;
+}
+
+body.christmas-theme .inventory-section h3 {
+    color: #ffdfdf;
+}
+
+body.christmas-theme .inventory-section strong {
+    color: #b5edff;
+}
+
+body.christmas-theme .inventory-content-wrapper::-webkit-scrollbar-thumb {
+    background: rgba(45, 191, 102, 0.4);
+}
+
+body.christmas-theme .inventory-content-wrapper::-webkit-scrollbar-track {
+    background: rgba(4, 20, 38, 0.65);
+}
+
+body.christmas-theme .portrait-frame {
+    border-color: rgba(255, 255, 255, 0.35);
+    background: rgba(8, 30, 52, 0.65);
+}
+
+body.christmas-theme .portrait-placeholder {
+    color: rgba(255, 255, 255, 0.55);
+}
+
+body.christmas-theme .club-entry,
+body.christmas-theme .project-entry {
+    background: rgba(15, 53, 88, 0.55);
+    border-color: rgba(181, 237, 255, 0.2);
+}
+
+body.christmas-theme .club-entry:hover,
+body.christmas-theme .project-entry:hover {
+    border-color: rgba(222, 34, 61, 0.4);
+}
+
+body.christmas-theme .relationship-entry:hover {
+    border-color: rgba(45, 191, 102, 0.4);
+}
+
+body.christmas-theme .monster-card {
+    background: rgba(12, 47, 80, 0.85);
+    border-color: rgba(181, 237, 255, 0.25);
+}
+
+body.christmas-theme .monster-card .monster-name {
+    color: #ffdfdf;
+}
+
+body.christmas-theme .monster-card .monster-details {
+    color: #d9eaff;
+}
+
+body.christmas-theme .schedule-table th {
+    background: rgba(45, 191, 102, 0.4);
+}
+
+body.christmas-theme .schedule-table td {
+    background: rgba(12, 47, 80, 0.6);
+}
+
+body.christmas-theme .schedule-table tr:nth-child(even) td {
+    background: rgba(18, 65, 105, 0.6);
+}
+
+body.christmas-theme .schedule-table tr:hover td {
+    background: rgba(222, 34, 61, 0.25);
+}
+
+body.christmas-theme .inventory-note {
+    background: rgba(15, 53, 88, 0.5);
+}
+
+body.christmas-theme .inventory-note strong {
+    color: #ffdfdf;
+}
+
+body.christmas-theme .inventory-note em {
+    color: #b5edff;
+}
+
+body.christmas-theme .status-bar {
+    background: rgba(12, 47, 80, 0.7);
+    border-color: rgba(181, 237, 255, 0.25);
+}
+
+body.christmas-theme .status-bar .status-label {
+    color: #e8f5ff;
+}
+
+body.christmas-theme .status-bar .status-value {
+    color: #ffdfdf;
+}
+
+body.christmas-theme .tab-description {
+    color: rgba(229, 244, 255, 0.85);
+}
+
+body.christmas-theme .tab-description strong {
+    color: #ffdfdf;
+}
+
+body.christmas-theme .tab-description em {
+    color: #b5edff;
+}
+
+body.christmas-theme .inventory-search input {
+    background: rgba(12, 47, 80, 0.6);
+    border-color: rgba(181, 237, 255, 0.35);
+}
+
+body.christmas-theme .inventory-search input:focus {
+    border-color: rgba(45, 191, 102, 0.7);
+}
+
+body.christmas-theme .inventory-list-item {
+    background: rgba(12, 47, 80, 0.55);
+    border-color: rgba(181, 237, 255, 0.25);
+}
+
+body.christmas-theme .inventory-list-item:hover {
+    border-color: rgba(222, 34, 61, 0.4);
+}
+
+body.christmas-theme .inventory-section .section-header {
+    color: #ffdfdf;
+}
+
+body.christmas-theme .inventory-actions button {
+    background: linear-gradient(145deg, #2dbf66, #1d8a46);
+    border-color: rgba(255, 255, 255, 0.35);
+}
+
+body.christmas-theme .inventory-actions button:hover {
+    background: linear-gradient(145deg, #35d476, #29a65c);
+}
+
+body.christmas-theme .inventory-section .note {
+    color: rgba(229, 244, 255, 0.85);
+}
+
+body.christmas-theme .relationship-entry strong,
+body.christmas-theme .inventory-item strong {
+    color: #ffdfdf;
+}
+
+body.christmas-theme .relationship-entry .relationship-notes,
+body.christmas-theme .inventory-item .item-notes {
+    color: #d9eaff;
+}
+
+body.christmas-theme .relationship-entry .relationship-points {
+    color: #35d476;
+}
+
+body.christmas-theme .christmas-snowflake {
+    position: fixed;
+    top: -40px;
+    width: 12px;
+    height: 12px;
+    background: radial-gradient(circle, #ffffff 0%, rgba(255, 255, 255, 0.1) 70%);
+    border-radius: 50%;
+    opacity: 0.9;
+    pointer-events: none;
+    animation: christmas-snowfall 12s linear forwards;
+    z-index: 1000;
+}
+
+@keyframes christmas-snowfall {
+    0% {
+        transform: translateY(0) translateX(0) scale(1);
+        opacity: 0;
+    }
+    10% {
+        opacity: 0.9;
+    }
+    100% {
+        transform: translateY(110vh) translateX(30px) scale(0.8);
+        opacity: 0;
+    }
+}

--- a/dnd/Christmas/theme.js
+++ b/dnd/Christmas/theme.js
@@ -1,0 +1,107 @@
+(function () {
+    const MIN_INTERVAL = 30000;
+    const MAX_INTERVAL = 45000;
+    const MAX_FLAKES = 3;
+    let spawnTimer = null;
+    let active = false;
+    let lastSpawnTime = 0;
+
+    function randomBetween(min, max) {
+        return Math.floor(Math.random() * (max - min + 1)) + min;
+    }
+
+    function createSnowflake() {
+        if (!active) {
+            return;
+        }
+        const snowflake = document.createElement('div');
+        snowflake.className = 'christmas-snowflake';
+        snowflake.style.left = `${randomBetween(0, 100)}vw`;
+        snowflake.style.animationDelay = `${randomBetween(0, 2000) / 1000}s`;
+        snowflake.style.transform = `scale(${randomBetween(75, 110) / 100})`;
+        document.body.appendChild(snowflake);
+        snowflake.addEventListener('animationend', function () {
+            if (snowflake.parentNode) {
+                snowflake.parentNode.removeChild(snowflake);
+            }
+        });
+    }
+
+    function spawnSnowfall() {
+        if (!active) {
+            return;
+        }
+        const now = Date.now();
+        if (now - lastSpawnTime < MIN_INTERVAL) {
+            scheduleNext();
+            return;
+        }
+        lastSpawnTime = now;
+        const flakeCount = randomBetween(1, MAX_FLAKES);
+        for (let i = 0; i < flakeCount; i += 1) {
+            setTimeout(createSnowflake, i * 250);
+        }
+        scheduleNext();
+    }
+
+    function clearSnowfall() {
+        if (spawnTimer) {
+            clearTimeout(spawnTimer);
+            spawnTimer = null;
+        }
+        const flakes = document.querySelectorAll('.christmas-snowflake');
+        flakes.forEach(flake => {
+            if (flake && flake.parentNode) {
+                flake.parentNode.removeChild(flake);
+            }
+        });
+    }
+
+    function scheduleNext() {
+        if (!active) {
+            return;
+        }
+        const delay = randomBetween(MIN_INTERVAL, MAX_INTERVAL);
+        spawnTimer = window.setTimeout(spawnSnowfall, delay);
+    }
+
+    function enableSnowfall() {
+        if (active) {
+            return;
+        }
+        active = true;
+        lastSpawnTime = Date.now() - MIN_INTERVAL;
+        scheduleNext();
+    }
+
+    function disableSnowfall() {
+        if (!active) {
+            return;
+        }
+        active = false;
+        clearSnowfall();
+    }
+
+    function handleThemeChange(themeName) {
+        if (themeName === 'christmas') {
+            enableSnowfall();
+        } else {
+            disableSnowfall();
+        }
+    }
+
+    document.addEventListener('themechange', function (event) {
+        if (!event || !event.detail) {
+            return;
+        }
+        handleThemeChange(event.detail.themeName);
+    });
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', function () {
+            handleThemeChange(document.body.dataset.activeTheme);
+        });
+    } else {
+        handleThemeChange(document.body.dataset.activeTheme);
+    }
+})();

--- a/dnd/Frunk/theme.css
+++ b/dnd/Frunk/theme.css
@@ -1,0 +1,367 @@
+@import url('https://fonts.googleapis.com/css2?family=Anton&family=Barlow+Condensed:wght@400;600;700&display=swap');
+
+body.frunk-theme {
+    font-family: 'Barlow Condensed', 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+    background: radial-gradient(circle at 20% 20%, #f6f7fb 0%, #dfe3ec 45%, #0e0f16 100%);
+    color: #140a12;
+    position: relative;
+    overflow-x: hidden;
+}
+
+body.frunk-theme::before {
+    content: '';
+    position: fixed;
+    inset: 0;
+    pointer-events: none;
+    background:
+        linear-gradient(115deg, rgba(255, 255, 255, 0.6) 0%, rgba(255, 255, 255, 0) 45%),
+        linear-gradient(245deg, rgba(255, 46, 99, 0.12) 0%, rgba(255, 46, 99, 0) 55%),
+        repeating-linear-gradient(90deg, rgba(15, 16, 24, 0.18), rgba(15, 16, 24, 0.18) 2px, transparent 2px, transparent 6px);
+    mix-blend-mode: screen;
+    z-index: -1;
+}
+
+body.frunk-theme::after {
+    content: '';
+    position: fixed;
+    inset: 0;
+    pointer-events: none;
+    background: radial-gradient(circle at 60% 20%, rgba(255, 255, 255, 0.3) 0%, rgba(255, 255, 255, 0) 40%),
+        radial-gradient(circle at 30% 80%, rgba(255, 46, 99, 0.22) 0%, rgba(255, 46, 99, 0) 55%);
+    z-index: -1;
+}
+
+body.frunk-theme .top-nav {
+    background: rgba(244, 246, 252, 0.9);
+    border-bottom: 3px solid rgba(255, 46, 99, 0.7);
+    box-shadow: 0 18px 35px rgba(15, 16, 24, 0.45);
+}
+
+body.frunk-theme .nav-title {
+    font-family: 'Anton', sans-serif;
+    color: #ff2e63;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    text-shadow: 0 4px 12px rgba(15, 16, 24, 0.35);
+}
+
+body.frunk-theme .nav-buttons .nav-btn {
+    background: linear-gradient(160deg, #ffffff, #f4f5fa);
+    color: #140a12;
+    border: 2px solid rgba(255, 46, 99, 0.55);
+    box-shadow: 0 8px 18px rgba(20, 10, 18, 0.25);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+}
+
+body.frunk-theme .nav-buttons .nav-btn:hover {
+    background: linear-gradient(160deg, #ffe8ee, #fff5f8);
+    transform: translateY(-1px) scale(1.01);
+}
+
+body.frunk-theme .nav-btn.logout-btn {
+    background: linear-gradient(160deg, #140a12, #2d0c17);
+    color: #ffffff;
+    border-color: rgba(255, 255, 255, 0.4);
+    box-shadow: 0 8px 22px rgba(20, 10, 18, 0.4);
+}
+
+body.frunk-theme .nav-btn.logout-btn:hover {
+    background: linear-gradient(160deg, #2d0c17, #430e22);
+}
+
+body.frunk-theme #theme-toggle-btn {
+    position: relative;
+    overflow: hidden;
+    border-width: 3px;
+    font-weight: 600;
+}
+
+body.frunk-theme #theme-toggle-btn::before {
+    content: '🐰';
+    margin-right: 8px;
+}
+
+body.frunk-theme #theme-toggle-btn.theme-active::after {
+    content: '';
+    position: absolute;
+    inset: -25%;
+    background: radial-gradient(circle at 30% 30%, rgba(255, 46, 99, 0.32) 0%, rgba(255, 46, 99, 0) 65%);
+    animation: frunk-rage-glow 6s infinite alternate;
+    z-index: -1;
+}
+
+@keyframes frunk-rage-glow {
+    from {
+        opacity: 0.35;
+        transform: scale(0.9);
+    }
+    to {
+        opacity: 0.75;
+        transform: scale(1.1);
+    }
+}
+
+body.frunk-theme .dropdown-content {
+    background: rgba(244, 246, 252, 0.95);
+    border: 2px solid rgba(20, 10, 18, 0.15);
+    box-shadow: 0 20px 45px rgba(14, 15, 22, 0.35);
+}
+
+body.frunk-theme .dropdown-content a {
+    color: #140a12;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+
+body.frunk-theme .dropdown-content a:hover {
+    background: rgba(255, 46, 99, 0.1);
+}
+
+body.frunk-theme .main-container {
+    max-width: 1400px;
+    margin: 30px auto;
+    padding: 0 20px 60px;
+}
+
+body.frunk-theme .character-tabs,
+body.frunk-theme .inventory-tabs {
+    background: rgba(255, 255, 255, 0.92);
+    border-radius: 18px 18px 0 0;
+    border: 2px solid rgba(20, 10, 18, 0.15);
+    box-shadow: 0 18px 40px rgba(14, 15, 22, 0.35);
+}
+
+body.frunk-theme .character-tab,
+body.frunk-theme .inventory-tab {
+    color: #140a12;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+}
+
+body.frunk-theme .character-tab:hover,
+body.frunk-theme .inventory-tab:hover {
+    background: rgba(255, 46, 99, 0.12);
+}
+
+body.frunk-theme .character-tab.active,
+body.frunk-theme .inventory-tab.active {
+    background: rgba(255, 46, 99, 0.18);
+    border-bottom: 3px solid rgba(255, 46, 99, 0.65);
+}
+
+body.frunk-theme .content-wrapper,
+body.frunk-theme .inventory-container,
+body.frunk-theme .inventory-content-wrapper {
+    background: rgba(248, 249, 253, 0.92);
+    border: 2px solid rgba(20, 10, 18, 0.1);
+    border-radius: 0 0 20px 20px;
+    box-shadow: 0 30px 60px rgba(14, 15, 22, 0.35);
+}
+
+body.frunk-theme .section h2,
+body.frunk-theme .inventory-section h2 {
+    font-family: 'Anton', sans-serif;
+    color: #140a12;
+    border-bottom-color: rgba(255, 46, 99, 0.4);
+    letter-spacing: 0.08em;
+}
+
+body.frunk-theme input,
+body.frunk-theme textarea,
+body.frunk-theme select {
+    background: rgba(255, 255, 255, 0.85);
+    border: 2px solid rgba(20, 10, 18, 0.15);
+    color: #140a12;
+}
+
+body.frunk-theme input:focus,
+body.frunk-theme textarea:focus,
+body.frunk-theme select:focus {
+    border-color: rgba(255, 46, 99, 0.55);
+    box-shadow: 0 0 0 3px rgba(255, 46, 99, 0.25);
+}
+
+body.frunk-theme .upload-btn {
+    background: linear-gradient(160deg, #ff2e63, #c21b46);
+    border: 2px solid rgba(255, 255, 255, 0.5);
+    color: #ffffff;
+}
+
+body.frunk-theme .upload-btn:hover {
+    background: linear-gradient(160deg, #ff4b79, #d91f54);
+}
+
+body.frunk-theme .relationship-entry,
+body.frunk-theme .inventory-item {
+    background: rgba(255, 255, 255, 0.75);
+    border: 2px solid rgba(20, 10, 18, 0.12);
+    box-shadow: 0 10px 18px rgba(20, 10, 18, 0.1);
+}
+
+body.frunk-theme .relationship-entry:hover,
+body.frunk-theme .inventory-item:hover {
+    border-color: rgba(255, 46, 99, 0.35);
+}
+
+body.frunk-theme .relationship-entry strong,
+body.frunk-theme .inventory-item strong {
+    color: #ff2e63;
+}
+
+body.frunk-theme .relationship-entry .relationship-points {
+    color: #2b2d42;
+}
+
+body.frunk-theme .relationship-entry .relationship-notes,
+body.frunk-theme .inventory-item .item-notes {
+    color: #2b2d42;
+}
+
+body.frunk-theme .card,
+body.frunk-theme .inventory-card {
+    background: rgba(255, 255, 255, 0.85);
+    border: 2px solid rgba(20, 10, 18, 0.12);
+    box-shadow: 0 15px 28px rgba(14, 15, 22, 0.25);
+}
+
+body.frunk-theme .card:hover,
+body.frunk-theme .inventory-card:hover {
+    transform: translateY(-3px);
+    box-shadow: 0 20px 40px rgba(14, 15, 22, 0.35);
+}
+
+body.frunk-theme .inventory-tab.gm {
+    color: #ff2e63;
+}
+
+body.frunk-theme .gm-allowed {
+    color: #c21b46;
+}
+
+body.frunk-theme .gm-restricted,
+body.frunk-theme .access-restricted {
+    color: rgba(20, 10, 18, 0.45);
+}
+
+body.frunk-theme .inventory-section h3 {
+    color: #ff2e63;
+}
+
+body.frunk-theme .inventory-section strong,
+body.frunk-theme .inventory-note strong {
+    color: #c21b46;
+}
+
+body.frunk-theme .inventory-note {
+    background: rgba(255, 255, 255, 0.65);
+    border: 2px solid rgba(20, 10, 18, 0.12);
+}
+
+body.frunk-theme .status-bar {
+    background: rgba(255, 255, 255, 0.8);
+    border: 2px solid rgba(20, 10, 18, 0.15);
+}
+
+body.frunk-theme .status-bar .status-label {
+    color: #2b2d42;
+}
+
+body.frunk-theme .status-bar .status-value {
+    color: #ff2e63;
+}
+
+body.frunk-theme .inventory-content-wrapper::-webkit-scrollbar-thumb {
+    background: rgba(255, 46, 99, 0.4);
+}
+
+body.frunk-theme .inventory-content-wrapper::-webkit-scrollbar-track {
+    background: rgba(255, 255, 255, 0.6);
+}
+
+body.frunk-theme .portrait-frame {
+    border: 3px solid rgba(255, 46, 99, 0.35);
+    background: rgba(255, 255, 255, 0.75);
+}
+
+body.frunk-theme .portrait-placeholder {
+    color: rgba(20, 10, 18, 0.5);
+}
+
+body.frunk-theme .monster-card {
+    background: rgba(255, 255, 255, 0.88);
+    border: 2px solid rgba(20, 10, 18, 0.12);
+}
+
+body.frunk-theme .monster-card .monster-name {
+    color: #ff2e63;
+}
+
+body.frunk-theme .monster-card .monster-details {
+    color: #2b2d42;
+}
+
+body.frunk-theme .schedule-table th {
+    background: rgba(255, 46, 99, 0.2);
+}
+
+body.frunk-theme .schedule-table td {
+    background: rgba(255, 255, 255, 0.7);
+}
+
+body.frunk-theme .schedule-table tr:nth-child(even) td {
+    background: rgba(255, 235, 242, 0.7);
+}
+
+body.frunk-theme .schedule-table tr:hover td {
+    background: rgba(255, 46, 99, 0.22);
+}
+
+body.frunk-theme .tab-description {
+    color: rgba(20, 10, 18, 0.75);
+}
+
+body.frunk-theme .tab-description strong {
+    color: #ff2e63;
+}
+
+body.frunk-theme .tab-description em {
+    color: #2b2d42;
+}
+
+body.frunk-theme .inventory-search input {
+    background: rgba(255, 255, 255, 0.8);
+    border: 2px solid rgba(20, 10, 18, 0.12);
+}
+
+body.frunk-theme .inventory-search input:focus {
+    border-color: rgba(255, 46, 99, 0.45);
+}
+
+body.frunk-theme .inventory-list-item {
+    background: rgba(255, 255, 255, 0.75);
+    border: 2px solid rgba(20, 10, 18, 0.12);
+}
+
+body.frunk-theme .inventory-list-item:hover {
+    border-color: rgba(255, 46, 99, 0.35);
+}
+
+body.frunk-theme .rage-ripple {
+    animation: frunk-rage-pulse 0.6s ease-in-out;
+}
+
+@keyframes frunk-rage-pulse {
+    0% {
+        transform: scale(1);
+        filter: drop-shadow(0 0 0 rgba(255, 46, 99, 0));
+    }
+    50% {
+        transform: scale(1.03);
+        filter: drop-shadow(0 0 12px rgba(255, 46, 99, 0.45));
+    }
+    100% {
+        transform: scale(1);
+        filter: drop-shadow(0 0 0 rgba(255, 46, 99, 0));
+    }
+}

--- a/dnd/Frunk/theme.js
+++ b/dnd/Frunk/theme.js
@@ -1,0 +1,87 @@
+(function () {
+    const MIN_RAGE_INTERVAL = 15000;
+    const MAX_RAGE_INTERVAL = 28000;
+    let rageTimer = null;
+    let active = false;
+
+    function randomBetween(min, max) {
+        return Math.floor(Math.random() * (max - min + 1)) + min;
+    }
+
+    function removeRageClass(target) {
+        if (!target) {
+            return;
+        }
+        target.classList.remove('rage-ripple');
+    }
+
+    function triggerRage() {
+        if (!active) {
+            return;
+        }
+        const targets = [
+            document.querySelector('.nav-title'),
+            document.getElementById('theme-toggle-btn')
+        ];
+        targets.forEach(target => {
+            if (!target) {
+                return;
+            }
+            target.classList.add('rage-ripple');
+            setTimeout(() => removeRageClass(target), 650);
+        });
+        scheduleNextRage();
+    }
+
+    function scheduleNextRage() {
+        if (!active) {
+            return;
+        }
+        const delay = randomBetween(MIN_RAGE_INTERVAL, MAX_RAGE_INTERVAL);
+        rageTimer = window.setTimeout(triggerRage, delay);
+    }
+
+    function enableRage() {
+        if (active) {
+            return;
+        }
+        active = true;
+        scheduleNextRage();
+    }
+
+    function disableRage() {
+        if (!active) {
+            return;
+        }
+        active = false;
+        if (rageTimer) {
+            clearTimeout(rageTimer);
+            rageTimer = null;
+        }
+        removeRageClass(document.querySelector('.nav-title'));
+        removeRageClass(document.getElementById('theme-toggle-btn'));
+    }
+
+    function handleThemeChange(themeName) {
+        if (themeName === 'frunk') {
+            enableRage();
+        } else {
+            disableRage();
+        }
+    }
+
+    document.addEventListener('themechange', function (event) {
+        if (!event || !event.detail) {
+            return;
+        }
+        handleThemeChange(event.detail.themeName);
+    });
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', function () {
+            handleThemeChange(document.body.dataset.activeTheme);
+        });
+    } else {
+        handleThemeChange(document.body.dataset.activeTheme);
+    }
+})();

--- a/dnd/Halloween/theme.css
+++ b/dnd/Halloween/theme.css
@@ -416,3 +416,15 @@ body.halloween-theme::-webkit-scrollbar-thumb:hover,
 body.halloween-theme *::-webkit-scrollbar-thumb:hover {
     background: linear-gradient(145deg, #ffb347, #fb923c);
 }
+body.halloween-theme.halloween-theme-active .nav-title {
+    animation: halloween-flicker 8s infinite ease-in-out;
+}
+
+@keyframes halloween-flicker {
+    0%, 100% {
+        text-shadow: 0 0 12px rgba(255, 111, 71, 0.55), 0 0 22px rgba(255, 111, 71, 0.35);
+    }
+    50% {
+        text-shadow: 0 0 18px rgba(255, 157, 63, 0.75), 0 0 32px rgba(249, 115, 22, 0.55);
+    }
+}

--- a/dnd/Halloween/theme.js
+++ b/dnd/Halloween/theme.js
@@ -1,221 +1,28 @@
 (function () {
-    const THEME_KEY = 'dnd-dashboard-theme';
-    const BUTTON_ID = 'theme-toggle-btn';
-    const DEFAULT_THEME = 'default';
-    const CLASSIC_LABEL = 'Return to the classic theme';
-    const CLASSIC_TITLE = 'Return to the classic theme';
-    const CANDIDATE_THEMES = [
-        {
-            name: 'halloween',
-            className: 'halloween-theme',
-            linkId: 'halloween-theme',
-            buttonLabel: 'Enable the Halloween theme',
-            buttonTitle: 'Enable the Halloween theme'
-        },
-        {
-            name: 'christmas',
-            className: 'christmas-theme',
-            linkId: 'christmas-theme',
-            buttonLabel: 'Enable the Christmas theme',
-            buttonTitle: 'Enable the Christmas theme'
-        },
-        {
-            name: 'pride',
-            className: 'pride-theme',
-            linkId: 'pride-theme',
-            buttonLabel: 'Enable the Pride theme',
-            buttonTitle: 'Enable the Pride theme'
-        }
-    ];
-
-    function getThemeConfig(themeName) {
-        if (themeName === DEFAULT_THEME) {
-            return {
-                name: DEFAULT_THEME,
-                className: '',
-                linkId: '',
-                buttonLabel: CLASSIC_LABEL,
-                buttonTitle: CLASSIC_TITLE
-            };
-        }
-
-        return CANDIDATE_THEMES.find(function (theme) {
-            return theme.name === themeName;
-        }) || null;
-    }
-
-    function getNextTheme(currentTheme, themeCycle) {
-        if (!Array.isArray(themeCycle) || themeCycle.length === 0) {
-            return DEFAULT_THEME;
-        }
-
-        var index = themeCycle.indexOf(currentTheme);
-        if (index === -1) {
-            return themeCycle[0];
-        }
-
-        return themeCycle[(index + 1) % themeCycle.length];
-    }
-
-    function persistTheme(themeName) {
-        try {
-            if (themeName === DEFAULT_THEME) {
-                window.localStorage.removeItem(THEME_KEY);
-            } else {
-                window.localStorage.setItem(THEME_KEY, themeName);
-            }
-        } catch (error) {
-            console.warn('Unable to persist theme preference:', error);
-        }
-    }
-
-    function updateButtonState(button, currentTheme, themeCycle, isDisabled) {
-        if (!button) {
+    function applyActiveState(themeName) {
+        const body = document.body;
+        if (!body) {
             return;
         }
-
-        var nextTheme = getNextTheme(currentTheme, themeCycle);
-        var nextConfig = getThemeConfig(nextTheme);
-        var isActiveTheme = currentTheme !== DEFAULT_THEME;
-        var label;
-        var title;
-
-        button.disabled = Boolean(isDisabled);
-        if (isDisabled) {
-            label = 'Theme options unavailable';
-            title = 'No alternate themes are currently loaded';
-            button.textContent = label;
-            button.title = title;
-            button.setAttribute('aria-label', title);
-            button.setAttribute('aria-disabled', 'true');
-            button.setAttribute('aria-pressed', 'false');
-            button.classList.remove('theme-active');
-            return;
-        }
-
-        button.removeAttribute('aria-disabled');
-        button.classList.toggle('theme-active', isActiveTheme);
-        button.setAttribute('aria-pressed', isActiveTheme ? 'true' : 'false');
-
-        if (!nextConfig || nextTheme === DEFAULT_THEME) {
-            label = CLASSIC_LABEL;
-            title = CLASSIC_TITLE;
+        if (themeName === 'halloween') {
+            body.classList.add('halloween-theme-active');
         } else {
-            label = nextConfig.buttonLabel;
-            title = nextConfig.buttonTitle || nextConfig.buttonLabel;
-        }
-
-        button.textContent = label;
-        button.title = title;
-        button.setAttribute('aria-label', title);
-    }
-
-    function applyTheme(themeName, options) {
-        var settings = options || {};
-        var button = settings.button;
-        var themeCycle = settings.themeCycle || [];
-        var isButtonDisabled = Boolean(settings.isButtonDisabled);
-        var config = getThemeConfig(themeName) || getThemeConfig(DEFAULT_THEME);
-        var activeThemeName = config ? config.name : DEFAULT_THEME;
-        var themeClassNames = CANDIDATE_THEMES.map(function (theme) {
-            return theme.className;
-        }).filter(Boolean);
-
-        themeClassNames.forEach(function (className) {
-            document.body.classList.remove(className);
-        });
-
-        if (config && config.className) {
-            document.body.classList.add(config.className);
-        }
-
-        CANDIDATE_THEMES.forEach(function (theme) {
-            var link = document.getElementById(theme.linkId);
-            if (link) {
-                link.disabled = !(config && config.linkId === theme.linkId);
-            }
-        });
-
-        document.body.dataset.activeTheme = activeThemeName;
-
-        if (button) {
-            updateButtonState(button, activeThemeName, themeCycle, isButtonDisabled);
+            body.classList.remove('halloween-theme-active');
         }
     }
 
-    function getThemeFromStorage(themeCycle) {
-        if (!Array.isArray(themeCycle) || themeCycle.length === 0) {
-            return DEFAULT_THEME;
-        }
-
-        try {
-            var storedValue = window.localStorage.getItem(THEME_KEY);
-            if (storedValue && themeCycle.indexOf(storedValue) !== -1) {
-                return storedValue;
-            }
-        } catch (error) {
-            console.warn('Unable to load theme preference:', error);
-        }
-
-        return DEFAULT_THEME;
-    }
-
-    function handleThemeToggle(context) {
-        if (!context) {
+    document.addEventListener('themechange', function (event) {
+        if (!event || !event.detail) {
             return;
         }
-
-        var themeCycle = context.themeCycle || [];
-        var button = context.button;
-        if (!Array.isArray(themeCycle) || themeCycle.length <= 1) {
-            return;
-        }
-
-        var currentTheme = document.body.dataset.activeTheme || DEFAULT_THEME;
-        var nextTheme = getNextTheme(currentTheme, themeCycle);
-
-        applyTheme(nextTheme, {
-            button: button,
-            themeCycle: themeCycle
-        });
-        persistTheme(nextTheme);
-    }
-
-    function initThemeToggle() {
-        var button = document.getElementById(BUTTON_ID);
-        if (!button) {
-            return;
-        }
-
-        var detectedThemes = CANDIDATE_THEMES.filter(function (theme) {
-            return Boolean(document.getElementById(theme.linkId));
-        }).map(function (theme) {
-            return theme.name;
-        });
-
-        var themeCycle = [DEFAULT_THEME].concat(detectedThemes);
-        var storedTheme = getThemeFromStorage(themeCycle);
-        var hasAlternates = themeCycle.length > 1;
-
-        applyTheme(storedTheme, {
-            button: button,
-            themeCycle: themeCycle,
-            isButtonDisabled: !hasAlternates
-        });
-
-        if (hasAlternates) {
-            button.addEventListener('click', function () {
-                handleThemeToggle({
-                    themeCycle: themeCycle,
-                    button: button
-                });
-            });
-        }
-    }
+        applyActiveState(event.detail.themeName);
+    });
 
     if (document.readyState === 'loading') {
-        document.addEventListener('DOMContentLoaded', initThemeToggle);
+        document.addEventListener('DOMContentLoaded', function () {
+            applyActiveState(document.body.dataset.activeTheme);
+        });
     } else {
-        initThemeToggle();
+        applyActiveState(document.body.dataset.activeTheme);
     }
 })();

--- a/dnd/dashboard.php
+++ b/dnd/dashboard.php
@@ -884,6 +884,8 @@ $defaultInventoryTab = $is_gm ? 'frunk' : $user;
     <link rel="stylesheet" href="css/style.css">
     <link rel="stylesheet" href="css/inventory.css">
     <link rel="stylesheet" href="Halloween/theme.css" id="halloween-theme" disabled>
+    <link rel="stylesheet" href="Christmas/theme.css" id="christmas-theme" disabled>
+    <link rel="stylesheet" href="Frunk/theme.css" id="frunk-theme" disabled>
 </head>
 <body>
     <!-- Top Navigation Bar -->
@@ -922,7 +924,7 @@ $defaultInventoryTab = $is_gm ? 'frunk' : $user;
             </div>
             <button class="nav-btn" onclick="openCombatTracker()">Combat Tracker</button>
             <button class="nav-btn" onclick="openSchedule()">Schedule</button>
-            <button type="button" class="nav-btn" id="theme-toggle-btn" title="Enable the Halloween theme">Theme</button>
+            <button type="button" class="nav-btn" id="theme-toggle-btn" title="Switch theme">Theme</button>
             <button class="nav-btn logout-btn" onclick="window.location.href='logout.php'">Logout</button>
         </div>
         <h1 class="nav-title"><?php echo $is_gm ? 'GM Dashboard' : ucfirst($user) . '\'s Character Sheet'; ?></h1>
@@ -1473,7 +1475,10 @@ $defaultInventoryTab = $is_gm ? 'frunk' : $user;
             }
         }
     </script>
-    <script src="Halloween/theme.js"></script>
+    <script src="js/theme-manager.js"></script>
+    <script src="Halloween/theme.js" defer></script>
+    <script src="Christmas/theme.js" defer></script>
+    <script src="Frunk/theme.js" defer></script>
     <script src="strixhaven/gm/js/character-lookup.js"></script>
     <script src="js/character-sheet.js"></script>
     <script src="js/inventory-integrated.js"></script>

--- a/dnd/js/theme-manager.js
+++ b/dnd/js/theme-manager.js
@@ -1,0 +1,238 @@
+(function () {
+    const STORAGE_KEY = 'dnd-dashboard-theme';
+    const BUTTON_ID = 'theme-toggle-btn';
+    const DEFAULT_THEME = 'classic';
+    const LEGACY_DEFAULT = 'default';
+    const THEMES = [
+        {
+            name: 'halloween',
+            className: 'halloween-theme',
+            linkId: 'halloween-theme',
+            label: 'Halloween'
+        },
+        {
+            name: 'christmas',
+            className: 'christmas-theme',
+            linkId: 'christmas-theme',
+            label: 'Christmas'
+        },
+        {
+            name: 'frunk',
+            className: 'frunk-theme',
+            linkId: 'frunk-theme',
+            label: 'Frunk'
+        }
+    ];
+
+    let activeTheme = DEFAULT_THEME;
+
+    function normalizeThemeName(themeName) {
+        if (themeName === null || typeof themeName === 'undefined') {
+            return DEFAULT_THEME;
+        }
+        const value = String(themeName).toLowerCase();
+        if (!value) {
+            return DEFAULT_THEME;
+        }
+        if (value === LEGACY_DEFAULT) {
+            return DEFAULT_THEME;
+        }
+        return value;
+    }
+
+    function formatLabel(themeName) {
+        if (!themeName) {
+            return '';
+        }
+        return themeName.charAt(0).toUpperCase() + themeName.slice(1);
+    }
+
+    function getThemeConfig(themeName) {
+        const normalized = normalizeThemeName(themeName);
+        if (normalized === DEFAULT_THEME) {
+            return {
+                name: DEFAULT_THEME,
+                className: '',
+                linkId: '',
+                label: 'Classic'
+            };
+        }
+        return THEMES.find(theme => theme.name === normalized) || null;
+    }
+
+    function getNextTheme(currentTheme, themeCycle) {
+        if (!Array.isArray(themeCycle) || themeCycle.length === 0) {
+            return DEFAULT_THEME;
+        }
+        const normalized = normalizeThemeName(currentTheme);
+        const index = themeCycle.indexOf(normalized);
+        if (index === -1) {
+            return themeCycle[0];
+        }
+        const nextIndex = (index + 1) % themeCycle.length;
+        return themeCycle[nextIndex];
+    }
+
+    function persistTheme(themeName) {
+        const normalized = normalizeThemeName(themeName);
+        try {
+            if (normalized === DEFAULT_THEME) {
+                window.localStorage.removeItem(STORAGE_KEY);
+            } else {
+                window.localStorage.setItem(STORAGE_KEY, normalized);
+            }
+        } catch (error) {
+            console.warn('Unable to persist theme preference:', error);
+        }
+    }
+
+    function updateButtonState(button, currentTheme, themeCycle, disabled) {
+        if (!button) {
+            return;
+        }
+
+        const isDisabled = Boolean(disabled);
+        button.disabled = isDisabled;
+
+        if (isDisabled) {
+            button.textContent = 'Theme: Unavailable';
+            button.title = 'No alternate themes are currently loaded';
+            button.setAttribute('aria-label', button.title);
+            button.setAttribute('aria-disabled', 'true');
+            button.classList.remove('theme-active');
+            button.setAttribute('aria-pressed', 'false');
+            return;
+        }
+
+        button.removeAttribute('aria-disabled');
+
+        const nextTheme = getNextTheme(currentTheme, themeCycle);
+        const nextConfig = getThemeConfig(nextTheme);
+        const label = nextConfig ? nextConfig.label : formatLabel(nextTheme);
+        const isAlternateTheme = normalizeThemeName(currentTheme) !== DEFAULT_THEME;
+
+        button.classList.toggle('theme-active', isAlternateTheme);
+        button.setAttribute('aria-pressed', isAlternateTheme ? 'true' : 'false');
+
+        const buttonLabel = label ? `Theme: ${label}` : 'Theme';
+        const buttonTitle = label ? `Switch to the ${label} theme` : 'Switch theme';
+
+        button.textContent = buttonLabel;
+        button.title = buttonTitle;
+        button.setAttribute('aria-label', buttonTitle);
+    }
+
+    function applyTheme(themeName, options) {
+        const settings = options || {};
+        const button = settings.button;
+        const themeCycle = settings.themeCycle || [];
+        const isButtonDisabled = Boolean(settings.isButtonDisabled);
+        const normalized = getThemeConfig(themeName) ? normalizeThemeName(themeName) : DEFAULT_THEME;
+        const config = getThemeConfig(normalized) || getThemeConfig(DEFAULT_THEME);
+        const themeClassNames = THEMES.map(theme => theme.className).filter(Boolean);
+        const previousTheme = activeTheme;
+
+        themeClassNames.forEach(className => {
+            document.body.classList.remove(className);
+        });
+
+        if (config && config.className) {
+            document.body.classList.add(config.className);
+        }
+
+        THEMES.forEach(theme => {
+            const link = document.getElementById(theme.linkId);
+            if (link) {
+                link.disabled = !(config && config.linkId === theme.linkId);
+            }
+        });
+
+        activeTheme = config ? config.name : DEFAULT_THEME;
+        document.body.dataset.activeTheme = activeTheme;
+
+        if (button) {
+            updateButtonState(button, activeTheme, themeCycle, isButtonDisabled);
+        }
+
+        if (previousTheme !== activeTheme) {
+            const event = new CustomEvent('themechange', {
+                detail: {
+                    themeName: activeTheme,
+                    previousTheme: previousTheme
+                }
+            });
+            document.dispatchEvent(event);
+        }
+    }
+
+    function getThemeFromStorage(themeCycle) {
+        if (!Array.isArray(themeCycle) || themeCycle.length === 0) {
+            return DEFAULT_THEME;
+        }
+        try {
+            const stored = window.localStorage.getItem(STORAGE_KEY);
+            if (stored) {
+                const normalized = normalizeThemeName(stored);
+                if (themeCycle.indexOf(normalized) !== -1) {
+                    return normalized;
+                }
+            }
+        } catch (error) {
+            console.warn('Unable to load theme preference:', error);
+        }
+        return DEFAULT_THEME;
+    }
+
+    function handleThemeToggle(context) {
+        if (!context) {
+            return;
+        }
+        const themeCycle = context.themeCycle || [];
+        if (!Array.isArray(themeCycle) || themeCycle.length <= 1) {
+            return;
+        }
+        const currentTheme = document.body.dataset.activeTheme || DEFAULT_THEME;
+        const nextTheme = getNextTheme(currentTheme, themeCycle);
+        applyTheme(nextTheme, {
+            button: context.button,
+            themeCycle: themeCycle
+        });
+        persistTheme(nextTheme);
+    }
+
+    function initThemeToggle() {
+        const button = document.getElementById(BUTTON_ID);
+        if (!button) {
+            return;
+        }
+
+        const detectedThemes = THEMES.filter(theme => {
+            return Boolean(document.getElementById(theme.linkId));
+        }).map(theme => theme.name);
+
+        const themeCycle = [DEFAULT_THEME].concat(detectedThemes);
+        const storedTheme = getThemeFromStorage(themeCycle);
+        const hasAlternates = themeCycle.length > 1;
+
+        applyTheme(storedTheme, {
+            button: button,
+            themeCycle: themeCycle,
+            isButtonDisabled: !hasAlternates
+        });
+
+        if (hasAlternates) {
+            button.addEventListener('click', function () {
+                handleThemeToggle({
+                    themeCycle: themeCycle,
+                    button: button
+                });
+            });
+        }
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', initThemeToggle);
+    } else {
+        initThemeToggle();
+    }
+})();


### PR DESCRIPTION
## Summary
- add a central theme manager that cycles the dashboard through classic, Halloween, Christmas, and Frunk looks
- wire the new Christmas and Frunk themes into the dashboard with dedicated styling and scripted effects
- refresh the Halloween theme hook so it responds to the new theme change events

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cafce49b2c83278be992a462ada658