### PR TITLE
Extend Halloween jumpscare visibility

### DIFF
--- a/dnd/Halloween/theme.js
+++ b/dnd/Halloween/theme.js
@@ -42,17 +42,11 @@
         body.appendChild(overlay);
         activeOverlay = overlay;
 
-        let frames = 0;
-        function removeOnNextFrame() {
-            frames += 1;
-            if (frames >= 2) {
+        window.setTimeout(function () {
+            if (activeOverlay === overlay) {
                 clearOverlay();
-                return;
             }
-            requestAnimationFrame(removeOnNextFrame);
-        }
-
-        requestAnimationFrame(removeOnNextFrame);
+        }, 500);
     }
 
     function scheduleJumpscare(body) {


### PR DESCRIPTION
## Summary
- keep the Halloween theme jumpscare overlay visible for half a second instead of only a couple frames
- clear the overlay only if it is still the active one when the timeout fires

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68cb769c6ce483279fcb897f72e4192e