### PR TITLE
Add dashboard dice roller modal

### DIFF
--- a/dnd/css/style.css
+++ b/dnd/css/style.css
@@ -1123,3 +1123,188 @@ body:not(.gm-mode) .club-navigation button:hover:not(:disabled) {
         justify-content: center;
     }
 }
+/* Dice roller modal */
+.dice-modal-overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.55);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 1050;
+    transition: opacity 0.2s ease;
+}
+
+.dice-modal-overlay.hidden {
+    opacity: 0;
+    pointer-events: none;
+}
+
+.dice-modal {
+    background: #f4f6f8;
+    color: #2c3e50;
+    border-radius: 12px;
+    width: min(480px, 90%);
+    box-shadow: 0 20px 45px rgba(0, 0, 0, 0.25);
+    display: flex;
+    flex-direction: column;
+    outline: none;
+}
+
+.dice-modal-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 1rem 1.25rem;
+    background: #34495e;
+    color: #ecf0f1;
+    border-top-left-radius: 12px;
+    border-top-right-radius: 12px;
+}
+
+.dice-modal-title {
+    font-size: 1.25rem;
+    margin: 0;
+}
+
+.dice-modal-close {
+    background: transparent;
+    border: none;
+    color: inherit;
+    font-size: 1.75rem;
+    cursor: pointer;
+    line-height: 1;
+    padding: 0;
+}
+
+.dice-modal-close:hover {
+    color: #bdc3c7;
+}
+
+.dice-modal-content {
+    padding: 1.25rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+}
+
+.dice-buttons-section {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.dice-buttons-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+}
+
+.dice-btn {
+    flex: 1;
+    min-width: 4.5rem;
+    padding: 0.6rem 0.75rem;
+    border-radius: 8px;
+    border: none;
+    background: #3498db;
+    color: #fff;
+    font-weight: 600;
+    cursor: pointer;
+    transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.dice-btn.special {
+    background: #9b59b6;
+}
+
+.dice-btn:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 6px 12px rgba(52, 152, 219, 0.3);
+}
+
+.dice-btn.special:hover {
+    box-shadow: 0 6px 12px rgba(155, 89, 182, 0.3);
+}
+
+.dice-queue-section {
+    background: #ecf0f1;
+    border-radius: 10px;
+    padding: 0.75rem 1rem;
+    box-shadow: inset 0 1px 4px rgba(0, 0, 0, 0.08);
+}
+
+.dice-queue-label {
+    font-weight: 600;
+    margin-bottom: 0.5rem;
+    color: #2c3e50;
+}
+
+.dice-queue {
+    min-height: 1.5rem;
+    font-family: 'Courier New', Courier, monospace;
+    font-size: 1rem;
+    color: #2c3e50;
+}
+
+.dice-queue.empty {
+    color: #7f8c8d;
+}
+
+.dice-actions {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.75rem;
+}
+
+.dice-roll-btn,
+.dice-clear-btn {
+    border: none;
+    border-radius: 8px;
+    padding: 0.65rem 1.5rem;
+    font-weight: 700;
+    cursor: pointer;
+    color: #fff;
+    transition: transform 0.1s ease, box-shadow 0.1s ease;
+}
+
+.dice-roll-btn {
+    background: #27ae60;
+}
+
+.dice-clear-btn {
+    background: #e67e22;
+}
+
+.dice-roll-btn:hover,
+.dice-clear-btn:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 6px 12px rgba(0, 0, 0, 0.15);
+}
+
+.dice-result {
+    flex: 1;
+    min-width: 120px;
+    font-size: 1.1rem;
+    font-weight: 600;
+    color: #2c3e50;
+}
+
+@media (max-width: 600px) {
+    .dice-buttons-row {
+        justify-content: center;
+    }
+
+    .dice-btn {
+        flex: 0 1 calc(33% - 0.5rem);
+    }
+
+    .dice-actions {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .dice-result {
+        text-align: center;
+    }
+}

--- a/dnd/dashboard.php
+++ b/dnd/dashboard.php
@@ -925,6 +925,7 @@ $defaultInventoryTab = $is_gm ? 'frunk' : $user;
             <button class="nav-btn" onclick="openCombatTracker()">Combat Tracker</button>
             <button class="nav-btn" onclick="openSchedule()">Schedule</button>
             <button type="button" class="nav-btn" id="theme-toggle-btn" title="Switch theme">Theme</button>
+            <button type="button" class="nav-btn" id="dice-roller-btn" title="Open dice roller">Dice Roller</button>
             <button class="nav-btn logout-btn" onclick="window.location.href='logout.php'">Logout</button>
         </div>
         <h1 class="nav-title"><?php echo $is_gm ? 'GM Dashboard' : ucfirst($user) . '\'s Character Sheet'; ?></h1>
@@ -1475,6 +1476,7 @@ $defaultInventoryTab = $is_gm ? 'frunk' : $user;
             }
         }
     </script>
+    <script src="js/dashboard-dice-roller.js"></script>
     <script src="js/theme-manager.js"></script>
     <script src="Halloween/theme.js" defer></script>
     <script src="Christmas/theme.js" defer></script>

--- a/dnd/js/dashboard-dice-roller.js
+++ b/dnd/js/dashboard-dice-roller.js
@@ -1,0 +1,257 @@
+class DashboardDiceRoller {
+    constructor(buttonId) {
+        this.triggerButton = document.getElementById(buttonId);
+        if (!this.triggerButton) {
+            console.warn(`Dice roller trigger button with id "${buttonId}" not found.`);
+            return;
+        }
+
+        this.currentRollQueue = [];
+        this.buildUI();
+        this.attachEvents();
+
+        this.handleKeyDown = (event) => {
+            if (event.key === 'Escape') {
+                this.close();
+            }
+        };
+    }
+
+    buildUI() {
+        this.overlay = document.createElement('div');
+        this.overlay.className = 'dice-modal-overlay hidden';
+
+        this.modal = document.createElement('div');
+        this.modal.className = 'dice-modal';
+        this.modal.setAttribute('role', 'dialog');
+        this.modal.setAttribute('aria-modal', 'true');
+        this.modal.setAttribute('aria-labelledby', 'dice-roller-title');
+        this.modal.tabIndex = -1;
+
+        const header = document.createElement('div');
+        header.className = 'dice-modal-header';
+
+        const title = document.createElement('h2');
+        title.className = 'dice-modal-title';
+        title.id = 'dice-roller-title';
+        title.textContent = 'Dice Roller';
+
+        const closeBtn = document.createElement('button');
+        closeBtn.type = 'button';
+        closeBtn.className = 'dice-modal-close';
+        closeBtn.setAttribute('aria-label', 'Close dice roller');
+        closeBtn.innerHTML = '&times;';
+        closeBtn.addEventListener('click', () => this.close());
+
+        header.appendChild(title);
+        header.appendChild(closeBtn);
+
+        const content = document.createElement('div');
+        content.className = 'dice-modal-content';
+
+        content.appendChild(this.createDiceButtonsSection());
+        content.appendChild(this.createQueueSection());
+        content.appendChild(this.createActionsSection());
+
+        this.modal.appendChild(header);
+        this.modal.appendChild(content);
+        this.overlay.appendChild(this.modal);
+        document.body.appendChild(this.overlay);
+
+        this.overlay.addEventListener('click', (event) => {
+            if (event.target === this.overlay) {
+                this.close();
+            }
+        });
+    }
+
+    attachEvents() {
+        this.triggerButton.addEventListener('click', () => this.open());
+    }
+
+    createDiceButtonsSection() {
+        const section = document.createElement('div');
+        section.className = 'dice-buttons-section';
+
+        const firstRow = document.createElement('div');
+        firstRow.className = 'dice-buttons-row';
+        [
+            { text: 'D2', dice: '1d2' },
+            { text: 'D4', dice: '1d4' },
+            { text: 'D8', dice: '1d8' },
+            { text: 'D10', dice: '1d10' },
+            { text: 'D20', dice: '1d20' }
+        ].forEach(({ text, dice }) => {
+            const btn = document.createElement('button');
+            btn.type = 'button';
+            btn.className = 'dice-btn';
+            btn.textContent = text;
+            btn.addEventListener('click', () => this.addToQueue(dice));
+            firstRow.appendChild(btn);
+        });
+
+        const secondRow = document.createElement('div');
+        secondRow.className = 'dice-buttons-row';
+        [
+            { text: 'Power Roll', value: '2d10' },
+            { text: 'Edge', value: '+2' },
+            { text: 'Bane', value: '-2' },
+            { text: '+1', value: '+1' }
+        ].forEach(({ text, value }) => {
+            const btn = document.createElement('button');
+            btn.type = 'button';
+            btn.className = 'dice-btn special';
+            btn.textContent = text;
+            btn.addEventListener('click', () => this.addToQueue(value));
+            secondRow.appendChild(btn);
+        });
+
+        section.appendChild(firstRow);
+        section.appendChild(secondRow);
+        return section;
+    }
+
+    createQueueSection() {
+        const queueSection = document.createElement('div');
+        queueSection.className = 'dice-queue-section';
+
+        const label = document.createElement('div');
+        label.className = 'dice-queue-label';
+        label.textContent = 'Current Roll:';
+
+        this.queueDisplay = document.createElement('div');
+        this.queueDisplay.className = 'dice-queue empty';
+        this.queueDisplay.textContent = '(nothing queued)';
+
+        queueSection.appendChild(label);
+        queueSection.appendChild(this.queueDisplay);
+        return queueSection;
+    }
+
+    createActionsSection() {
+        const actions = document.createElement('div');
+        actions.className = 'dice-actions';
+
+        const rollBtn = document.createElement('button');
+        rollBtn.type = 'button';
+        rollBtn.className = 'dice-roll-btn';
+        rollBtn.textContent = 'Roll!';
+        rollBtn.addEventListener('click', () => this.calculateRoll());
+
+        const clearBtn = document.createElement('button');
+        clearBtn.type = 'button';
+        clearBtn.className = 'dice-clear-btn';
+        clearBtn.textContent = 'Clear';
+        clearBtn.addEventListener('click', () => this.clearQueue());
+
+        this.resultLabel = document.createElement('div');
+        this.resultLabel.className = 'dice-result';
+        this.resultLabel.textContent = 'Result: -';
+
+        actions.appendChild(rollBtn);
+        actions.appendChild(clearBtn);
+        actions.appendChild(this.resultLabel);
+        return actions;
+    }
+
+    open() {
+        if (this.overlay) {
+            this.overlay.classList.remove('hidden');
+            document.addEventListener('keydown', this.handleKeyDown);
+            requestAnimationFrame(() => this.modal.focus());
+        }
+    }
+
+    close() {
+        if (this.overlay) {
+            this.overlay.classList.add('hidden');
+            document.removeEventListener('keydown', this.handleKeyDown);
+        }
+    }
+
+    addToQueue(item) {
+        this.currentRollQueue.push(item);
+        this.updateQueueDisplay();
+    }
+
+    updateQueueDisplay() {
+        if (!this.queueDisplay) {
+            return;
+        }
+
+        if (this.currentRollQueue.length === 0) {
+            this.queueDisplay.textContent = '(nothing queued)';
+            this.queueDisplay.classList.add('empty');
+        } else {
+            this.queueDisplay.textContent = this.currentRollQueue.join(' ');
+            this.queueDisplay.classList.remove('empty');
+        }
+    }
+
+    clearQueue() {
+        this.currentRollQueue = [];
+        this.updateQueueDisplay();
+        if (this.resultLabel) {
+            this.resultLabel.textContent = 'Result: -';
+        }
+    }
+
+    calculateRoll() {
+        if (this.currentRollQueue.length === 0) {
+            if (this.resultLabel) {
+                this.resultLabel.textContent = 'Nothing to roll!';
+            }
+            return;
+        }
+
+        try {
+            let totalResult = 0;
+
+            for (const item of this.currentRollQueue) {
+                if (item.startsWith('+')) {
+                    totalResult += parseInt(item.substring(1), 10);
+                } else if (item.startsWith('-')) {
+                    totalResult -= parseInt(item.substring(1), 10);
+                } else {
+                    const { result } = this.parseAndRollDice(item);
+                    totalResult += result;
+                }
+            }
+
+            if (this.resultLabel) {
+                this.resultLabel.textContent = `Result: ${totalResult}`;
+            }
+
+            this.currentRollQueue = [];
+            this.updateQueueDisplay();
+        } catch (error) {
+            if (this.resultLabel) {
+                this.resultLabel.textContent = `Error: ${error.message}`;
+            }
+        }
+    }
+
+    parseAndRollDice(diceNotation) {
+        const pattern = /^(\d+)d(\d+)$/;
+        const match = diceNotation.match(pattern);
+
+        if (!match) {
+            throw new Error(`Invalid dice notation: ${diceNotation}`);
+        }
+
+        const numDice = parseInt(match[1], 10);
+        const dieSize = parseInt(match[2], 10);
+
+        const rolls = [];
+        for (let i = 0; i < numDice; i += 1) {
+            rolls.push(Math.floor(Math.random() * dieSize) + 1);
+        }
+
+        const total = rolls.reduce((sum, roll) => sum + roll, 0);
+        return { result: total, detail: rolls };
+    }
+}
+
+window.addEventListener('DOMContentLoaded', () => {
+    new DashboardDiceRoller('dice-roller-btn');
+});


### PR DESCRIPTION
## Summary
- add a dice roller button to the GM dashboard navigation bar and load the supporting script
- implement a dashboard-themed modal dice roller that mirrors the GM screen functionality
- introduce styling for the modal, controls, and responsive layout adjustments

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cb82f571b88327b43e7222e113326e