### PR TITLE
Add dashboard chat panel UI and polling logic

### DIFF
--- a/dnd/css/style.css
+++ b/dnd/css/style.css
@@ -196,6 +196,208 @@ body {
     padding: 0 20px;
 }
 
+/* Chat panel */
+.chat-panel {
+    position: fixed;
+    right: 20px;
+    bottom: 20px;
+    width: 360px;
+    max-width: calc(100% - 40px);
+    background: #ffffff;
+    border-radius: 16px;
+    box-shadow: 0 12px 30px rgba(0, 0, 0, 0.15);
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    transform: translateX(calc(100% + 40px));
+    transition: transform 0.3s ease;
+    z-index: 1200;
+}
+
+.chat-panel--open {
+    transform: translateX(0);
+}
+
+.chat-panel--closed {
+    pointer-events: none;
+}
+
+.chat-panel__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 12px 16px;
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    color: #fff;
+}
+
+.chat-panel__title {
+    font-size: 1rem;
+    font-weight: 600;
+}
+
+.chat-panel__close {
+    background: transparent;
+    border: none;
+    color: inherit;
+    font-size: 1.5rem;
+    cursor: pointer;
+    padding: 0 4px;
+    line-height: 1;
+}
+
+.chat-panel__history {
+    padding: 12px 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    max-height: 360px;
+    overflow-y: auto;
+    background: #f7f8fc;
+}
+
+.chat-message {
+    display: flex;
+    flex-direction: column;
+    background: #fff;
+    border-radius: 10px;
+    padding: 8px 12px;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.08);
+    font-size: 0.9rem;
+}
+
+.chat-message--self {
+    align-self: flex-end;
+    background: #e2e8ff;
+}
+
+.chat-message__meta {
+    display: flex;
+    justify-content: space-between;
+    font-size: 0.75rem;
+    color: #6b7280;
+    margin-bottom: 4px;
+}
+
+.chat-message__text {
+    color: #1f2937;
+    white-space: pre-wrap;
+    word-break: break-word;
+}
+
+.chat-message--pending .chat-message__meta::after {
+    content: ' (sending...)';
+    font-style: italic;
+    color: #a0aec0;
+}
+
+.chat-message--error {
+    border: 1px solid #f87171;
+}
+
+.chat-panel__input {
+    display: flex;
+    gap: 8px;
+    padding: 12px 16px 16px;
+    border-top: 1px solid #e5e7eb;
+    background: #ffffff;
+}
+
+.chat-panel__textarea {
+    flex: 1;
+    resize: none;
+    border: 1px solid #d1d5db;
+    border-radius: 10px;
+    padding: 8px 10px;
+    font-family: inherit;
+    font-size: 0.95rem;
+    min-height: 48px;
+}
+
+.chat-panel__send {
+    background: #667eea;
+    border: none;
+    color: #fff;
+    padding: 10px 16px;
+    border-radius: 10px;
+    cursor: pointer;
+    font-weight: 600;
+    transition: background 0.2s ease;
+}
+
+.chat-panel__send:hover {
+    background: #5a67d8;
+}
+
+.chat-panel-toggle {
+    position: fixed;
+    right: 20px;
+    bottom: 20px;
+    background: #1f2937;
+    color: #fff;
+    border: none;
+    border-radius: 999px;
+    padding: 10px 18px;
+    font-weight: 600;
+    cursor: pointer;
+    box-shadow: 0 8px 20px rgba(0, 0, 0, 0.18);
+    z-index: 1190;
+    transition: transform 0.2s ease, background 0.2s ease;
+}
+
+.chat-panel-toggle:hover {
+    transform: translateY(-2px);
+    background: #111827;
+}
+
+.chat-panel-toggle[aria-expanded="true"] {
+    background: #667eea;
+}
+
+.chat-drop-target {
+    position: fixed;
+    inset: 0;
+    background: rgba(102, 126, 234, 0.85);
+    color: #fff;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1.4rem;
+    font-weight: 600;
+    z-index: 1300;
+}
+
+.chat-drop-target[hidden] {
+    display: none;
+}
+
+@media (max-width: 1024px) {
+    .chat-panel {
+        width: 320px;
+    }
+}
+
+@media (max-width: 768px) {
+    .chat-panel {
+        right: 10px;
+        left: 10px;
+        width: auto;
+        max-width: none;
+        bottom: 90px;
+        transform: translateY(calc(100% + 40px));
+    }
+
+    .chat-panel--open {
+        transform: translateY(0);
+    }
+
+    .chat-panel-toggle {
+        right: 10px;
+        left: 10px;
+        width: calc(100% - 20px);
+    }
+}
+
 /* Character tabs (GM only) */
 .character-tabs {
     display: flex;

--- a/dnd/dashboard.php
+++ b/dnd/dashboard.php
@@ -1363,6 +1363,23 @@ $defaultInventoryTab = $is_gm ? 'frunk' : $user;
                 </button>
             </div>
         <?php endif; ?>
+
+        <!-- Chat Panel -->
+        <div id="chat-panel" class="chat-panel chat-panel--closed" aria-hidden="true">
+            <div class="chat-panel__header">
+                <h3 class="chat-panel__title">Table Chat</h3>
+                <button type="button" id="chat-panel-close" class="chat-panel__close" aria-label="Close chat">&times;</button>
+            </div>
+            <div id="chat-message-list" class="chat-panel__history" role="log" aria-live="polite"></div>
+            <form id="chat-input-form" class="chat-panel__input" autocomplete="off">
+                <textarea id="chat-input" class="chat-panel__textarea" rows="2" placeholder="Type a message..."></textarea>
+                <button type="submit" id="chat-send-btn" class="chat-panel__send">Send</button>
+            </form>
+        </div>
+        <button id="chat-panel-toggle" class="chat-panel-toggle" type="button" aria-expanded="false" aria-controls="chat-panel">
+            Open Chat
+        </button>
+        <div id="chat-drop-target" class="chat-drop-target" hidden aria-hidden="true">Drop files to upload</div>
     </div>
 
     <!-- Modal for Past Class Details -->
@@ -1425,6 +1442,8 @@ $defaultInventoryTab = $is_gm ? 'frunk' : $user;
             loadInventoryData();
             setupInventoryAutoSave();
             updateInventoryPermissions();
+
+            initChatPanel(isGM, currentUser);
         });
 
         // Session backup functionality for Dashboard
@@ -1498,6 +1517,7 @@ $defaultInventoryTab = $is_gm ? 'frunk' : $user;
             }
         }
     </script>
+    <script src="js/chat-panel.js"></script>
     <script src="js/dashboard-dice-roller.js"></script>
     <script src="js/theme-manager.js"></script>
     <script src="Halloween/theme.js" defer></script>

--- a/dnd/js/chat-panel.js
+++ b/dnd/js/chat-panel.js
@@ -1,0 +1,363 @@
+(function () {
+    const FETCH_INTERVAL_MS = 2500;
+    const MAX_MESSAGES = 100;
+
+    function initChatPanel(isGM, currentUser) {
+        const panel = document.getElementById('chat-panel');
+        const toggleButton = document.getElementById('chat-panel-toggle');
+        const closeButton = document.getElementById('chat-panel-close');
+        const messageList = document.getElementById('chat-message-list');
+        const form = document.getElementById('chat-input-form');
+        const textarea = document.getElementById('chat-input');
+        const sendButton = document.getElementById('chat-send-btn');
+        const dropTarget = document.getElementById('chat-drop-target');
+
+        if (!panel || !toggleButton || !messageList || !form || !textarea || !sendButton) {
+            return;
+        }
+
+        let isOpen = false;
+        let fetchTimer = null;
+        let fetchInProgress = false;
+        let latestServerTimestamp = '';
+        let messages = [];
+
+        const existingMessages = messageList.dataset.initialMessages;
+        if (existingMessages) {
+            try {
+                messages = JSON.parse(existingMessages);
+            } catch (error) {
+                messages = [];
+            }
+        }
+
+        function trimMessages() {
+            if (messages.length > MAX_MESSAGES) {
+                messages = messages.slice(-MAX_MESSAGES);
+            }
+        }
+
+        function formatTimestamp(timestamp) {
+            if (!timestamp) {
+                return '';
+            }
+
+            const parsed = new Date(timestamp);
+            if (Number.isNaN(parsed.getTime())) {
+                return '';
+            }
+
+            return parsed.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+        }
+
+        function createMessageElement(message) {
+            const wrapper = document.createElement('div');
+            wrapper.className = 'chat-message';
+
+            if (message.user === currentUser) {
+                wrapper.classList.add('chat-message--self');
+            }
+
+            if (message.pending) {
+                wrapper.classList.add('chat-message--pending');
+            }
+
+            if (message.error) {
+                wrapper.classList.add('chat-message--error');
+            }
+
+            const meta = document.createElement('div');
+            meta.className = 'chat-message__meta';
+
+            const userSpan = document.createElement('span');
+            userSpan.textContent = message.user || 'Unknown';
+            meta.appendChild(userSpan);
+
+            const timeSpan = document.createElement('span');
+            timeSpan.textContent = formatTimestamp(message.timestamp);
+            meta.appendChild(timeSpan);
+
+            const body = document.createElement('div');
+            body.className = 'chat-message__text';
+            body.textContent = message.message || '';
+
+            wrapper.appendChild(meta);
+            wrapper.appendChild(body);
+
+            return wrapper;
+        }
+
+        function renderMessages() {
+            messageList.innerHTML = '';
+
+            const sorted = [...messages].sort((a, b) => {
+                const timeA = new Date(a.timestamp || 0).getTime();
+                const timeB = new Date(b.timestamp || 0).getTime();
+                return timeA - timeB;
+            });
+
+            for (const message of sorted) {
+                messageList.appendChild(createMessageElement(message));
+            }
+
+            messageList.scrollTop = messageList.scrollHeight;
+        }
+
+        function setOpen(state) {
+            isOpen = state;
+            panel.classList.toggle('chat-panel--open', state);
+            panel.classList.toggle('chat-panel--closed', !state);
+            panel.setAttribute('aria-hidden', state ? 'false' : 'true');
+            toggleButton.setAttribute('aria-expanded', state ? 'true' : 'false');
+            toggleButton.textContent = state ? 'Close Chat' : 'Open Chat';
+
+            if (state) {
+                textarea.focus();
+            }
+        }
+
+        function ensureInterval() {
+            if (fetchTimer === null) {
+                fetchTimer = window.setInterval(fetchMessages, FETCH_INTERVAL_MS);
+            }
+        }
+
+        function updateLatestTimestamp(candidate) {
+            if (!candidate) {
+                return;
+            }
+
+            if (!latestServerTimestamp) {
+                latestServerTimestamp = candidate;
+                return;
+            }
+
+            const currentTime = new Date(latestServerTimestamp).getTime();
+            const candidateTime = new Date(candidate).getTime();
+            if (!Number.isNaN(candidateTime) && candidateTime > currentTime) {
+                latestServerTimestamp = candidate;
+            }
+        }
+
+        function mergeMessages(incoming) {
+            if (!Array.isArray(incoming) || incoming.length === 0) {
+                return;
+            }
+
+            const idToIndex = new Map();
+            messages.forEach((msg, index) => {
+                if (msg && msg.id) {
+                    idToIndex.set(msg.id, index);
+                }
+            });
+
+            let hasChanges = false;
+            for (const message of incoming) {
+                if (!message || !message.id) {
+                    continue;
+                }
+
+                updateLatestTimestamp(message.timestamp);
+
+                if (idToIndex.has(message.id)) {
+                    const idx = idToIndex.get(message.id);
+                    messages[idx] = Object.assign({}, messages[idx], message, { pending: false, error: false });
+                } else {
+                    messages.push(Object.assign({}, message, { pending: false, error: false }));
+                }
+
+                hasChanges = true;
+            }
+
+            if (hasChanges) {
+                trimMessages();
+                renderMessages();
+            }
+        }
+
+        async function fetchMessages() {
+            if (fetchInProgress) {
+                return;
+            }
+
+            fetchInProgress = true;
+            try {
+                const params = new URLSearchParams();
+                params.append('action', 'chat_fetch');
+                if (latestServerTimestamp) {
+                    params.append('since', latestServerTimestamp);
+                }
+
+                const response = await fetch('chat_handler.php', {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/x-www-form-urlencoded'
+                    },
+                    body: params.toString()
+                });
+
+                if (!response.ok) {
+                    return;
+                }
+
+                const data = await response.json();
+                if (data && data.success) {
+                    mergeMessages(data.messages || []);
+                    updateLatestTimestamp(data.latest);
+                }
+            } catch (error) {
+                // Swallow errors to keep polling running
+            } finally {
+                fetchInProgress = false;
+            }
+        }
+
+        async function handleSend(event) {
+            event.preventDefault();
+            const text = textarea.value.trim();
+            if (text === '') {
+                return;
+            }
+
+            const tempId = `temp-${Date.now()}`;
+            const optimisticMessage = {
+                id: tempId,
+                timestamp: new Date().toISOString(),
+                user: currentUser || 'You',
+                message: text,
+                pending: true,
+                error: false
+            };
+
+            messages.push(optimisticMessage);
+            trimMessages();
+            renderMessages();
+
+            textarea.value = '';
+            textarea.focus();
+            sendButton.disabled = true;
+
+            try {
+                const params = new URLSearchParams();
+                params.append('action', 'chat_send');
+                params.append('message', text);
+
+                const response = await fetch('chat_handler.php', {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/x-www-form-urlencoded'
+                    },
+                    body: params.toString()
+                });
+
+                const data = await response.json();
+                if (data && data.success && data.message) {
+                    resolvePendingMessage(tempId, data.message);
+                    updateLatestTimestamp(data.message.timestamp);
+                } else {
+                    markMessageError(tempId);
+                }
+            } catch (error) {
+                markMessageError(tempId);
+            } finally {
+                sendButton.disabled = false;
+            }
+        }
+
+        function resolvePendingMessage(tempId, serverMessage) {
+            const index = messages.findIndex((message) => message.id === tempId);
+            if (index !== -1) {
+                messages[index] = Object.assign({}, serverMessage, { pending: false, error: false });
+            } else {
+                messages.push(Object.assign({}, serverMessage, { pending: false, error: false }));
+            }
+
+            trimMessages();
+            renderMessages();
+        }
+
+        function markMessageError(tempId) {
+            const index = messages.findIndex((message) => message.id === tempId);
+            if (index !== -1) {
+                messages[index].pending = false;
+                messages[index].error = true;
+                renderMessages();
+            }
+        }
+
+        function handleTextareaKeydown(event) {
+            if (event.key === 'Enter' && !event.shiftKey) {
+                event.preventDefault();
+                form.requestSubmit();
+            }
+        }
+
+        function shouldHandleDrag(event) {
+            if (!event.dataTransfer) {
+                return false;
+            }
+            const types = Array.from(event.dataTransfer.types || []);
+            return types.includes('Files');
+        }
+
+        function showDropTarget() {
+            if (!dropTarget) {
+                return;
+            }
+            dropTarget.hidden = false;
+            dropTarget.setAttribute('aria-hidden', 'false');
+        }
+
+        function hideDropTarget() {
+            if (!dropTarget) {
+                return;
+            }
+            dropTarget.hidden = true;
+            dropTarget.setAttribute('aria-hidden', 'true');
+        }
+
+        document.addEventListener('dragenter', (event) => {
+            if (shouldHandleDrag(event)) {
+                event.preventDefault();
+                showDropTarget();
+            }
+        });
+
+        document.addEventListener('dragover', (event) => {
+            if (shouldHandleDrag(event)) {
+                event.preventDefault();
+            }
+        });
+
+        document.addEventListener('dragleave', (event) => {
+            if (event.target === dropTarget || !event.relatedTarget) {
+                hideDropTarget();
+            }
+        });
+
+        document.addEventListener('drop', (event) => {
+            if (shouldHandleDrag(event)) {
+                event.preventDefault();
+                hideDropTarget();
+            }
+        });
+
+        toggleButton.addEventListener('click', () => {
+            setOpen(!isOpen);
+        });
+
+        if (closeButton) {
+            closeButton.addEventListener('click', () => setOpen(false));
+        }
+
+        form.addEventListener('submit', handleSend);
+        textarea.addEventListener('keydown', handleTextareaKeydown);
+
+        setOpen(false);
+        renderMessages();
+        ensureInterval();
+        fetchMessages();
+    }
+
+    window.initChatPanel = initChatPanel;
+})();


### PR DESCRIPTION
## Summary
- add fixed-position chat panel markup to the dashboard along with a toggle button and drop target
- style the new chat interface with responsive behavior, transitions, and scrollable history
- implement chat-panel.js to initialize the UI, handle sending, polling for messages, and prevent XSS when rendering

## Testing
- php -l dnd/dashboard.php

------
https://chatgpt.com/codex/tasks/task_e_68d0883fd38c8327a2f088dc8c669902