### PR TITLE
Enable dragging portraits into chat and handle image drops

### DIFF
--- a/dnd/css/style.css
+++ b/dnd/css/style.css
@@ -285,6 +285,23 @@ body {
     word-break: break-word;
 }
 
+.chat-message__text--image {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.chat-message__image {
+    max-width: 260px;
+    border-radius: 10px;
+    box-shadow: 0 6px 18px rgba(15, 23, 42, 0.25);
+}
+
+.chat-message__caption {
+    font-size: 0.8rem;
+    color: #4b5563;
+}
+
 .chat-message--pending .chat-message__meta::after {
     content: ' (sending...)';
     font-style: italic;
@@ -369,6 +386,35 @@ body {
 
 .chat-drop-target[hidden] {
     display: none;
+}
+
+.chat-toast {
+    position: fixed;
+    right: 20px;
+    bottom: 20px;
+    background: rgba(31, 41, 55, 0.95);
+    color: #ffffff;
+    padding: 12px 18px;
+    border-radius: 12px;
+    box-shadow: 0 12px 30px rgba(15, 23, 42, 0.35);
+    font-size: 0.9rem;
+    z-index: 1500;
+    opacity: 1;
+    transform: translateY(0);
+    transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+.chat-toast--error {
+    background: rgba(239, 68, 68, 0.95);
+}
+
+.chat-toast--success {
+    background: rgba(16, 185, 129, 0.95);
+}
+
+.chat-toast--hide {
+    opacity: 0;
+    transform: translateY(14px);
 }
 
 @media (max-width: 1024px) {

--- a/dnd/dashboard.php
+++ b/dnd/dashboard.php
@@ -1379,7 +1379,7 @@ $defaultInventoryTab = $is_gm ? 'frunk' : $user;
         <button id="chat-panel-toggle" class="chat-panel-toggle" type="button" aria-expanded="false" aria-controls="chat-panel">
             Open Chat
         </button>
-        <div id="chat-drop-target" class="chat-drop-target" hidden aria-hidden="true">Drop files to upload</div>
+        <div id="chat-drop-target" class="chat-drop-target" hidden aria-hidden="true">Drop images or image links to share</div>
     </div>
 
     <!-- Modal for Past Class Details -->

--- a/dnd/js/inventory-integrated.js
+++ b/dnd/js/inventory-integrated.js
@@ -111,11 +111,11 @@ function createInventoryItemCard(item, index, tab) {
     card.innerHTML = `
         <div class="inventory-item-card-header">
             <div class="inventory-item-name">${escapeHtml(item.name || 'Unnamed Item')}</div>
-            ${item.image ? `<img src="${item.image}" alt="${escapeHtml(item.name)}" class="inventory-item-image-small">` : ''}
+            ${item.image ? `<img src="${item.image}" alt="${escapeHtml(item.name)}" class="inventory-item-image-small" draggable="true">` : ''}
         </div>
         
         <div class="inventory-item-details">
-            ${item.image ? `<img src="${item.image}" alt="${escapeHtml(item.name)}" class="inventory-item-image-large">` : ''}
+            ${item.image ? `<img src="${item.image}" alt="${escapeHtml(item.name)}" class="inventory-item-image-large" draggable="true">` : ''}
             
             <div class="inventory-item-field">
                 <label>Name:</label>
@@ -182,7 +182,37 @@ function createInventoryItemCard(item, index, tab) {
         }
         expandInventoryCard(this);
     });
-    
+
+    const dragImages = card.querySelectorAll('.inventory-item-image-small, .inventory-item-image-large');
+    dragImages.forEach((img) => {
+        if (!img || !img.getAttribute('src')) {
+            return;
+        }
+
+        const url = img.getAttribute('src');
+        if (typeof window.makeImageDraggable === 'function') {
+            window.makeImageDraggable(img, url);
+            return;
+        }
+
+        const absoluteUrl = (() => {
+            try {
+                return new URL(url, window.location.href).toString();
+            } catch (error) {
+                return url;
+            }
+        })();
+
+        img.addEventListener('dragstart', (event) => {
+            if (!event.dataTransfer) {
+                return;
+            }
+            event.dataTransfer.effectAllowed = 'copy';
+            event.dataTransfer.setData('text/uri-list', absoluteUrl);
+            event.dataTransfer.setData('text/plain', absoluteUrl);
+        });
+    });
+
     return card;
 }
 

--- a/dnd/strixhaven/gm/character-details.php
+++ b/dnd/strixhaven/gm/character-details.php
@@ -253,9 +253,10 @@ $type = $result['type'];
                 
                 if ($imagePath && file_exists($imagePath)):
                 ?>
-                    <img src="<?php echo htmlspecialchars($imagePath); ?>" 
-                         alt="<?php echo htmlspecialchars($character['name']); ?>" 
-                         class="character-portrait">
+                    <img src="<?php echo htmlspecialchars($imagePath); ?>"
+                         alt="<?php echo htmlspecialchars($character['name']); ?>"
+                         class="character-portrait"
+                         draggable="true">
                 <?php else: ?>
                     <div class="character-portrait-placeholder">No Photo</div>
                 <?php endif; ?>
@@ -350,5 +351,33 @@ $type = $result['type'];
             </div>
         </div>
     </div>
+<?php if ($imagePath && file_exists($imagePath)): ?>
+<script>
+    (function() {
+        const portrait = document.querySelector('.character-portrait');
+        if (!portrait) {
+            return;
+        }
+
+        portrait.setAttribute('draggable', 'true');
+        const src = portrait.getAttribute('src');
+        let absoluteUrl = src;
+        try {
+            absoluteUrl = new URL(src, window.location.href).href;
+        } catch (error) {
+            absoluteUrl = src;
+        }
+
+        portrait.addEventListener('dragstart', function(event) {
+            if (!event.dataTransfer) {
+                return;
+            }
+            event.dataTransfer.effectAllowed = 'copy';
+            event.dataTransfer.setData('text/uri-list', absoluteUrl);
+            event.dataTransfer.setData('text/plain', absoluteUrl);
+        });
+    })();
+</script>
+<?php endif; ?>
 </body>
 </html>

--- a/dnd/strixhaven/gm/js/character-lookup.js
+++ b/dnd/strixhaven/gm/js/character-lookup.js
@@ -512,6 +512,32 @@ class CharacterLookup {
                         ${this.createStudentDetailContent(student)}
                     </div>
                 </div>
+                <script>
+                    (function() {
+                        const portrait = document.querySelector('.character-portrait');
+                        if (!portrait) {
+                            return;
+                        }
+
+                        portrait.setAttribute('draggable', 'true');
+                        const src = portrait.getAttribute('src');
+                        let absoluteUrl = src;
+                        try {
+                            absoluteUrl = new URL(src, window.location.href).href;
+                        } catch (error) {
+                            absoluteUrl = src;
+                        }
+
+                        portrait.addEventListener('dragstart', function(event) {
+                            if (!event.dataTransfer) {
+                                return;
+                            }
+                            event.dataTransfer.effectAllowed = 'copy';
+                            event.dataTransfer.setData('text/uri-list', absoluteUrl);
+                            event.dataTransfer.setData('text/plain', absoluteUrl);
+                        });
+                    })();
+                </script>
             </body>
             </html>
         `);
@@ -560,6 +586,32 @@ class CharacterLookup {
                         ${this.createStaffDetailContent(staff)}
                     </div>
                 </div>
+                <script>
+                    (function() {
+                        const portrait = document.querySelector('.character-portrait');
+                        if (!portrait) {
+                            return;
+                        }
+
+                        portrait.setAttribute('draggable', 'true');
+                        const src = portrait.getAttribute('src');
+                        let absoluteUrl = src;
+                        try {
+                            absoluteUrl = new URL(src, window.location.href).href;
+                        } catch (error) {
+                            absoluteUrl = src;
+                        }
+
+                        portrait.addEventListener('dragstart', function(event) {
+                            if (!event.dataTransfer) {
+                                return;
+                            }
+                            event.dataTransfer.effectAllowed = 'copy';
+                            event.dataTransfer.setData('text/uri-list', absoluteUrl);
+                            event.dataTransfer.setData('text/plain', absoluteUrl);
+                        });
+                    })();
+                </script>
             </body>
             </html>
         `);
@@ -608,6 +660,32 @@ class CharacterLookup {
                         ${this.createLocationDetailContent(location)}
                     </div>
                 </div>
+                <script>
+                    (function() {
+                        const portrait = document.querySelector('.character-portrait');
+                        if (!portrait) {
+                            return;
+                        }
+
+                        portrait.setAttribute('draggable', 'true');
+                        const src = portrait.getAttribute('src');
+                        let absoluteUrl = src;
+                        try {
+                            absoluteUrl = new URL(src, window.location.href).href;
+                        } catch (error) {
+                            absoluteUrl = src;
+                        }
+
+                        portrait.addEventListener('dragstart', function(event) {
+                            if (!event.dataTransfer) {
+                                return;
+                            }
+                            event.dataTransfer.effectAllowed = 'copy';
+                            event.dataTransfer.setData('text/uri-list', absoluteUrl);
+                            event.dataTransfer.setData('text/plain', absoluteUrl);
+                        });
+                    })();
+                </script>
             </body>
             </html>
         `);
@@ -619,8 +697,8 @@ class CharacterLookup {
         const imagePath = student.image_path ? `../students/${student.image_path}?t=${Date.now()}` : '';
         return `
             <div class="character-portrait-section">
-                ${imagePath ? 
-                    `<img src="${imagePath}" alt="${this.escapeHtml(student.name)}" class="character-portrait">` : 
+                ${imagePath ?
+                    `<img src="${imagePath}" alt="${this.escapeHtml(student.name)}" class="character-portrait" draggable="true">` :
                     '<div class="character-portrait-placeholder">No Photo</div>'
                 }
             </div>
@@ -717,8 +795,8 @@ class CharacterLookup {
         const imagePath = staff.image_path ? `../staff/${staff.image_path}?t=${Date.now()}` : '';
         return `
             <div class="character-portrait-section">
-                ${imagePath ? 
-                    `<img src="${imagePath}" alt="${this.escapeHtml(staff.name)}" class="character-portrait">` : 
+                ${imagePath ?
+                    `<img src="${imagePath}" alt="${this.escapeHtml(staff.name)}" class="character-portrait" draggable="true">` :
                     '<div class="character-portrait-placeholder">No Photo</div>'
                 }
             </div>
@@ -755,8 +833,8 @@ class CharacterLookup {
         const imagePath = location.image_path ? `../locations/${location.image_path}?t=${Date.now()}` : '';
         return `
             <div class="character-portrait-section">
-                ${imagePath ? 
-                    `<img src="${imagePath}" alt="${this.escapeHtml(location.name)}" class="character-portrait">` : 
+                ${imagePath ?
+                    `<img src="${imagePath}" alt="${this.escapeHtml(location.name)}" class="character-portrait" draggable="true">` :
                     '<div class="character-portrait-placeholder">📍</div>'
                 }
             </div>

--- a/dnd/strixhaven/locations/character-details.php
+++ b/dnd/strixhaven/locations/character-details.php
@@ -198,7 +198,7 @@ $type = $result['type'];
                 }
                 
                 if ($imagePath && file_exists($imagePath)): ?>
-                    <img src="<?php echo htmlspecialchars($imagePath); ?>" alt="<?php echo htmlspecialchars($character['name']); ?>" class="character-portrait">
+                    <img src="<?php echo htmlspecialchars($imagePath); ?>" alt="<?php echo htmlspecialchars($character['name']); ?>" class="character-portrait" draggable="true">
                 <?php else: ?>
                     <div class="character-portrait" style="background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); display: flex; align-items: center; justify-content: center; color: white; font-size: 3em;">
                         <?php echo $type === 'location' ? '📍' : '👤'; ?>
@@ -344,5 +344,33 @@ $type = $result['type'];
             </div>
         </div>
     </div>
+<?php if ($imagePath && file_exists($imagePath)): ?>
+<script>
+    (function() {
+        const portrait = document.querySelector('.character-portrait');
+        if (!portrait) {
+            return;
+        }
+
+        portrait.setAttribute('draggable', 'true');
+        const src = portrait.getAttribute('src');
+        let absoluteUrl = src;
+        try {
+            absoluteUrl = new URL(src, window.location.href).href;
+        } catch (error) {
+            absoluteUrl = src;
+        }
+
+        portrait.addEventListener('dragstart', function(event) {
+            if (!event.dataTransfer) {
+                return;
+            }
+            event.dataTransfer.effectAllowed = 'copy';
+            event.dataTransfer.setData('text/uri-list', absoluteUrl);
+            event.dataTransfer.setData('text/plain', absoluteUrl);
+        });
+    })();
+</script>
+<?php endif; ?>
 </body>
 </html>

--- a/dnd/strixhaven/staff/character-details.php
+++ b/dnd/strixhaven/staff/character-details.php
@@ -198,7 +198,7 @@ $type = $result['type'];
                 }
                 
                 if ($imagePath && file_exists($imagePath)): ?>
-                    <img src="<?php echo htmlspecialchars($imagePath); ?>" alt="<?php echo htmlspecialchars($character['name']); ?>" class="character-portrait">
+                    <img src="<?php echo htmlspecialchars($imagePath); ?>" alt="<?php echo htmlspecialchars($character['name']); ?>" class="character-portrait" draggable="true">
                 <?php else: ?>
                     <div class="character-portrait" style="background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); display: flex; align-items: center; justify-content: center; color: white; font-size: 3em;">
                         <?php echo $type === 'location' ? '📍' : '👤'; ?>
@@ -344,5 +344,33 @@ $type = $result['type'];
             </div>
         </div>
     </div>
+<?php if ($imagePath && file_exists($imagePath)): ?>
+<script>
+    (function() {
+        const portrait = document.querySelector('.character-portrait');
+        if (!portrait) {
+            return;
+        }
+
+        portrait.setAttribute('draggable', 'true');
+        const src = portrait.getAttribute('src');
+        let absoluteUrl = src;
+        try {
+            absoluteUrl = new URL(src, window.location.href).href;
+        } catch (error) {
+            absoluteUrl = src;
+        }
+
+        portrait.addEventListener('dragstart', function(event) {
+            if (!event.dataTransfer) {
+                return;
+            }
+            event.dataTransfer.effectAllowed = 'copy';
+            event.dataTransfer.setData('text/uri-list', absoluteUrl);
+            event.dataTransfer.setData('text/plain', absoluteUrl);
+        });
+    })();
+</script>
+<?php endif; ?>
 </body>
 </html>

--- a/dnd/strixhaven/students/character-details.php
+++ b/dnd/strixhaven/students/character-details.php
@@ -198,7 +198,7 @@ $type = $result['type'];
                 }
                 
                 if ($imagePath && file_exists($imagePath)): ?>
-                    <img src="<?php echo htmlspecialchars($imagePath); ?>" alt="<?php echo htmlspecialchars($character['name']); ?>" class="character-portrait">
+                    <img src="<?php echo htmlspecialchars($imagePath); ?>" alt="<?php echo htmlspecialchars($character['name']); ?>" class="character-portrait" draggable="true">
                 <?php else: ?>
                     <div class="character-portrait" style="background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); display: flex; align-items: center; justify-content: center; color: white; font-size: 3em;">
                         <?php echo $type === 'location' ? '📍' : '👤'; ?>
@@ -344,5 +344,33 @@ $type = $result['type'];
             </div>
         </div>
     </div>
+<?php if ($imagePath && file_exists($imagePath)): ?>
+<script>
+    (function() {
+        const portrait = document.querySelector('.character-portrait');
+        if (!portrait) {
+            return;
+        }
+
+        portrait.setAttribute('draggable', 'true');
+        const src = portrait.getAttribute('src');
+        let absoluteUrl = src;
+        try {
+            absoluteUrl = new URL(src, window.location.href).href;
+        } catch (error) {
+            absoluteUrl = src;
+        }
+
+        portrait.addEventListener('dragstart', function(event) {
+            if (!event.dataTransfer) {
+                return;
+            }
+            event.dataTransfer.effectAllowed = 'copy';
+            event.dataTransfer.setData('text/uri-list', absoluteUrl);
+            event.dataTransfer.setData('text/plain', absoluteUrl);
+        });
+    })();
+</script>
+<?php endif; ?>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add chat panel drag-and-drop support for image uploads and image URLs, render shared images inline, and surface drop errors via toasts
- expose a helper that seeds drag data from portraits and mark dashboard/inventory images draggable
- update Strixhaven detail templates (and GM lookup windows) to set portraits draggable and populate drag payloads with absolute URLs

## Testing
- php -l dnd/chat_handler.php
- php -l dnd/dashboard.php
- php -l dnd/strixhaven/students/character-details.php
- php -l dnd/strixhaven/staff/character-details.php
- php -l dnd/strixhaven/locations/character-details.php
- php -l dnd/strixhaven/gm/character-details.php

------
https://chatgpt.com/codex/tasks/task_e_68d0897993f48327a65664c4a1806d10