### PR TITLE
Restyle chat panel as right-side drawer

### DIFF
--- a/dnd/css/style.css
+++ b/dnd/css/style.css
@@ -96,6 +96,11 @@ body {
     color: #333;
 }
 
+:root {
+    --chat-panel-width: 360px;
+    --chat-panel-offset: 20px;
+}
+
 /* Top Navigation Bar */
 .top-nav {
     background: rgba(255, 255, 255, 0.95);
@@ -199,23 +204,25 @@ body {
 /* Chat panel */
 .chat-panel {
     position: fixed;
-    right: 20px;
-    bottom: 20px;
-    width: 360px;
-    max-width: calc(100% - 40px);
+    top: var(--chat-panel-offset);
+    right: 0;
+    bottom: var(--chat-panel-offset);
+    width: min(var(--chat-panel-width), calc(100vw - (var(--chat-panel-offset) * 2)));
     background: #ffffff;
-    border-radius: 16px;
-    box-shadow: 0 12px 30px rgba(0, 0, 0, 0.15);
+    border-radius: 16px 0 0 16px;
+    box-shadow: -12px 0 35px rgba(15, 23, 42, 0.22);
     display: flex;
     flex-direction: column;
     overflow: hidden;
-    transform: translateX(calc(100% + 40px));
-    transition: transform 0.3s ease;
-    z-index: 1200;
+    transform: translateX(calc(100% + var(--chat-panel-offset)));
+    transition: transform 0.35s ease;
+    z-index: 1400;
+    border-left: 1px solid rgba(15, 23, 42, 0.08);
 }
 
 .chat-panel--open {
     transform: translateX(0);
+    pointer-events: auto;
 }
 
 .chat-panel--closed {
@@ -251,9 +258,10 @@ body {
     display: flex;
     flex-direction: column;
     gap: 8px;
-    max-height: 360px;
-    overflow-y: auto;
     background: #f7f8fc;
+    flex: 1;
+    overflow-y: auto;
+    min-height: 0;
 }
 
 .chat-message {
@@ -348,27 +356,36 @@ body {
 
 .chat-panel-toggle {
     position: fixed;
-    right: 20px;
-    bottom: 20px;
+    top: 50%;
+    right: 0;
     background: #1f2937;
     color: #fff;
     border: none;
-    border-radius: 999px;
-    padding: 10px 18px;
+    border-radius: 12px 0 0 12px;
+    padding: 18px 12px;
     font-weight: 600;
     cursor: pointer;
-    box-shadow: 0 8px 20px rgba(0, 0, 0, 0.18);
-    z-index: 1190;
-    transition: transform 0.2s ease, background 0.2s ease;
+    box-shadow: -10px 0 25px rgba(15, 23, 42, 0.25);
+    z-index: 1390;
+    transition: background 0.2s ease, transform 0.3s ease;
+    transform: translate3d(0, -50%, 0);
+    writing-mode: vertical-rl;
+    text-orientation: mixed;
+    letter-spacing: 0.12em;
 }
 
-.chat-panel-toggle:hover {
-    transform: translateY(-2px);
+.chat-panel-toggle:not([aria-expanded="true"]):hover {
     background: #111827;
+    transform: translate3d(-6px, -50%, 0);
 }
 
 .chat-panel-toggle[aria-expanded="true"] {
     background: #667eea;
+    transform: translate3d(calc(-1 * (var(--chat-panel-width) + var(--chat-panel-offset))), -50%, 0);
+}
+
+.chat-panel-toggle[aria-expanded="true"]:hover {
+    transform: translate3d(calc(-1 * (var(--chat-panel-width) + var(--chat-panel-offset)) - 6px), -50%, 0);
 }
 
 .chat-drop-target {
@@ -417,30 +434,50 @@ body {
     transform: translateY(14px);
 }
 
+@media (max-width: 1200px) {
+    :root {
+        --chat-panel-width: 340px;
+    }
+}
+
 @media (max-width: 1024px) {
-    .chat-panel {
-        width: 320px;
+    :root {
+        --chat-panel-width: 320px;
     }
 }
 
 @media (max-width: 768px) {
-    .chat-panel {
-        right: 10px;
-        left: 10px;
-        width: auto;
-        max-width: none;
-        bottom: 90px;
-        transform: translateY(calc(100% + 40px));
+    :root {
+        --chat-panel-width: calc(100vw - 24px);
+        --chat-panel-offset: 12px;
     }
 
-    .chat-panel--open {
-        transform: translateY(0);
+    .chat-panel {
+        right: var(--chat-panel-offset);
+        border-radius: 16px;
+        box-shadow: 0 18px 40px rgba(15, 23, 42, 0.25);
     }
 
     .chat-panel-toggle {
-        right: 10px;
-        left: 10px;
-        width: calc(100% - 20px);
+        top: auto;
+        bottom: 16px;
+        right: 16px;
+        transform: none;
+        padding: 12px 20px;
+        border-radius: 999px;
+        writing-mode: horizontal-tb;
+        text-orientation: initial;
+        letter-spacing: 0.02em;
+        box-shadow: 0 10px 24px rgba(15, 23, 42, 0.25);
+    }
+
+    .chat-panel-toggle:not([aria-expanded="true"]):hover,
+    .chat-panel-toggle[aria-expanded="true"]:hover {
+        transform: translateY(-2px);
+    }
+
+    .chat-panel-toggle[aria-expanded="true"] {
+        transform: none;
     }
 }
 


### PR DESCRIPTION
## Summary
- convert the table chat widget into a right-aligned drawer that slides over the dashboard and keeps its message history scrollable
- reposition the chat toggle into a vertical tab, using CSS variables so the drawer and toggle spacing adapt to different breakpoints
- refresh responsive rules so the drawer still works on narrow viewports while the toggle returns to a bottom pill control

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d091ae37a083278bc7c1755cfa2a53