### PR TITLE
Preserve chat image previews when server payloads omit URLs

### DIFF
--- a/dnd/js/chat-panel.js
+++ b/dnd/js/chat-panel.js
@@ -432,7 +432,8 @@
         function resolvePendingMessage(tempId, serverMessage) {
             const index = messages.findIndex((message) => message.id === tempId);
             if (index !== -1) {
-                messages[index] = Object.assign({}, serverMessage, { pending: false, error: false });
+                const existing = messages[index] || {};
+                messages[index] = Object.assign({}, existing, serverMessage, { pending: false, error: false });
             } else {
                 messages.push(Object.assign({}, serverMessage, { pending: false, error: false }));
             }


### PR DESCRIPTION
## Summary
- merge server confirmations with optimistic chat messages so existing imageUrl values survive resolution

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d0a005db108327b151efe590f5f862