### PR TITLE
Allow interacting with dashboard while dice tray open

### DIFF
--- a/dnd/css/style.css
+++ b/dnd/css/style.css
@@ -1505,17 +1505,17 @@ body:not(.gm-mode) .club-navigation button:hover:not(:disabled) {
 .dice-modal-overlay {
     position: fixed;
     inset: 0;
-    background: rgba(0, 0, 0, 0.55);
     display: flex;
     align-items: center;
     justify-content: center;
     z-index: 1050;
-    transition: opacity 0.2s ease;
+    pointer-events: none;
+    background: transparent;
 }
 
 .dice-modal-overlay.hidden {
     opacity: 0;
-    pointer-events: none;
+    visibility: hidden;
 }
 
 .dice-modal {
@@ -1528,6 +1528,7 @@ body:not(.gm-mode) .club-navigation button:hover:not(:disabled) {
     display: flex;
     flex-direction: column;
     outline: none;
+    pointer-events: auto;
 }
 
 .dice-modal-header {
@@ -1640,7 +1641,8 @@ body:not(.gm-mode) .club-navigation button:hover:not(:disabled) {
 }
 
 .dice-roll-btn,
-.dice-clear-btn {
+.dice-clear-btn,
+.dice-project-btn {
     border: none;
     border-radius: 8px;
     padding: 0.65rem 1.5rem;
@@ -1658,8 +1660,13 @@ body:not(.gm-mode) .club-navigation button:hover:not(:disabled) {
     background: #e67e22;
 }
 
+.dice-project-btn {
+    background: #16a085;
+}
+
 .dice-roll-btn:hover,
-.dice-clear-btn:hover {
+.dice-clear-btn:hover,
+.dice-project-btn:hover {
     transform: translateY(-1px);
     box-shadow: 0 6px 12px rgba(0, 0, 0, 0.15);
 }

--- a/dnd/js/dashboard-dice-roller.js
+++ b/dnd/js/dashboard-dice-roller.js
@@ -73,11 +73,6 @@ class DashboardDiceRoller {
         this.overlay.appendChild(this.modal);
         document.body.appendChild(this.overlay);
 
-        this.overlay.addEventListener('click', (event) => {
-            if (event.target === this.overlay) {
-                this.close();
-            }
-        });
     }
 
     attachEvents() {
@@ -159,6 +154,11 @@ class DashboardDiceRoller {
         clearBtn.textContent = 'Clear';
         clearBtn.addEventListener('click', () => this.clearQueue());
 
+        const projectBtn = document.createElement('button');
+        projectBtn.type = 'button';
+        projectBtn.className = 'dice-project-btn';
+        projectBtn.textContent = 'Project Roll';
+
         this.resultLabel = document.createElement('div');
         this.resultLabel.className = 'dice-result';
 
@@ -175,6 +175,7 @@ class DashboardDiceRoller {
 
         actions.appendChild(rollBtn);
         actions.appendChild(clearBtn);
+        actions.appendChild(projectBtn);
         actions.appendChild(this.resultLabel);
         return actions;
     }


### PR DESCRIPTION
## Summary
- remove the modal overlay dimming and click-to-close behavior so the dashboard remains interactive when the dice tray is open
- ensure the modal remains interactive by restoring pointer events and leaving the close button/Escape handling intact
- add a placeholder "Project Roll" button to the dice tray action bar with styling consistent with the existing controls

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d0a428930483278b87556b7a892947