### PR TITLE
Fix chat image URL sanitization

### DIFF
--- a/dnd/chat_handler.php
+++ b/dnd/chat_handler.php
@@ -2,38 +2,40 @@
 // Chat handler for dashboard real-time messaging
 // Handles chat_send, chat_fetch, and chat_upload actions
 
-if (session_status() === PHP_SESSION_NONE) {
-    session_start();
-}
+if (PHP_SAPI !== 'cli') {
+    if (session_status() === PHP_SESSION_NONE) {
+        session_start();
+    }
 
-$chatDataFile = __DIR__ . '/data/chat_messages.json';
-$chatUploadsDir = __DIR__ . '/chat_uploads';
-$maxMessages = 100;
+    $chatDataFile = __DIR__ . '/data/chat_messages.json';
+    $chatUploadsDir = __DIR__ . '/chat_uploads';
+    $maxMessages = 100;
 
-ensureChatStorage($chatDataFile, $chatUploadsDir);
+    ensureChatStorage($chatDataFile, $chatUploadsDir);
 
-$chatAction = substr($_POST['action'], 5); // remove "chat_" prefix
+    $chatAction = substr($_POST['action'], 5); // remove "chat_" prefix
 
-switch ($chatAction) {
-    case 'send':
-        handleChatSend($chatDataFile, $maxMessages);
-        break;
+    switch ($chatAction) {
+        case 'send':
+            handleChatSend($chatDataFile, $maxMessages);
+            break;
 
-    case 'fetch':
-        handleChatFetch($chatDataFile);
-        break;
+        case 'fetch':
+            handleChatFetch($chatDataFile);
+            break;
 
-    case 'upload':
-        handleChatUpload($chatUploadsDir);
-        break;
+        case 'upload':
+            handleChatUpload($chatUploadsDir);
+            break;
 
-    case 'update_roll':
-        handleRollStatusUpdate($chatDataFile);
-        break;
+        case 'update_roll':
+            handleRollStatusUpdate($chatDataFile);
+            break;
 
-    default:
-        echo json_encode(['success' => false, 'error' => 'Invalid chat action']);
-        exit;
+        default:
+            echo json_encode(['success' => false, 'error' => 'Invalid chat action']);
+            exit;
+    }
 }
 
 function ensureChatStorage($dataFile, $uploadsDir) {
@@ -358,7 +360,7 @@ function sanitizeImageUrl($url) {
         return $sanitized;
     }
 
-    if (preg_match('/^[A-Za-z0-9_\-./]+$/', $sanitized)) {
+    if (preg_match('#^[A-Za-z0-9_\-./]+$#', $sanitized)) {
         return $sanitized;
     }
 

--- a/dnd/tests/sanitize_image_url_test.php
+++ b/dnd/tests/sanitize_image_url_test.php
@@ -1,0 +1,23 @@
+<?php
+require_once __DIR__ . '/../chat_handler.php';
+
+$cases = [
+    'chat_uploads/example.png' => 'chat_uploads/example.png',
+    'https://example.com/image.png' => 'https://example.com/image.png',
+    'javascript:alert(1)' => ''
+];
+
+$allPassed = true;
+foreach ($cases as $input => $expected) {
+    $result = sanitizeImageUrl($input);
+    if ($result !== $expected) {
+        fwrite(STDERR, sprintf("sanitizeImageUrl failed for input '%s'. Expected '%s', got '%s'\n", $input, $expected, $result));
+        $allPassed = false;
+    }
+}
+
+if (!$allPassed) {
+    exit(1);
+}
+
+echo "All sanitizeImageUrl checks passed.\n";


### PR DESCRIPTION
## Summary
- prevent the chat handler from running when included via CLI and tighten the relative path validation to allow upload subdirectories
- add a regression test that covers relative, https, and disallowed javascript URLs for sanitizeImageUrl

## Testing
- php dnd/tests/sanitize_image_url_test.php

------
https://chatgpt.com/codex/tasks/task_e_68d0be68de908327a420932837111152