### PR TITLE
Expose current character globally

### DIFF
--- a/dnd/dashboard.php
+++ b/dnd/dashboard.php
@@ -1412,6 +1412,7 @@ $defaultInventoryTab = $is_gm ? 'frunk' : $user;
         const isGM = <?php echo $is_gm ? 'true' : 'false'; ?>;
         const currentUser = '<?php echo $user; ?>';
         let currentCharacter = '<?php echo $currentCharacter; ?>';
+        window.currentCharacter = currentCharacter;
         let characterData = {};
         let currentClubIndex = 0;
         let currentPastClassIndex = -1;

--- a/dnd/js/character-sheet.js
+++ b/dnd/js/character-sheet.js
@@ -330,6 +330,7 @@ async function switchCharacter(character) {
         
         // Update current character AFTER saving the previous one
         currentCharacter = character;
+        window.currentCharacter = currentCharacter;
         
         // Update tab appearance
         document.querySelectorAll('.character-tab').forEach(tab => {


### PR DESCRIPTION
## Summary
- expose the dashboard's current character identifier on `window` so shared UI components can read it
- keep the global value synchronized when the GM switches tabs in the character sheet

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d0c225ad7c8327a7d2a4baf9a5478c