### PR TITLE
Add advantage toggle and manual project roll entry

### DIFF
--- a/dnd/css/style.css
+++ b/dnd/css/style.css
@@ -513,6 +513,20 @@ body {
     margin-bottom: 10px;
 }
 
+.project-roll-prompt__manual-entry {
+    margin-top: 10px;
+    padding-top: 10px;
+    border-top: 1px dashed #c7d2fe;
+}
+
+.project-roll-prompt__label--manual {
+    color: #1d4ed8;
+}
+
+.project-roll-prompt__input--manual {
+    margin-bottom: 0;
+}
+
 .project-roll-prompt__actions {
     display: flex;
     justify-content: flex-end;
@@ -546,6 +560,24 @@ body {
 .project-roll-prompt__btn--cancel:hover {
     background: #d1d5db;
     transform: translateY(-1px);
+}
+
+.project-roll-prompt__btn--manual {
+    background: #fef3c7;
+    color: #92400e;
+    border: 1px solid #facc15;
+}
+
+.project-roll-prompt__btn--manual:hover {
+    background: #fde68a;
+    transform: translateY(-1px);
+}
+
+.project-roll-prompt__btn--manual-active {
+    background: #f59e0b;
+    color: #fff;
+    border-color: #d97706;
+    box-shadow: 0 6px 12px rgba(245, 158, 11, 0.25);
 }
 
 .project-roll-prompt--dragging {
@@ -1899,6 +1931,7 @@ body:not(.gm-mode) .club-navigation button:hover:not(:disabled) {
     gap: 0.75rem;
 }
 
+.dice-advantage-toggle,
 .dice-roll-btn,
 .dice-clear-btn,
 .dice-project-btn {
@@ -1909,6 +1942,28 @@ body:not(.gm-mode) .club-navigation button:hover:not(:disabled) {
     cursor: pointer;
     color: #fff;
     transition: transform 0.1s ease, box-shadow 0.1s ease;
+}
+
+.dice-advantage-toggle {
+    background: #ffffff;
+    color: #8e44ad;
+    border: 2px solid #8e44ad;
+    font-weight: 700;
+    padding: 0.6rem 1.25rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+
+.dice-advantage-toggle:hover,
+.dice-advantage-toggle:focus {
+    background: rgba(142, 68, 173, 0.08);
+    outline: none;
+}
+
+.dice-advantage-toggle--active {
+    background: #8e44ad;
+    color: #ffffff;
+    box-shadow: 0 6px 12px rgba(142, 68, 173, 0.3);
 }
 
 .dice-roll-btn {
@@ -1923,6 +1978,7 @@ body:not(.gm-mode) .club-navigation button:hover:not(:disabled) {
     background: #16a085;
 }
 
+.dice-advantage-toggle:hover,
 .dice-roll-btn:hover,
 .dice-clear-btn:hover,
 .dice-project-btn:hover {


### PR DESCRIPTION
## Summary
- add an advantage toggle to the dice roller, update result messaging, and annotate chat output
- support manual project roll results with a dedicated prompt toggle and validation
- refresh styling for the new controls in the dice modal and project prompt

## Testing
- npm test *(fails: npm not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d37a37848483279178c3a6340eaafd