### PR TITLE
Add ASL level targeting for skills

### DIFF
--- a/asl1/add_skill.php
+++ b/asl1/add_skill.php
@@ -21,6 +21,11 @@ $skill_name = trim($_POST['skill_name'] ?? '');
 $skill_description = trim($_POST['skill_description'] ?? '');
 $unit = trim($_POST['unit'] ?? '');
 $resources_text = trim($_POST['resources'] ?? '');
+$asl_level = intval($_POST['asl_level'] ?? 1);
+
+if (!in_array($asl_level, [1, 2, 3], true)) {
+    $asl_level = 1;
+}
 
 // Validate required fields
 if (empty($skill_name)) {
@@ -46,11 +51,11 @@ try {
     
     // Insert the new skill
     $stmt = $pdo->prepare("
-        INSERT INTO skills (skill_name, skill_description, unit, points_not_started, points_progressing, points_proficient, order_index) 
-        VALUES (?, ?, ?, 0, 1, 3, ?)
+        INSERT INTO skills (skill_name, skill_description, unit, points_not_started, points_progressing, points_proficient, order_index, asl_level)
+        VALUES (?, ?, ?, 0, 1, 3, ?, ?)
     ");
     $unit_value = empty($unit) ? null : $unit;
-    $stmt->execute([$skill_name, $skill_description, $unit_value, $next_order]);
+    $stmt->execute([$skill_name, $skill_description, $unit_value, $next_order, $asl_level]);
     
     $skill_id = $pdo->lastInsertId();
     

--- a/asl1/add_skill_level.sql
+++ b/asl1/add_skill_level.sql
@@ -1,7 +1,7 @@
 -- One-off migration to add ASL level support to skills
 ALTER TABLE skills
-    ADD COLUMN IF NOT EXISTS asl_level TINYINT NOT NULL DEFAULT 1 AFTER unit;
+    ADD COLUMN IF NOT EXISTS asl_level TINYINT NOT NULL DEFAULT 3 AFTER unit;
 
 UPDATE skills
-SET asl_level = 1
-WHERE asl_level IS NULL OR asl_level = 0;
+SET asl_level = 3
+WHERE asl_level IS NULL OR asl_level NOT IN (1, 2, 3);

--- a/asl1/dashboard.php
+++ b/asl1/dashboard.php
@@ -8,6 +8,11 @@ if (!isset($_SESSION['user_id'])) {
     exit;
 }
 
+$user_level = intval($_SESSION['user_level'] ?? 1);
+if (!in_array($user_level, [1, 2], true)) {
+    $user_level = 1;
+}
+
 // Redirect teachers to teacher dashboard
 if (isset($_SESSION['is_teacher']) && $_SESSION['is_teacher']) {
     header('Location: teacher_dashboard.php');
@@ -27,14 +32,14 @@ try {
 // Get user's progress
 try {
     // Get total skills count
-    $stmt = $pdo->prepare("SELECT COUNT(*) as total_skills FROM skills");
-    $stmt->execute();
+    $stmt = $pdo->prepare("SELECT COUNT(*) as total_skills FROM skills WHERE asl_level = ? OR asl_level = 3");
+    $stmt->execute([$user_level]);
     $total_skills = $stmt->fetchColumn();
-    
+
     // Get user's skill progress
     $stmt = $pdo->prepare("
-        SELECT 
-            SUM(CASE 
+        SELECT
+            SUM(CASE
                 WHEN us.status = 'not_started' THEN s.points_not_started
                 WHEN us.status = 'progressing' THEN s.points_progressing
                 WHEN us.status = 'proficient' THEN s.points_proficient
@@ -43,8 +48,9 @@ try {
             SUM(s.points_proficient) as total_possible_points
         FROM skills s
         LEFT JOIN user_skills us ON s.id = us.skill_id AND us.user_id = ?
+        WHERE s.asl_level = ? OR s.asl_level = 3
     ");
-    $stmt->execute([$_SESSION['user_id']]);
+    $stmt->execute([$_SESSION['user_id'], $user_level]);
     $progress = $stmt->fetch();
     
     $earned_points = $progress['earned_points'] ?? 0;

--- a/asl1/database_setup.sql
+++ b/asl1/database_setup.sql
@@ -24,6 +24,7 @@ CREATE TABLE IF NOT EXISTS skills (
     skill_name VARCHAR(255) NOT NULL,
     skill_description TEXT,
     unit VARCHAR(255) NULL,
+    asl_level TINYINT NOT NULL DEFAULT 3,
     points_not_started INT DEFAULT 0,
     points_progressing INT DEFAULT 1,
     points_proficient INT DEFAULT 3,
@@ -57,9 +58,9 @@ CREATE TABLE IF NOT EXISTS resources (
 );
 
 -- Insert sample skills
-INSERT INTO skills (skill_name, skill_description, order_index) VALUES
-('Skill Test 1', 'This is the first skill test for ASL students', 1),
-('Skill Test 2', 'This is the second skill test for ASL students', 2);
+INSERT INTO skills (skill_name, skill_description, order_index, asl_level) VALUES
+('Skill Test 1', 'This is the first skill test for ASL students', 1, 3),
+('Skill Test 2', 'This is the second skill test for ASL students', 2, 3);
 
 -- Insert sample resources
 INSERT INTO resources (skill_id, resource_name, resource_url, order_index) VALUES

--- a/asl1/edit_skill.php
+++ b/asl1/edit_skill.php
@@ -21,6 +21,11 @@ $skill_id = intval($_POST['skill_id'] ?? 0);
 $skill_name = trim($_POST['skill_name'] ?? '');
 $skill_description = trim($_POST['skill_description'] ?? '');
 $unit = trim($_POST['unit'] ?? '');
+$asl_level = intval($_POST['asl_level'] ?? 1);
+
+if (!in_array($asl_level, [1, 2, 3], true)) {
+    $asl_level = 1;
+}
 
 // Validate required fields
 if ($skill_id <= 0) {
@@ -58,12 +63,12 @@ try {
     
     // Update the skill
     $stmt = $pdo->prepare("
-        UPDATE skills 
-        SET skill_name = ?, skill_description = ?, unit = ?, updated_at = CURRENT_TIMESTAMP
+        UPDATE skills
+        SET skill_name = ?, skill_description = ?, unit = ?, asl_level = ?, updated_at = CURRENT_TIMESTAMP
         WHERE id = ?
     ");
     $unit_value = empty($unit) ? null : $unit;
-    $stmt->execute([$skill_name, $skill_description, $unit_value, $skill_id]);
+    $stmt->execute([$skill_name, $skill_description, $unit_value, $asl_level, $skill_id]);
     
     // Success response
     echo json_encode([

--- a/asl1/populate_sample_data.php
+++ b/asl1/populate_sample_data.php
@@ -29,8 +29,8 @@ try {
     ];
     
     $skill_insert = $pdo->prepare("
-        INSERT INTO skills (skill_name, skill_description, points_not_started, points_progressing, points_proficient, order_index) 
-        VALUES (?, ?, 0, 1, 3, ?)
+        INSERT INTO skills (skill_name, skill_description, points_not_started, points_progressing, points_proficient, order_index, asl_level)
+        VALUES (?, ?, 0, 1, 3, ?, 3)
     ");
     
     $resource_insert = $pdo->prepare("

--- a/asl1/student_details.php
+++ b/asl1/student_details.php
@@ -49,14 +49,14 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['action']) && $_POST['
 // Get student details
 try {
     $stmt = $pdo->prepare("
-        SELECT 
+        SELECT
             u.id,
             u.first_name,
             u.last_name,
             u.email,
             u.level,
             COALESCE(
-                SUM(CASE 
+                SUM(CASE
                     WHEN us.status = 'not_started' THEN s.points_not_started
                     WHEN us.status = 'progressing' THEN s.points_progressing
                     WHEN us.status = 'proficient' THEN s.points_proficient
@@ -64,11 +64,16 @@ try {
                 END), 0
             ) as earned_points,
             COALESCE(
-                (SELECT SUM(points_proficient) FROM skills), 0
+                (
+                    SELECT SUM(points_proficient)
+                    FROM skills
+                    WHERE asl_level = COALESCE(u.level, 1) OR asl_level = 3
+                ), 0
             ) as total_possible_points
         FROM users u
         LEFT JOIN user_skills us ON u.id = us.user_id
         LEFT JOIN skills s ON us.skill_id = s.id
+            AND (s.asl_level = COALESCE(u.level, 1) OR s.asl_level = 3)
         WHERE u.id = ? AND u.is_teacher = FALSE
         GROUP BY u.id, u.first_name, u.last_name, u.email, u.level
     ");
@@ -81,8 +86,13 @@ try {
     }
     
     // Get student's skills progress
+    $student_level = intval($student['level'] ?? 1);
+    if (!in_array($student_level, [1, 2], true)) {
+        $student_level = 1;
+    }
+
     $stmt = $pdo->prepare("
-        SELECT 
+        SELECT
             s.skill_name,
             s.skill_description,
             s.unit,
@@ -92,9 +102,10 @@ try {
             s.points_proficient
         FROM skills s
         LEFT JOIN user_skills us ON s.id = us.skill_id AND us.user_id = ?
+        WHERE s.asl_level = ? OR s.asl_level = 3
         ORDER BY s.order_index
     ");
-    $stmt->execute([$student_id]);
+    $stmt->execute([$student_id, $student_level]);
     $skills = $stmt->fetchAll();
     
     // Note: In a production environment, you should NEVER store or display passwords in plain text

--- a/asl1/update_skill_status.php
+++ b/asl1/update_skill_status.php
@@ -25,6 +25,11 @@ if (!isset($_POST['skill_id']) || !isset($_POST['status'])) {
 
 $skill_id = intval($_POST['skill_id']);
 $status = $_POST['status'];
+$user_level = intval($_SESSION['user_level'] ?? 1);
+
+if (!in_array($user_level, [1, 2], true)) {
+    $user_level = 1;
+}
 
 // Validate status
 if (!in_array($status, ['not_started', 'progressing', 'proficient'])) {
@@ -35,8 +40,8 @@ if (!in_array($status, ['not_started', 'progressing', 'proficient'])) {
 
 try {
     // Check if the skill exists
-    $stmt = $pdo->prepare("SELECT id FROM skills WHERE id = ?");
-    $stmt->execute([$skill_id]);
+    $stmt = $pdo->prepare("SELECT id FROM skills WHERE id = ? AND (asl_level = ? OR asl_level = 3)");
+    $stmt->execute([$skill_id, $user_level]);
     if (!$stmt->fetch()) {
         http_response_code(404);
         echo json_encode(['success' => false, 'message' => 'Skill not found']);
@@ -63,8 +68,9 @@ try {
             SUM(s.points_proficient) as total_possible_points
         FROM skills s
         LEFT JOIN user_skills us ON s.id = us.skill_id AND us.user_id = ?
+        WHERE s.asl_level = ? OR s.asl_level = 3
     ");
-    $stmt->execute([$_SESSION['user_id']]);
+    $stmt->execute([$_SESSION['user_id'], $user_level]);
     $progress = $stmt->fetch();
     
     $earned_points = $progress['earned_points'] ?? 0;

--- a/asl2/add_skill.php
+++ b/asl2/add_skill.php
@@ -21,6 +21,11 @@ $skill_name = trim($_POST['skill_name'] ?? '');
 $skill_description = trim($_POST['skill_description'] ?? '');
 $unit = trim($_POST['unit'] ?? '');
 $resources_text = trim($_POST['resources'] ?? '');
+$asl_level = intval($_POST['asl_level'] ?? 2);
+
+if (!in_array($asl_level, [1, 2, 3], true)) {
+    $asl_level = 2;
+}
 
 // Validate required fields
 if (empty($skill_name)) {
@@ -46,11 +51,11 @@ try {
     
     // Insert the new skill
     $stmt = $pdo->prepare("
-        INSERT INTO skills (skill_name, skill_description, unit, points_not_started, points_progressing, points_proficient, order_index) 
-        VALUES (?, ?, ?, 0, 1, 3, ?)
+        INSERT INTO skills (skill_name, skill_description, unit, points_not_started, points_progressing, points_proficient, order_index, asl_level)
+        VALUES (?, ?, ?, 0, 1, 3, ?, ?)
     ");
     $unit_value = empty($unit) ? null : $unit;
-    $stmt->execute([$skill_name, $skill_description, $unit_value, $next_order]);
+    $stmt->execute([$skill_name, $skill_description, $unit_value, $next_order, $asl_level]);
     
     $skill_id = $pdo->lastInsertId();
     

--- a/asl2/add_skill_level.sql
+++ b/asl2/add_skill_level.sql
@@ -1,7 +1,7 @@
 -- One-off migration to add ASL level support to skills
 ALTER TABLE skills
-    ADD COLUMN IF NOT EXISTS asl_level TINYINT NOT NULL DEFAULT 1 AFTER unit;
+    ADD COLUMN IF NOT EXISTS asl_level TINYINT NOT NULL DEFAULT 3 AFTER unit;
 
 UPDATE skills
-SET asl_level = 1
-WHERE asl_level IS NULL OR asl_level = 0;
+SET asl_level = 3
+WHERE asl_level IS NULL OR asl_level NOT IN (1, 2, 3);

--- a/asl2/database_setup.sql
+++ b/asl2/database_setup.sql
@@ -24,6 +24,7 @@ CREATE TABLE IF NOT EXISTS skills (
     skill_name VARCHAR(255) NOT NULL,
     skill_description TEXT,
     unit VARCHAR(255) NULL,
+    asl_level TINYINT NOT NULL DEFAULT 3,
     points_not_started INT DEFAULT 0,
     points_progressing INT DEFAULT 1,
     points_proficient INT DEFAULT 3,
@@ -57,9 +58,9 @@ CREATE TABLE IF NOT EXISTS resources (
 );
 
 -- Insert sample skills
-INSERT INTO skills (skill_name, skill_description, order_index) VALUES
-('Skill Test 1', 'This is the first skill test for ASL students', 1),
-('Skill Test 2', 'This is the second skill test for ASL students', 2);
+INSERT INTO skills (skill_name, skill_description, order_index, asl_level) VALUES
+('Skill Test 1', 'This is the first skill test for ASL students', 1, 3),
+('Skill Test 2', 'This is the second skill test for ASL students', 2, 3);
 
 -- Insert sample resources
 INSERT INTO resources (skill_id, resource_name, resource_url, order_index) VALUES

--- a/asl2/edit_skill.php
+++ b/asl2/edit_skill.php
@@ -21,6 +21,11 @@ $skill_id = intval($_POST['skill_id'] ?? 0);
 $skill_name = trim($_POST['skill_name'] ?? '');
 $skill_description = trim($_POST['skill_description'] ?? '');
 $unit = trim($_POST['unit'] ?? '');
+$asl_level = intval($_POST['asl_level'] ?? 2);
+
+if (!in_array($asl_level, [1, 2, 3], true)) {
+    $asl_level = 2;
+}
 
 // Validate required fields
 if ($skill_id <= 0) {
@@ -58,12 +63,12 @@ try {
     
     // Update the skill
     $stmt = $pdo->prepare("
-        UPDATE skills 
-        SET skill_name = ?, skill_description = ?, unit = ?, updated_at = CURRENT_TIMESTAMP
+        UPDATE skills
+        SET skill_name = ?, skill_description = ?, unit = ?, asl_level = ?, updated_at = CURRENT_TIMESTAMP
         WHERE id = ?
     ");
     $unit_value = empty($unit) ? null : $unit;
-    $stmt->execute([$skill_name, $skill_description, $unit_value, $skill_id]);
+    $stmt->execute([$skill_name, $skill_description, $unit_value, $asl_level, $skill_id]);
     
     // Success response
     echo json_encode([

--- a/asl2/populate_sample_data.php
+++ b/asl2/populate_sample_data.php
@@ -29,8 +29,8 @@ try {
     ];
     
     $skill_insert = $pdo->prepare("
-        INSERT INTO skills (skill_name, skill_description, points_not_started, points_progressing, points_proficient, order_index) 
-        VALUES (?, ?, 0, 1, 3, ?)
+        INSERT INTO skills (skill_name, skill_description, points_not_started, points_progressing, points_proficient, order_index, asl_level)
+        VALUES (?, ?, 0, 1, 3, ?, 3)
     ");
     
     $resource_insert = $pdo->prepare("

--- a/asl2/skills.php
+++ b/asl2/skills.php
@@ -14,10 +14,16 @@ if (isset($_SESSION['is_teacher']) && $_SESSION['is_teacher']) {
     exit;
 }
 
+// Determine the user's ASL level (default to 2 for ASL 2 portal)
+$user_level = intval($_SESSION['user_level'] ?? 2);
+if (!in_array($user_level, [1, 2], true)) {
+    $user_level = 2;
+}
+
 // Get all skills with user's progress
 try {
     $stmt = $pdo->prepare("
-        SELECT 
+        SELECT
             s.id,
             s.skill_name,
             s.skill_description,
@@ -25,17 +31,19 @@ try {
             s.points_not_started,
             s.points_progressing,
             s.points_proficient,
+            s.asl_level,
             COALESCE(us.status, 'not_started') as user_status
         FROM skills s
         LEFT JOIN user_skills us ON s.id = us.skill_id AND us.user_id = ?
+        WHERE s.asl_level = ? OR s.asl_level = 3
         ORDER BY s.order_index
     ");
-    $stmt->execute([$_SESSION['user_id']]);
+    $stmt->execute([$_SESSION['user_id'], $user_level]);
     $skills = $stmt->fetchAll();
-    
+
     // Get unique units for filter dropdown
-    $stmt = $pdo->prepare("SELECT DISTINCT unit FROM skills WHERE unit IS NOT NULL ORDER BY unit");
-    $stmt->execute();
+    $stmt = $pdo->prepare("SELECT DISTINCT unit FROM skills WHERE unit IS NOT NULL AND (asl_level = ? OR asl_level = 3) ORDER BY unit");
+    $stmt->execute([$user_level]);
     $units = $stmt->fetchAll(PDO::FETCH_COLUMN);
     
     // Get resources for each skill
@@ -153,10 +161,11 @@ try {
                     </div>
                     
                     <?php foreach ($skills as $skill): ?>
-                        <div class="skill-item" 
-                             id="skill-<?php echo $skill['id']; ?>" 
+                        <div class="skill-item"
+                             id="skill-<?php echo $skill['id']; ?>"
                              data-status="<?php echo $skill['user_status']; ?>"
-                             data-unit="<?php echo htmlspecialchars($skill['unit'] ?? 'no-unit'); ?>">
+                             data-unit="<?php echo htmlspecialchars($skill['unit'] ?? 'no-unit'); ?>"
+                             data-asl-level="<?php echo (int)($skill['asl_level'] ?? 3); ?>">
                             <div class="skill-header">
                                 <?php echo htmlspecialchars($skill['skill_name']); ?>
                                 <?php if (!empty($skill['unit'])): ?>

--- a/asl2/student_details.php
+++ b/asl2/student_details.php
@@ -49,14 +49,14 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['action']) && $_POST['
 // Get student details
 try {
     $stmt = $pdo->prepare("
-        SELECT 
+        SELECT
             u.id,
             u.first_name,
             u.last_name,
             u.email,
             u.level,
             COALESCE(
-                SUM(CASE 
+                SUM(CASE
                     WHEN us.status = 'not_started' THEN s.points_not_started
                     WHEN us.status = 'progressing' THEN s.points_progressing
                     WHEN us.status = 'proficient' THEN s.points_proficient
@@ -64,11 +64,16 @@ try {
                 END), 0
             ) as earned_points,
             COALESCE(
-                (SELECT SUM(points_proficient) FROM skills), 0
+                (
+                    SELECT SUM(points_proficient)
+                    FROM skills
+                    WHERE asl_level = COALESCE(u.level, 2) OR asl_level = 3
+                ), 0
             ) as total_possible_points
         FROM users u
         LEFT JOIN user_skills us ON u.id = us.user_id
         LEFT JOIN skills s ON us.skill_id = s.id
+            AND (s.asl_level = COALESCE(u.level, 2) OR s.asl_level = 3)
         WHERE u.id = ? AND u.is_teacher = FALSE
         GROUP BY u.id, u.first_name, u.last_name, u.email, u.level
     ");
@@ -81,8 +86,13 @@ try {
     }
     
     // Get student's skills progress
+    $student_level = intval($student['level'] ?? 2);
+    if (!in_array($student_level, [1, 2], true)) {
+        $student_level = 2;
+    }
+
     $stmt = $pdo->prepare("
-        SELECT 
+        SELECT
             s.skill_name,
             s.skill_description,
             s.unit,
@@ -92,9 +102,10 @@ try {
             s.points_proficient
         FROM skills s
         LEFT JOIN user_skills us ON s.id = us.skill_id AND us.user_id = ?
+        WHERE s.asl_level = ? OR s.asl_level = 3
         ORDER BY s.order_index
     ");
-    $stmt->execute([$student_id]);
+    $stmt->execute([$student_id, $student_level]);
     $skills = $stmt->fetchAll();
     
     // Note: In a production environment, you should NEVER store or display passwords in plain text

--- a/asl2/teacher_dashboard.php
+++ b/asl2/teacher_dashboard.php
@@ -27,11 +27,16 @@ try {
                 END), 0
             ) as earned_points,
             COALESCE(
-                (SELECT SUM(points_proficient) FROM skills), 0
+                (
+                    SELECT SUM(points_proficient)
+                    FROM skills
+                    WHERE asl_level = COALESCE(u.level, 2) OR asl_level = 3
+                ), 0
             ) as total_possible_points
         FROM users u
         LEFT JOIN user_skills us ON u.id = us.user_id
         LEFT JOIN skills s ON us.skill_id = s.id
+            AND (s.asl_level = COALESCE(u.level, 2) OR s.asl_level = 3)
         WHERE u.is_teacher = FALSE
         GROUP BY u.id, u.first_name, u.last_name, u.email, u.class_period, u.level
         ORDER BY u.first_name, u.last_name
@@ -46,15 +51,18 @@ try {
     
     // Get skills summary
     $stmt = $pdo->prepare("
-        SELECT 
+        SELECT
+            s.id,
             s.skill_name,
+            s.asl_level,
             COUNT(CASE WHEN us.status = 'not_started' OR us.status IS NULL THEN 1 END) as not_started,
             COUNT(CASE WHEN us.status = 'progressing' THEN 1 END) as progressing,
             COUNT(CASE WHEN us.status = 'proficient' THEN 1 END) as proficient
         FROM skills s
         LEFT JOIN user_skills us ON s.id = us.skill_id
         LEFT JOIN users u ON us.user_id = u.id AND u.is_teacher = FALSE
-        GROUP BY s.id, s.skill_name
+            AND (s.asl_level = COALESCE(u.level, 2) OR s.asl_level = 3)
+        GROUP BY s.id, s.skill_name, s.asl_level
         ORDER BY s.order_index
     ");
     $stmt->execute();
@@ -210,7 +218,7 @@ try {
                     <div class="skills-summary">
                         <?php 
                         // Get all skills with their IDs for the action buttons
-                        $stmt = $pdo->prepare("SELECT id, skill_name, skill_description, unit, order_index FROM skills ORDER BY order_index");
+                        $stmt = $pdo->prepare("SELECT id, skill_name, skill_description, unit, order_index, asl_level FROM skills ORDER BY order_index");
                         $stmt->execute();
                         $all_skills = $stmt->fetchAll();
                         
@@ -218,12 +226,12 @@ try {
                         foreach ($all_skills as $skill): 
                             // Find the corresponding skill summary
                             $skill_summary = null;
-                            foreach ($skills_summary as $summary) {
-                                if ($summary['skill_name'] === $skill['skill_name']) {
-                                    $skill_summary = $summary;
-                                    break;
-                                }
-                            }
+        foreach ($skills_summary as $summary) {
+            if ((int)$summary['id'] === (int)$skill['id']) {
+                $skill_summary = $summary;
+                break;
+            }
+        }
                             
                             if (!$skill_summary) {
                                 $skill_summary = [
@@ -246,16 +254,21 @@ try {
                                 <div class="skill-summary-header">
                                     <div>
                                         <h3><?php echo htmlspecialchars($skill_summary['skill_name']); ?></h3>
-                                        <?php if (!empty($skill['unit'])): ?>
-                                            <span class="skill-unit">Unit: <?php echo htmlspecialchars($skill['unit']); ?></span>
-                                        <?php else: ?>
-                                            <span class="skill-unit no-unit">No Unit</span>
-                                        <?php endif; ?>
+                                        <div class="skill-meta-line">
+                                            <?php if (!empty($skill['unit'])): ?>
+                                                <span class="skill-unit">Unit: <?php echo htmlspecialchars($skill['unit']); ?></span>
+                                            <?php else: ?>
+                                                <span class="skill-unit no-unit">No Unit</span>
+                                            <?php endif; ?>
+                                            <span class="skill-level-badge">
+                                                <?php echo (($skill['asl_level'] ?? 3) == 3) ? 'ASL 1 & 2' : 'ASL ' . (int)$skill['asl_level']; ?>
+                                            </span>
+                                        </div>
                                     </div>
                                     <div class="skill-actions">
-                                        <button class="action-btn edit-btn" onclick="editSkill(<?php echo $skill['id']; ?>, '<?php echo htmlspecialchars($skill['skill_name']); ?>', '<?php echo htmlspecialchars($skill['skill_description']); ?>', '<?php echo htmlspecialchars($skill['unit'] ?? ''); ?>')">Edit</button>
-                                        <button class="action-btn resources-btn" onclick="manageResources(<?php echo $skill['id']; ?>, '<?php echo htmlspecialchars($skill['skill_name']); ?>')">Resources</button>
-                                        <button class="action-btn delete-btn" onclick="deleteSkill(<?php echo $skill['id']; ?>, '<?php echo htmlspecialchars($skill['skill_name']); ?>')">Delete</button>
+                                        <button class="action-btn edit-btn" onclick="editSkill(<?php echo $skill['id']; ?>, '<?php echo htmlspecialchars($skill['skill_name'], ENT_QUOTES); ?>', '<?php echo htmlspecialchars($skill['skill_description'], ENT_QUOTES); ?>', '<?php echo htmlspecialchars($skill['unit'] ?? '', ENT_QUOTES); ?>', <?php echo (int)($skill['asl_level'] ?? 3); ?>)">Edit</button>
+                                        <button class="action-btn resources-btn" onclick="manageResources(<?php echo $skill['id']; ?>, '<?php echo htmlspecialchars($skill['skill_name'], ENT_QUOTES); ?>')">Resources</button>
+                                        <button class="action-btn delete-btn" onclick="deleteSkill(<?php echo $skill['id']; ?>, '<?php echo htmlspecialchars($skill['skill_name'], ENT_QUOTES); ?>')">Delete</button>
                                     </div>
                                 </div>
                                 <div class="skill-stats">
@@ -307,6 +320,14 @@ try {
                             <div class="form-group">
                                 <label>Unit (optional - leave blank for year-round skills)</label>
                                 <input type="text" name="unit" class="form-input" placeholder="e.g., Unit 1, Semester 1, etc.">
+                            </div>
+                            <div class="form-group">
+                                <label>ASL Level</label>
+                                <select name="asl_level" class="form-input">
+                                    <option value="1">ASL 1 Only</option>
+                                    <option value="2" selected>ASL 2 Only</option>
+                                    <option value="3">Both ASL 1 &amp; 2</option>
+                                </select>
                             </div>
                             <div class="form-group">
                                 <label>Resources (one per line)</label>
@@ -1007,26 +1028,37 @@ try {
         }
         
         // Edit skill function
-        function editSkill(skillId, skillName, skillDescription, skillUnit) {
+        function editSkill(skillId, skillName, skillDescription, skillUnit, skillLevel) {
+            const currentLevel = [1, 2, 3].includes(Number(skillLevel)) ? Number(skillLevel) : 2;
             const newName = prompt('Edit skill name:', skillName);
             if (newName === null) return; // User cancelled
-            
+
             if (newName.trim() === '') {
                 alert('Skill name cannot be empty');
                 return;
             }
-            
+
             const newDescription = prompt('Edit skill description:', skillDescription);
             if (newDescription === null) return; // User cancelled
-            
+
             const newUnit = prompt('Edit unit (leave blank for year-round skills):', skillUnit || '');
             if (newUnit === null) return; // User cancelled
-            
+
+            const levelPrompt = prompt('Set ASL level for this skill (1 = ASL 1, 2 = ASL 2, 3 = Both):', currentLevel);
+            if (levelPrompt === null) return; // User cancelled
+
+            const parsedLevel = parseInt(levelPrompt, 10);
+            if (![1, 2, 3].includes(parsedLevel)) {
+                alert('ASL level must be 1, 2, or 3.');
+                return;
+            }
+
             const formData = new FormData();
             formData.append('skill_id', skillId);
             formData.append('skill_name', newName.trim());
             formData.append('skill_description', newDescription.trim());
             formData.append('unit', newUnit.trim());
+            formData.append('asl_level', parsedLevel);
             
             fetch('edit_skill.php', {
                 method: 'POST',
@@ -1659,6 +1691,23 @@ try {
             font-size: 14px;
         }
         
+        .skill-meta-line {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            margin-top: 4px;
+            flex-wrap: wrap;
+        }
+
+        .skill-level-badge {
+            display: inline-block;
+            padding: 2px 8px;
+            background: #805ad5;
+            color: #f7fafc;
+            border-radius: 4px;
+            font-size: 0.85rem;
+        }
+
         .skill-unit {
             display: inline-block;
             padding: 2px 8px;


### PR DESCRIPTION
## Summary
- add an `asl_level` flag to skills schema/migrations so skills can target ASL 1, ASL 2 or both
- extend the teacher dashboard to capture/edit skill levels and show the assigned level when managing skills
- scope student skill listings, dashboards and progress calculations to the viewer's ASL level so only relevant skills appear

## Testing
- php -l asl1/add_skill.php
- php -l asl1/edit_skill.php
- php -l asl1/skills.php
- php -l asl1/dashboard.php
- php -l asl1/student_details.php
- php -l asl1/teacher_dashboard.php
- php -l asl1/update_skill_status.php
- php -l asl1/populate_sample_data.php
- php -l asl2/add_skill.php
- php -l asl2/edit_skill.php
- php -l asl2/skills.php
- php -l asl2/dashboard.php
- php -l asl2/student_details.php
- php -l asl2/teacher_dashboard.php
- php -l asl2/update_skill_status.php
- php -l asl2/populate_sample_data.php

------
https://chatgpt.com/codex/tasks/task_e_68d4768e4070832788768540b4a518da