### PR TITLE
Fix ASL word list edit modal not opening

### DIFF
--- a/asl1/teacher_dashboard.php
+++ b/asl1/teacher_dashboard.php
@@ -831,17 +831,27 @@ try {
         }
 
         function showEditWordlistModal(list) {
+            const modal = document.getElementById('edit-wordlist-modal');
             document.getElementById('edit-wordlist-id').value = list.id;
             document.getElementById('edit-wordlist-name').value = list.wordlist_name;
             document.getElementById('edit-words').value = (list.words || []).join('\n');
             document.getElementById('edit-speed').value = list.speed;
             document.getElementById('edit-word-count').value = list.word_count;
             document.getElementById('edit-asl-level').value = list.asl_level || 1;
-            document.getElementById('edit-wordlist-modal').style.display = 'block';
+
+            // Display modal with animation similar to resource modal
+            modal.style.display = 'flex';
+            requestAnimationFrame(() => modal.classList.add('active'));
+            document.body.style.overflow = 'hidden';
         }
 
         function closeEditWordlistModal() {
-            document.getElementById('edit-wordlist-modal').style.display = 'none';
+            const modal = document.getElementById('edit-wordlist-modal');
+            modal.classList.remove('active');
+            document.body.style.overflow = '';
+            setTimeout(() => {
+                modal.style.display = 'none';
+            }, 300);
         }
 
         function submitEditWordlist() {

--- a/asl2/teacher_dashboard.php
+++ b/asl2/teacher_dashboard.php
@@ -831,17 +831,27 @@ try {
         }
 
         function showEditWordlistModal(list) {
+            const modal = document.getElementById('edit-wordlist-modal');
             document.getElementById('edit-wordlist-id').value = list.id;
             document.getElementById('edit-wordlist-name').value = list.wordlist_name;
             document.getElementById('edit-words').value = (list.words || []).join('\n');
             document.getElementById('edit-speed').value = list.speed;
             document.getElementById('edit-word-count').value = list.word_count;
             document.getElementById('edit-asl-level').value = list.asl_level || 2;
-            document.getElementById('edit-wordlist-modal').style.display = 'block';
+
+            // Display modal with animation similar to resource modal
+            modal.style.display = 'flex';
+            requestAnimationFrame(() => modal.classList.add('active'));
+            document.body.style.overflow = 'hidden';
         }
 
         function closeEditWordlistModal() {
-            document.getElementById('edit-wordlist-modal').style.display = 'none';
+            const modal = document.getElementById('edit-wordlist-modal');
+            modal.classList.remove('active');
+            document.body.style.overflow = '';
+            setTimeout(() => {
+                modal.style.display = 'none';
+            }, 300);
         }
 
         function submitEditWordlist() {


### PR DESCRIPTION
## Summary
- ensure the ASL word list edit modal uses the same active-class animation as other modals
- restore body scroll locking while the edit modal is open and hide it cleanly after transitions

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d74c1a3924832798c21ab10eefc0fe