### PR TITLE
Add student goals tracking for ASL dashboards

### DIFF
--- a/asl1/config.php
+++ b/asl1/config.php
@@ -53,5 +53,37 @@ if (!function_exists('aslhubEnsureSkillLevels')) {
     }
 }
 
+if (!function_exists('aslhubEnsureGoalsTable')) {
+    function aslhubEnsureGoalsTable(PDO $pdo): void
+    {
+        static $checkedGoals = false;
+
+        if ($checkedGoals) {
+            return;
+        }
+
+        $checkedGoals = true;
+
+        try {
+            $pdo->exec("CREATE TABLE IF NOT EXISTS user_goals (
+                id INT AUTO_INCREMENT PRIMARY KEY,
+                user_id INT NOT NULL,
+                framework VARCHAR(100) NOT NULL,
+                goal_type ENUM('daily','weekly') NOT NULL DEFAULT 'daily',
+                goal_focus TEXT NOT NULL,
+                success_criteria TEXT NOT NULL,
+                status ENUM('not_started','progressing','proficient') NOT NULL DEFAULT 'not_started',
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+                INDEX idx_user_goals_user (user_id),
+                CONSTRAINT fk_user_goals_user FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci");
+        } catch (PDOException $e) {
+            error_log('ASL Hub schema check (user_goals) failed: ' . $e->getMessage());
+        }
+    }
+}
+
 aslhubEnsureSkillLevels($pdo, 1);
+aslhubEnsureGoalsTable($pdo);
 ?>

--- a/asl1/css/asl-style.css
+++ b/asl1/css/asl-style.css
@@ -637,25 +637,291 @@ header h1 {
     text-align: center;
 }
 
+/* ===== GOALS PAGE STYLES ===== */
+.goals-page .dashboard-container {
+    align-items: flex-start;
+}
+
+.goals-layout {
+    display: grid;
+    grid-template-columns: minmax(280px, 360px) 1fr;
+    gap: 24px;
+    width: 100%;
+}
+
+.goal-create-card,
+.goal-cards-card {
+    background: rgba(255, 255, 255, 0.95);
+    border-radius: 15px;
+    padding: 24px;
+    box-shadow: 0 8px 32px rgba(76, 81, 191, 0.12);
+    border: 1px solid rgba(226, 232, 240, 0.8);
+}
+
+.goal-cards-card {
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+}
+
+.goal-cards-header h2 {
+    font-size: 1.6rem;
+    color: #2d3748;
+}
+
+.goal-cards-header p {
+    color: #4a5568;
+    margin-top: 6px;
+}
+
+.goal-instructions {
+    color: #4a5568;
+    margin-bottom: 20px;
+}
+
+.goal-form {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.goal-form-row {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    margin-bottom: 10px;
+}
+
+.goal-select,
+.goal-textarea {
+    width: 100%;
+    padding: 12px 14px;
+    border: 2px solid #e2e8f0;
+    border-radius: 10px;
+    font-size: 1rem;
+    transition: all 0.2s ease;
+    background: #fff;
+    color: #2d3748;
+}
+
+.goal-select:focus,
+.goal-textarea:focus {
+    outline: none;
+    border-color: #4299e1;
+    box-shadow: 0 0 0 3px rgba(66, 153, 225, 0.15);
+}
+
+.goal-type-toggle {
+    display: inline-flex;
+    background: rgba(237, 242, 247, 0.7);
+    border-radius: 12px;
+    padding: 6px;
+    gap: 10px;
+}
+
+.goal-type-option {
+    position: relative;
+    cursor: pointer;
+}
+
+.goal-type-option input {
+    position: absolute;
+    opacity: 0;
+}
+
+.goal-type-option span {
+    display: inline-block;
+    padding: 8px 16px;
+    border-radius: 10px;
+    font-weight: 600;
+    color: #4a5568;
+    transition: all 0.2s ease;
+}
+
+.goal-type-option input:checked + span {
+    background: linear-gradient(135deg, #4299e1 0%, #3182ce 100%);
+    color: #fff;
+    box-shadow: 0 6px 16px rgba(66, 153, 225, 0.35);
+}
+
+.goal-submit-button {
+    margin-top: 10px;
+}
+
+.goal-message {
+    min-height: 22px;
+    margin-top: 12px;
+    font-weight: 600;
+}
+
+.goal-message-success {
+    color: #2f855a;
+}
+
+.goal-message-error {
+    color: #c53030;
+}
+
+.goal-card-list {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+.goal-card {
+    background: rgba(247, 250, 252, 0.95);
+    border-radius: 15px;
+    border: 1px solid rgba(226, 232, 240, 0.9);
+    padding: 18px 20px;
+    box-shadow: 0 6px 20px rgba(74, 85, 104, 0.08);
+}
+
+.goal-card-header {
+    display: flex;
+    justify-content: space-between;
+    gap: 12px;
+    align-items: center;
+    margin-bottom: 16px;
+}
+
+.goal-card-header-text h3 {
+    font-size: 1.3rem;
+    color: #2d3748;
+    margin-bottom: 4px;
+}
+
+.goal-type-badge {
+    display: inline-block;
+    padding: 4px 10px;
+    border-radius: 999px;
+    background: rgba(66, 153, 225, 0.12);
+    color: #2b6cb0;
+    font-weight: 600;
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    margin-bottom: 4px;
+}
+
+.goal-delete-button {
+    background: rgba(229, 62, 62, 0.12);
+    color: #c53030;
+    border: 1px solid rgba(229, 62, 62, 0.35);
+    border-radius: 10px;
+    padding: 8px 16px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.goal-delete-button:hover {
+    background: #e53e3e;
+    color: #fff;
+    box-shadow: 0 6px 20px rgba(229, 62, 62, 0.35);
+}
+
+.goal-card-body {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    color: #4a5568;
+}
+
+.goal-status-buttons {
+    display: flex;
+    gap: 12px;
+    flex-wrap: wrap;
+}
+
+.goal-status-button {
+    flex: 1;
+    min-width: 140px;
+    padding: 10px 14px;
+    border-radius: 10px;
+    font-weight: 600;
+    border: 1px solid transparent;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    text-align: center;
+}
+
+.goal-status-button.not-started {
+    background: rgba(229, 62, 62, 0.12);
+    color: #c53030;
+    border-color: rgba(229, 62, 62, 0.3);
+}
+
+.goal-status-button.not-started.active {
+    background: #e53e3e;
+    color: #fff;
+    box-shadow: 0 6px 20px rgba(229, 62, 62, 0.35);
+}
+
+.goal-status-button.progressing {
+    background: rgba(214, 158, 46, 0.15);
+    color: #b7791f;
+    border-color: rgba(214, 158, 46, 0.35);
+}
+
+.goal-status-button.progressing.active {
+    background: #d69e2e;
+    color: #fff;
+    box-shadow: 0 6px 20px rgba(214, 158, 46, 0.35);
+}
+
+.goal-status-button.proficient {
+    background: rgba(56, 161, 105, 0.15);
+    color: #2f855a;
+    border-color: rgba(56, 161, 105, 0.35);
+}
+
+.goal-status-button.proficient.active {
+    background: #38a169;
+    color: #fff;
+    box-shadow: 0 6px 20px rgba(56, 161, 105, 0.35);
+}
+
+.goal-status-button:hover {
+    transform: translateY(-1px);
+}
+
+.goal-empty-state {
+    background: rgba(237, 242, 247, 0.65);
+    border: 1px dashed rgba(160, 174, 192, 0.7);
+    border-radius: 15px;
+    padding: 30px;
+    text-align: center;
+    color: #4a5568;
+}
+
+.goal-empty-state h3 {
+    font-size: 1.3rem;
+    margin-bottom: 8px;
+}
+
 /* ===== RESPONSIVE DESIGN ===== */
 @media (max-width: 1200px) {
     .dashboard-container {
         grid-template-columns: 1fr;
         grid-template-rows: auto auto auto 1fr;
-        grid-template-areas: 
+        grid-template-areas:
             "user-info"
             "progress-bar"
             "sidebar"
             "main-content";
     }
-    
+
     .sidebar {
         flex-direction: row;
         overflow-x: auto;
     }
-    
+
     .sidebar-button {
         min-width: 120px;
+    }
+
+    .goals-layout {
+        grid-template-columns: 1fr;
     }
 }
 
@@ -721,6 +987,14 @@ header h1 {
     
     .search-results {
         text-align: center;
+    }
+
+    .goal-status-buttons {
+        flex-direction: column;
+    }
+
+    .goal-status-button {
+        width: 100%;
     }
 }
 

--- a/asl1/dashboard.php
+++ b/asl1/dashboard.php
@@ -109,7 +109,7 @@ try {
             <div class="sidebar">
                 <button class="sidebar-button" onclick="showContent('skills')">Skills</button>
                 <button class="sidebar-button" onclick="window.open('scrollergame/index.html', '_blank')">Scroller Game</button>
-                <button class="sidebar-button" onclick="showContent('coming-soon')">Coming Soon</button>
+                <button class="sidebar-button" onclick="openGoals()">Goals</button>
                 <button class="sidebar-button" onclick="showContent('coming-soon')">Coming Soon</button>
                 <button class="sidebar-button" onclick="showContent('coming-soon')">Coming Soon</button>
                 <button class="sidebar-button" onclick="showContent('coming-soon')">Coming Soon</button>
@@ -122,6 +122,7 @@ try {
                     <ul>
                         <li><strong>Skills:</strong> Track your progress through various ASL skills and access learning resources</li>
                         <li><strong>Scroller Game:</strong> Practice ASL vocabulary with an interactive word scrolling game</li>
+                        <li><strong>Goals:</strong> Create personal ASL practice goals and monitor how you're doing.</li>
                         <li><strong>Coming Soon:</strong> More exciting features are being developed!</li>
                     </ul>
                     <p>Your current progress: <strong><?php echo $progress_percentage; ?>%</strong> complete</p>
@@ -140,7 +141,7 @@ try {
             </div>
         </div>
     </div>
-    
+
     <script>
         // Update progress bar with animation
         document.addEventListener('DOMContentLoaded', function() {
@@ -189,7 +190,11 @@ try {
                 event.target.classList.add('active');
             }
         }
-        
+
+        function openGoals() {
+            window.open('goals/index.php', 'aslGoalsWindow', 'width=960,height=720,scrollbars=yes,resizable=yes');
+        }
+
         let originalClassPeriod = '<?php echo $current_class_period ?? ''; ?>';
         
         function updateClassPeriod(newPeriod) {

--- a/asl1/goals/create_goal.php
+++ b/asl1/goals/create_goal.php
@@ -1,0 +1,3 @@
+<?php
+$ASL_BASE_PATH = dirname(__DIR__);
+require_once __DIR__ . '/../../common/goals/create_goal.php';

--- a/asl1/goals/delete_goal.php
+++ b/asl1/goals/delete_goal.php
@@ -1,0 +1,3 @@
+<?php
+$ASL_BASE_PATH = dirname(__DIR__);
+require_once __DIR__ . '/../../common/goals/delete_goal.php';

--- a/asl1/goals/index.php
+++ b/asl1/goals/index.php
@@ -1,0 +1,5 @@
+<?php
+$ASL_BASE_PATH = dirname(__DIR__);
+$ASL_RELATIVE_PATH = '..';
+$ASL_LEVEL_NAME = 'ASL 1';
+require_once __DIR__ . '/../../common/goals/index.php';

--- a/asl1/goals/update_goal_status.php
+++ b/asl1/goals/update_goal_status.php
@@ -1,0 +1,3 @@
+<?php
+$ASL_BASE_PATH = dirname(__DIR__);
+require_once __DIR__ . '/../../common/goals/update_goal_status.php';

--- a/asl1/skills.php
+++ b/asl1/skills.php
@@ -122,7 +122,7 @@ try {
             <div class="sidebar">
                 <button class="sidebar-button active" onclick="showContent('skills')">Skills</button>
                 <button class="sidebar-button" onclick="goBack()">Scroller Game</button>
-                <button class="sidebar-button" onclick="goBack()">Coming Soon</button>
+                <button class="sidebar-button" onclick="openGoals()">Goals</button>
                 <button class="sidebar-button" onclick="goBack()">Coming Soon</button>
                 <button class="sidebar-button" onclick="goBack()">Coming Soon</button>
                 <button class="sidebar-button" onclick="goBack()">Coming Soon</button>
@@ -357,6 +357,10 @@ try {
         
         function goBack() {
             window.location.href = 'dashboard.php';
+        }
+
+        function openGoals() {
+            window.open('goals/index.php', 'aslGoalsWindow', 'width=960,height=720,scrollbars=yes,resizable=yes');
         }
         
         // Get active status filters

--- a/asl2/config.php
+++ b/asl2/config.php
@@ -48,5 +48,37 @@ if (!function_exists('aslhubEnsureSkillLevels')) {
     }
 }
 
+if (!function_exists('aslhubEnsureGoalsTable')) {
+    function aslhubEnsureGoalsTable(PDO $pdo): void
+    {
+        static $checkedGoals = false;
+
+        if ($checkedGoals) {
+            return;
+        }
+
+        $checkedGoals = true;
+
+        try {
+            $pdo->exec("CREATE TABLE IF NOT EXISTS user_goals (
+                id INT AUTO_INCREMENT PRIMARY KEY,
+                user_id INT NOT NULL,
+                framework VARCHAR(100) NOT NULL,
+                goal_type ENUM('daily','weekly') NOT NULL DEFAULT 'daily',
+                goal_focus TEXT NOT NULL,
+                success_criteria TEXT NOT NULL,
+                status ENUM('not_started','progressing','proficient') NOT NULL DEFAULT 'not_started',
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+                INDEX idx_user_goals_user (user_id),
+                CONSTRAINT fk_user_goals_user FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci");
+        } catch (PDOException $e) {
+            error_log('ASL Hub schema check (user_goals) failed: ' . $e->getMessage());
+        }
+    }
+}
+
 aslhubEnsureSkillLevels($pdo, 2);
+aslhubEnsureGoalsTable($pdo);
 ?>

--- a/asl2/css/asl-style.css
+++ b/asl2/css/asl-style.css
@@ -637,25 +637,291 @@ header h1 {
     text-align: center;
 }
 
+/* ===== GOALS PAGE STYLES ===== */
+.goals-page .dashboard-container {
+    align-items: flex-start;
+}
+
+.goals-layout {
+    display: grid;
+    grid-template-columns: minmax(280px, 360px) 1fr;
+    gap: 24px;
+    width: 100%;
+}
+
+.goal-create-card,
+.goal-cards-card {
+    background: rgba(255, 255, 255, 0.95);
+    border-radius: 15px;
+    padding: 24px;
+    box-shadow: 0 8px 32px rgba(76, 81, 191, 0.12);
+    border: 1px solid rgba(226, 232, 240, 0.8);
+}
+
+.goal-cards-card {
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+}
+
+.goal-cards-header h2 {
+    font-size: 1.6rem;
+    color: #2d3748;
+}
+
+.goal-cards-header p {
+    color: #4a5568;
+    margin-top: 6px;
+}
+
+.goal-instructions {
+    color: #4a5568;
+    margin-bottom: 20px;
+}
+
+.goal-form {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.goal-form-row {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    margin-bottom: 10px;
+}
+
+.goal-select,
+.goal-textarea {
+    width: 100%;
+    padding: 12px 14px;
+    border: 2px solid #e2e8f0;
+    border-radius: 10px;
+    font-size: 1rem;
+    transition: all 0.2s ease;
+    background: #fff;
+    color: #2d3748;
+}
+
+.goal-select:focus,
+.goal-textarea:focus {
+    outline: none;
+    border-color: #4299e1;
+    box-shadow: 0 0 0 3px rgba(66, 153, 225, 0.15);
+}
+
+.goal-type-toggle {
+    display: inline-flex;
+    background: rgba(237, 242, 247, 0.7);
+    border-radius: 12px;
+    padding: 6px;
+    gap: 10px;
+}
+
+.goal-type-option {
+    position: relative;
+    cursor: pointer;
+}
+
+.goal-type-option input {
+    position: absolute;
+    opacity: 0;
+}
+
+.goal-type-option span {
+    display: inline-block;
+    padding: 8px 16px;
+    border-radius: 10px;
+    font-weight: 600;
+    color: #4a5568;
+    transition: all 0.2s ease;
+}
+
+.goal-type-option input:checked + span {
+    background: linear-gradient(135deg, #4299e1 0%, #3182ce 100%);
+    color: #fff;
+    box-shadow: 0 6px 16px rgba(66, 153, 225, 0.35);
+}
+
+.goal-submit-button {
+    margin-top: 10px;
+}
+
+.goal-message {
+    min-height: 22px;
+    margin-top: 12px;
+    font-weight: 600;
+}
+
+.goal-message-success {
+    color: #2f855a;
+}
+
+.goal-message-error {
+    color: #c53030;
+}
+
+.goal-card-list {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+.goal-card {
+    background: rgba(247, 250, 252, 0.95);
+    border-radius: 15px;
+    border: 1px solid rgba(226, 232, 240, 0.9);
+    padding: 18px 20px;
+    box-shadow: 0 6px 20px rgba(74, 85, 104, 0.08);
+}
+
+.goal-card-header {
+    display: flex;
+    justify-content: space-between;
+    gap: 12px;
+    align-items: center;
+    margin-bottom: 16px;
+}
+
+.goal-card-header-text h3 {
+    font-size: 1.3rem;
+    color: #2d3748;
+    margin-bottom: 4px;
+}
+
+.goal-type-badge {
+    display: inline-block;
+    padding: 4px 10px;
+    border-radius: 999px;
+    background: rgba(66, 153, 225, 0.12);
+    color: #2b6cb0;
+    font-weight: 600;
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    margin-bottom: 4px;
+}
+
+.goal-delete-button {
+    background: rgba(229, 62, 62, 0.12);
+    color: #c53030;
+    border: 1px solid rgba(229, 62, 62, 0.35);
+    border-radius: 10px;
+    padding: 8px 16px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.goal-delete-button:hover {
+    background: #e53e3e;
+    color: #fff;
+    box-shadow: 0 6px 20px rgba(229, 62, 62, 0.35);
+}
+
+.goal-card-body {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    color: #4a5568;
+}
+
+.goal-status-buttons {
+    display: flex;
+    gap: 12px;
+    flex-wrap: wrap;
+}
+
+.goal-status-button {
+    flex: 1;
+    min-width: 140px;
+    padding: 10px 14px;
+    border-radius: 10px;
+    font-weight: 600;
+    border: 1px solid transparent;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    text-align: center;
+}
+
+.goal-status-button.not-started {
+    background: rgba(229, 62, 62, 0.12);
+    color: #c53030;
+    border-color: rgba(229, 62, 62, 0.3);
+}
+
+.goal-status-button.not-started.active {
+    background: #e53e3e;
+    color: #fff;
+    box-shadow: 0 6px 20px rgba(229, 62, 62, 0.35);
+}
+
+.goal-status-button.progressing {
+    background: rgba(214, 158, 46, 0.15);
+    color: #b7791f;
+    border-color: rgba(214, 158, 46, 0.35);
+}
+
+.goal-status-button.progressing.active {
+    background: #d69e2e;
+    color: #fff;
+    box-shadow: 0 6px 20px rgba(214, 158, 46, 0.35);
+}
+
+.goal-status-button.proficient {
+    background: rgba(56, 161, 105, 0.15);
+    color: #2f855a;
+    border-color: rgba(56, 161, 105, 0.35);
+}
+
+.goal-status-button.proficient.active {
+    background: #38a169;
+    color: #fff;
+    box-shadow: 0 6px 20px rgba(56, 161, 105, 0.35);
+}
+
+.goal-status-button:hover {
+    transform: translateY(-1px);
+}
+
+.goal-empty-state {
+    background: rgba(237, 242, 247, 0.65);
+    border: 1px dashed rgba(160, 174, 192, 0.7);
+    border-radius: 15px;
+    padding: 30px;
+    text-align: center;
+    color: #4a5568;
+}
+
+.goal-empty-state h3 {
+    font-size: 1.3rem;
+    margin-bottom: 8px;
+}
+
 /* ===== RESPONSIVE DESIGN ===== */
 @media (max-width: 1200px) {
     .dashboard-container {
         grid-template-columns: 1fr;
         grid-template-rows: auto auto auto 1fr;
-        grid-template-areas: 
+        grid-template-areas:
             "user-info"
             "progress-bar"
             "sidebar"
             "main-content";
     }
-    
+
     .sidebar {
         flex-direction: row;
         overflow-x: auto;
     }
-    
+
     .sidebar-button {
         min-width: 120px;
+    }
+
+    .goals-layout {
+        grid-template-columns: 1fr;
     }
 }
 
@@ -721,6 +987,14 @@ header h1 {
     
     .search-results {
         text-align: center;
+    }
+
+    .goal-status-buttons {
+        flex-direction: column;
+    }
+
+    .goal-status-button {
+        width: 100%;
     }
 }
 

--- a/asl2/dashboard.php
+++ b/asl2/dashboard.php
@@ -109,7 +109,7 @@ try {
             <div class="sidebar">
                 <button class="sidebar-button" onclick="showContent('skills')">Skills</button>
                 <button class="sidebar-button" onclick="window.open('scrollergame/index.html', '_blank')">Scroller Game</button>
-                <button class="sidebar-button" onclick="showContent('coming-soon')">Coming Soon</button>
+                <button class="sidebar-button" onclick="openGoals()">Goals</button>
                 <button class="sidebar-button" onclick="showContent('coming-soon')">Coming Soon</button>
                 <button class="sidebar-button" onclick="showContent('coming-soon')">Coming Soon</button>
                 <button class="sidebar-button" onclick="showContent('coming-soon')">Coming Soon</button>
@@ -122,6 +122,7 @@ try {
                     <ul>
                         <li><strong>Skills:</strong> Track your progress through various ASL skills and access learning resources</li>
                         <li><strong>Scroller Game:</strong> Practice ASL vocabulary with an interactive word scrolling game</li>
+                        <li><strong>Goals:</strong> Create personal ASL practice goals and monitor how you're doing.</li>
                         <li><strong>Coming Soon:</strong> More exciting features are being developed!</li>
                     </ul>
                     <p>Your current progress: <strong><?php echo $progress_percentage; ?>%</strong> complete</p>
@@ -188,6 +189,10 @@ try {
                 // Activate the clicked button
                 event.target.classList.add('active');
             }
+        }
+
+        function openGoals() {
+            window.open('goals/index.php', 'aslGoalsWindow', 'width=960,height=720,scrollbars=yes,resizable=yes');
         }
         
         let originalClassPeriod = '<?php echo $current_class_period ?? ''; ?>';

--- a/asl2/goals/create_goal.php
+++ b/asl2/goals/create_goal.php
@@ -1,0 +1,3 @@
+<?php
+$ASL_BASE_PATH = dirname(__DIR__);
+require_once __DIR__ . '/../../common/goals/create_goal.php';

--- a/asl2/goals/delete_goal.php
+++ b/asl2/goals/delete_goal.php
@@ -1,0 +1,3 @@
+<?php
+$ASL_BASE_PATH = dirname(__DIR__);
+require_once __DIR__ . '/../../common/goals/delete_goal.php';

--- a/asl2/goals/index.php
+++ b/asl2/goals/index.php
@@ -1,0 +1,5 @@
+<?php
+$ASL_BASE_PATH = dirname(__DIR__);
+$ASL_RELATIVE_PATH = '..';
+$ASL_LEVEL_NAME = 'ASL 2';
+require_once __DIR__ . '/../../common/goals/index.php';

--- a/asl2/goals/update_goal_status.php
+++ b/asl2/goals/update_goal_status.php
@@ -1,0 +1,3 @@
+<?php
+$ASL_BASE_PATH = dirname(__DIR__);
+require_once __DIR__ . '/../../common/goals/update_goal_status.php';

--- a/asl2/skills.php
+++ b/asl2/skills.php
@@ -122,7 +122,7 @@ try {
             <div class="sidebar">
                 <button class="sidebar-button active" onclick="showContent('skills')">Skills</button>
                 <button class="sidebar-button" onclick="goBack()">Scroller Game</button>
-                <button class="sidebar-button" onclick="goBack()">Coming Soon</button>
+                <button class="sidebar-button" onclick="openGoals()">Goals</button>
                 <button class="sidebar-button" onclick="goBack()">Coming Soon</button>
                 <button class="sidebar-button" onclick="goBack()">Coming Soon</button>
                 <button class="sidebar-button" onclick="goBack()">Coming Soon</button>
@@ -357,6 +357,10 @@ try {
         
         function goBack() {
             window.location.href = 'dashboard.php';
+        }
+
+        function openGoals() {
+            window.open('goals/index.php', 'aslGoalsWindow', 'width=960,height=720,scrollbars=yes,resizable=yes');
         }
         
         // Get active status filters

--- a/common/goals/create_goal.php
+++ b/common/goals/create_goal.php
@@ -1,0 +1,84 @@
+<?php
+if (!isset($ASL_BASE_PATH)) {
+    $ASL_BASE_PATH = dirname(__DIR__, 2) . '/asl1';
+}
+
+session_start();
+require_once $ASL_BASE_PATH . '/config.php';
+
+header('Content-Type: application/json');
+
+if (!isset($_SESSION['user_id'])) {
+    http_response_code(401);
+    echo json_encode(['success' => false, 'message' => 'Please log in to manage goals.']);
+    exit;
+}
+
+if (isset($_SESSION['is_teacher']) && $_SESSION['is_teacher']) {
+    http_response_code(403);
+    echo json_encode(['success' => false, 'message' => 'Teachers cannot create student goals.']);
+    exit;
+}
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    http_response_code(405);
+    echo json_encode(['success' => false, 'message' => 'Invalid request method.']);
+    exit;
+}
+
+$payload = json_decode(file_get_contents('php://input'), true);
+
+if (!is_array($payload)) {
+    http_response_code(400);
+    echo json_encode(['success' => false, 'message' => 'Invalid data received.']);
+    exit;
+}
+
+$framework = trim((string)($payload['framework'] ?? ''));
+$goalType = $payload['goal_type'] ?? 'daily';
+$goalFocus = trim((string)($payload['goal_focus'] ?? ''));
+$successCriteria = trim((string)($payload['success_criteria'] ?? ''));
+
+if ($framework === '') {
+    $framework = 'simple';
+}
+
+if (!in_array($goalType, ['daily', 'weekly'], true)) {
+    $goalType = 'daily';
+}
+
+if ($goalFocus === '' || $successCriteria === '') {
+    http_response_code(422);
+    echo json_encode(['success' => false, 'message' => 'Both goal fields are required.']);
+    exit;
+}
+
+$framework = mb_substr($framework, 0, 100);
+$goalFocus = mb_substr($goalFocus, 0, 600);
+$successCriteria = mb_substr($successCriteria, 0, 600);
+
+try {
+    $stmt = $pdo->prepare('INSERT INTO user_goals (user_id, framework, goal_type, goal_focus, success_criteria) VALUES (?, ?, ?, ?, ?)');
+    $stmt->execute([
+        $_SESSION['user_id'],
+        $framework,
+        $goalType,
+        $goalFocus,
+        $successCriteria,
+    ]);
+
+    $goalId = (int) $pdo->lastInsertId();
+
+    $fetchStmt = $pdo->prepare('SELECT id, framework, goal_type, goal_focus, success_criteria, status, created_at FROM user_goals WHERE id = ? AND user_id = ?');
+    $fetchStmt->execute([$goalId, $_SESSION['user_id']]);
+    $goal = $fetchStmt->fetch(PDO::FETCH_ASSOC);
+
+    if (!$goal) {
+        throw new RuntimeException('Goal could not be retrieved after saving.');
+    }
+
+    echo json_encode(['success' => true, 'goal' => $goal]);
+} catch (Throwable $e) {
+    http_response_code(500);
+    echo json_encode(['success' => false, 'message' => 'We had trouble saving your goal. Please try again.']);
+}

--- a/common/goals/delete_goal.php
+++ b/common/goals/delete_goal.php
@@ -1,0 +1,52 @@
+<?php
+if (!isset($ASL_BASE_PATH)) {
+    $ASL_BASE_PATH = dirname(__DIR__, 2) . '/asl1';
+}
+
+session_start();
+require_once $ASL_BASE_PATH . '/config.php';
+
+header('Content-Type: application/json');
+
+if (!isset($_SESSION['user_id'])) {
+    http_response_code(401);
+    echo json_encode(['success' => false, 'message' => 'Please log in to manage goals.']);
+    exit;
+}
+
+if (isset($_SESSION['is_teacher']) && $_SESSION['is_teacher']) {
+    http_response_code(403);
+    echo json_encode(['success' => false, 'message' => 'Teachers cannot delete student goals.']);
+    exit;
+}
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    http_response_code(405);
+    echo json_encode(['success' => false, 'message' => 'Invalid request method.']);
+    exit;
+}
+
+$payload = json_decode(file_get_contents('php://input'), true);
+$goalId = isset($payload['goal_id']) ? (int) $payload['goal_id'] : 0;
+
+if ($goalId <= 0) {
+    http_response_code(422);
+    echo json_encode(['success' => false, 'message' => 'Invalid goal selection.']);
+    exit;
+}
+
+try {
+    $stmt = $pdo->prepare('DELETE FROM user_goals WHERE id = ? AND user_id = ?');
+    $stmt->execute([$goalId, $_SESSION['user_id']]);
+
+    if ($stmt->rowCount() === 0) {
+        http_response_code(404);
+        echo json_encode(['success' => false, 'message' => 'Goal not found.']);
+        exit;
+    }
+
+    echo json_encode(['success' => true, 'goal_id' => $goalId]);
+} catch (Throwable $e) {
+    http_response_code(500);
+    echo json_encode(['success' => false, 'message' => 'Unable to delete the goal right now.']);
+}

--- a/common/goals/index.php
+++ b/common/goals/index.php
@@ -1,0 +1,441 @@
+<?php
+if (!isset($ASL_BASE_PATH)) {
+    $ASL_BASE_PATH = dirname(__DIR__, 2) . '/asl1';
+}
+if (!isset($ASL_RELATIVE_PATH)) {
+    $ASL_RELATIVE_PATH = '..';
+}
+if (!isset($ASL_LEVEL_NAME)) {
+    $ASL_LEVEL_NAME = 'ASL';
+}
+
+session_start();
+require_once $ASL_BASE_PATH . '/config.php';
+
+if (!isset($_SESSION['user_id'])) {
+    header('Location: ' . $ASL_RELATIVE_PATH . '/index.php');
+    exit;
+}
+
+if (isset($_SESSION['is_teacher']) && $_SESSION['is_teacher']) {
+    header('Location: ' . $ASL_RELATIVE_PATH . '/teacher_dashboard.php');
+    exit;
+}
+
+$userFullName = trim((string)($_SESSION['user_first_name'] ?? '') . ' ' . (string)($_SESSION['user_last_name'] ?? ''));
+
+try {
+    $stmt = $pdo->prepare('SELECT id, framework, goal_type, goal_focus, success_criteria, status, created_at FROM user_goals WHERE user_id = ? ORDER BY created_at DESC');
+    $stmt->execute([$_SESSION['user_id']]);
+    $goals = $stmt->fetchAll(PDO::FETCH_ASSOC);
+} catch (PDOException $e) {
+    $goals = [];
+}
+
+$totalGoals = count($goals);
+$progressPercentage = 0;
+
+if ($totalGoals > 0) {
+    $statusWeights = [
+        'not_started' => 0,
+        'progressing' => 0.5,
+        'proficient' => 1,
+    ];
+
+    $totalWeight = 0;
+    foreach ($goals as $goal) {
+        $status = $goal['status'] ?? 'not_started';
+        $totalWeight += $statusWeights[$status] ?? 0;
+    }
+
+    $progressPercentage = (int) round(($totalWeight / $totalGoals) * 100);
+}
+
+$goalsJson = json_encode($goals, JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP);
+$escapedName = htmlspecialchars($userFullName !== '' ? $userFullName : 'Student', ENT_QUOTES, 'UTF-8');
+$levelHeading = htmlspecialchars($ASL_LEVEL_NAME, ENT_QUOTES, 'UTF-8');
+$cssPath = htmlspecialchars($ASL_RELATIVE_PATH . '/css/asl-style.css', ENT_QUOTES, 'UTF-8');
+$dashboardPath = htmlspecialchars($ASL_RELATIVE_PATH . '/dashboard.php', ENT_QUOTES, 'UTF-8');
+$logoutPath = htmlspecialchars($ASL_RELATIVE_PATH . '/logout.php', ENT_QUOTES, 'UTF-8');
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title><?php echo $levelHeading; ?> Goals</title>
+    <link rel="stylesheet" href="<?php echo $cssPath; ?>">
+</head>
+<body>
+    <div class="container goals-page">
+        <header>
+            <h1><?php echo $levelHeading; ?> Goals</h1>
+            <div class="user-info">
+                <span>Welcome, <?php echo $escapedName; ?>!</span>
+                <a href="<?php echo $dashboardPath; ?>" class="back-btn">← Back to Dashboard</a>
+                <a href="<?php echo $logoutPath; ?>" class="logout-btn">Logout</a>
+            </div>
+        </header>
+
+        <div class="dashboard-container">
+            <div class="user-info-box">
+                <div class="user-name"><?php echo $escapedName; ?></div>
+            </div>
+
+            <div class="progress-bar-container goals-progress">
+                <div class="progress-label">Goals Progress</div>
+                <div class="progress-bar">
+                    <div class="progress-fill" id="goal-progress-fill" style="width: <?php echo $progressPercentage; ?>%"></div>
+                    <div class="progress-text" id="goal-progress-text"><?php echo $progressPercentage; ?>%</div>
+                </div>
+            </div>
+
+            <div class="goals-layout">
+                <section class="goal-create-card">
+                    <h2>Create a New Goal</h2>
+                    <p class="goal-instructions">Choose your goal framework and focus. We'll track it separately from your skill progress.</p>
+
+                    <form id="goal-form" class="goal-form" autocomplete="off">
+                        <div class="goal-form-row">
+                            <label for="goal-framework">Goal Framework</label>
+                            <select id="goal-framework" class="goal-select">
+                                <option value="simple" selected>Simple</option>
+                            </select>
+                        </div>
+
+                        <div class="goal-form-row">
+                            <span class="goal-label">Goal Type</span>
+                            <div class="goal-type-toggle" role="radiogroup" aria-label="Select goal timeframe">
+                                <label class="goal-type-option">
+                                    <input type="radio" name="goal-type" value="daily" checked>
+                                    <span>Daily</span>
+                                </label>
+                                <label class="goal-type-option">
+                                    <input type="radio" name="goal-type" value="weekly">
+                                    <span>Weekly</span>
+                                </label>
+                            </div>
+                        </div>
+
+                        <div class="goal-form-row">
+                            <label for="goal-focus" id="goal-focus-label">Today my goal is to...</label>
+                            <textarea id="goal-focus" class="goal-textarea" rows="3" placeholder="Practice fingerspelling for 10 minutes"></textarea>
+                        </div>
+
+                        <div class="goal-form-row">
+                            <label for="goal-success" id="goal-success-label">When I can..., I know I've accomplished my goal.</label>
+                            <textarea id="goal-success" class="goal-textarea" rows="3" placeholder="Fingerspell the alphabet smoothly without pausing"></textarea>
+                        </div>
+
+                        <button type="submit" class="form-button goal-submit-button">Save Goal</button>
+                    </form>
+
+                    <div id="goal-message" class="goal-message" role="alert" aria-live="polite"></div>
+                </section>
+
+                <section class="goal-cards-card">
+                    <div class="goal-cards-header">
+                        <h2>Your Goals</h2>
+                        <p>Update each goal as you progress. You can delete a goal once you're finished with it.</p>
+                    </div>
+                    <div id="goal-list" class="goal-card-list"></div>
+                </section>
+            </div>
+        </div>
+    </div>
+
+    <script>
+        const goalData = <?php echo $goalsJson ?: '[]'; ?>;
+        const goalForm = document.getElementById('goal-form');
+        const goalList = document.getElementById('goal-list');
+        const goalMessage = document.getElementById('goal-message');
+        const goalFocusLabel = document.getElementById('goal-focus-label');
+        const goalSuccessLabel = document.getElementById('goal-success-label');
+        const goalFocusInput = document.getElementById('goal-focus');
+        const goalSuccessInput = document.getElementById('goal-success');
+        const goalProgressFill = document.getElementById('goal-progress-fill');
+        const goalProgressText = document.getElementById('goal-progress-text');
+        const goalTypeRadios = Array.from(document.querySelectorAll('input[name="goal-type"]'));
+
+        const statusWeights = {
+            'not_started': 0,
+            'progressing': 0.5,
+            'proficient': 1
+        };
+
+        goalTypeRadios.forEach(radio => {
+            radio.addEventListener('change', () => {
+                const timeframe = getSelectedGoalType();
+                if (timeframe === 'weekly') {
+                    goalFocusLabel.textContent = 'This week my goal is to...';
+                    goalSuccessLabel.textContent = 'When I can..., I know I\'ve accomplished my goal.';
+                    goalFocusInput.placeholder = 'Practice my ASL story three times this week';
+                    goalSuccessInput.placeholder = 'Share the story smoothly with my partner';
+                } else {
+                    goalFocusLabel.textContent = 'Today my goal is to...';
+                    goalSuccessLabel.textContent = 'When I can..., I know I\'ve accomplished my goal.';
+                    goalFocusInput.placeholder = 'Practice fingerspelling for 10 minutes';
+                    goalSuccessInput.placeholder = 'Fingerspell the alphabet smoothly without pausing';
+                }
+            });
+        });
+
+        goalForm.addEventListener('submit', async (event) => {
+            event.preventDefault();
+            clearGoalMessage();
+
+            const framework = document.getElementById('goal-framework').value;
+            const goalType = getSelectedGoalType();
+            const goalFocus = goalFocusInput.value.trim();
+            const goalSuccess = goalSuccessInput.value.trim();
+
+            if (!goalFocus || !goalSuccess) {
+                showGoalMessage('Please fill out both goal fields before saving.', false);
+                return;
+            }
+
+            try {
+                const response = await fetch('create_goal.php', {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json'
+                    },
+                    body: JSON.stringify({
+                        framework,
+                        goal_type: goalType,
+                        goal_focus: goalFocus,
+                        success_criteria: goalSuccess
+                    })
+                });
+
+                const data = await response.json();
+
+                if (!response.ok || !data.success) {
+                    throw new Error(data.message || 'Unable to save your goal right now.');
+                }
+
+                goalData.unshift(data.goal);
+                goalFocusInput.value = '';
+                goalSuccessInput.value = '';
+                renderGoals();
+                showGoalMessage('Goal saved successfully!', true);
+            } catch (error) {
+                showGoalMessage(error.message, false);
+            }
+        });
+
+        function getSelectedGoalType() {
+            const selected = goalTypeRadios.find(radio => radio.checked);
+            return selected ? selected.value : 'daily';
+        }
+
+        function renderGoals() {
+            goalList.innerHTML = '';
+
+            if (!Array.isArray(goalData) || goalData.length === 0) {
+                const emptyState = document.createElement('div');
+                emptyState.className = 'goal-empty-state';
+                emptyState.innerHTML = '<h3>No goals yet</h3><p>Create your first goal to start tracking your progress.</p>';
+                goalList.appendChild(emptyState);
+                updateProgressBar();
+                return;
+            }
+
+            goalData.forEach(goal => {
+                const card = document.createElement('article');
+                card.className = 'goal-card';
+                card.dataset.goalId = goal.id;
+
+                const header = document.createElement('div');
+                header.className = 'goal-card-header';
+
+                const headerText = document.createElement('div');
+                headerText.className = 'goal-card-header-text';
+
+                const badge = document.createElement('span');
+                badge.className = 'goal-type-badge';
+                badge.textContent = goal.goal_type === 'weekly' ? 'Weekly Goal' : 'Daily Goal';
+
+                const title = document.createElement('h3');
+                title.textContent = formatFramework(goal.framework);
+
+                headerText.appendChild(badge);
+                headerText.appendChild(title);
+
+                const deleteButton = document.createElement('button');
+                deleteButton.className = 'goal-delete-button';
+                deleteButton.type = 'button';
+                deleteButton.textContent = 'Delete Goal';
+                deleteButton.addEventListener('click', () => handleDeleteGoal(goal.id));
+
+                header.appendChild(headerText);
+                header.appendChild(deleteButton);
+                card.appendChild(header);
+
+                const body = document.createElement('div');
+                body.className = 'goal-card-body';
+
+                const focus = document.createElement('p');
+                focus.className = 'goal-focus';
+                const focusText = (goal.goal_focus || '').trim();
+                focus.textContent = (goal.goal_type === 'weekly' ? 'This week my goal is to ' : 'Today my goal is to ') + focusText;
+
+                const success = document.createElement('p');
+                success.className = 'goal-success';
+                const successText = (goal.success_criteria || '').trim();
+                if (successText) {
+                    const needsEnding = /[.!?]$/.test(successText) ? '' : '.';
+                    success.textContent = `I'll know I've accomplished it when I can ${successText}${needsEnding}`;
+                } else {
+                    success.textContent = "Set how you will measure this goal so you know when it's complete.";
+                }
+
+                const statusContainer = document.createElement('div');
+                statusContainer.className = 'goal-status-buttons';
+
+                const normalizedStatus = Object.prototype.hasOwnProperty.call(statusWeights, goal.status) ? goal.status : 'not_started';
+                if (normalizedStatus !== goal.status) {
+                    goal.status = normalizedStatus;
+                }
+
+                const statuses = [
+                    { key: 'not_started', label: 'Not Started' },
+                    { key: 'progressing', label: 'Progressing' },
+                    { key: 'proficient', label: 'Proficient' }
+                ];
+
+                statuses.forEach(({ key, label }) => {
+                    const button = document.createElement('button');
+                    button.type = 'button';
+                    button.className = `goal-status-button ${key.replace('_', '-')}`;
+                    if (normalizedStatus === key) {
+                        button.classList.add('active');
+                    }
+                    button.textContent = label;
+                    button.addEventListener('click', () => handleStatusChange(goal.id, key));
+                    statusContainer.appendChild(button);
+                });
+
+                body.appendChild(focus);
+                body.appendChild(success);
+                body.appendChild(statusContainer);
+                card.appendChild(body);
+
+                goalList.appendChild(card);
+            });
+
+            updateProgressBar();
+        }
+
+        async function handleStatusChange(goalId, status) {
+            const goal = goalData.find(item => Number(item.id) === Number(goalId));
+            if (!goal || goal.status === status) {
+                return;
+            }
+
+            try {
+                const response = await fetch('update_goal_status.php', {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json'
+                    },
+                    body: JSON.stringify({ goal_id: goalId, status })
+                });
+
+                const data = await response.json();
+
+                if (!response.ok || !data.success) {
+                    throw new Error(data.message || 'Unable to update that goal right now.');
+                }
+
+                goal.status = status;
+                renderGoals();
+                showGoalMessage('Goal status updated.', true);
+            } catch (error) {
+                showGoalMessage(error.message, false);
+            }
+        }
+
+        async function handleDeleteGoal(goalId) {
+            if (!confirm('Delete this goal? This cannot be undone.')) {
+                return;
+            }
+
+            try {
+                const response = await fetch('delete_goal.php', {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json'
+                    },
+                    body: JSON.stringify({ goal_id: goalId })
+                });
+
+                const data = await response.json();
+
+                if (!response.ok || !data.success) {
+                    throw new Error(data.message || 'Unable to delete that goal right now.');
+                }
+
+                const goalIndex = goalData.findIndex(item => Number(item.id) === Number(goalId));
+                if (goalIndex !== -1) {
+                    goalData.splice(goalIndex, 1);
+                }
+                renderGoals();
+                showGoalMessage('Goal deleted.', true);
+            } catch (error) {
+                showGoalMessage(error.message, false);
+            }
+        }
+
+        function updateProgressBar() {
+            const totalGoals = Array.isArray(goalData) ? goalData.length : 0;
+            if (totalGoals === 0) {
+                goalProgressFill.style.width = '0%';
+                goalProgressText.textContent = '0%';
+                setProgressColor(0);
+                return;
+            }
+
+            let earned = 0;
+            goalData.forEach(goal => {
+                earned += statusWeights[goal.status] ?? 0;
+            });
+
+            const percentage = Math.round((earned / totalGoals) * 100);
+            goalProgressFill.style.width = `${percentage}%`;
+            goalProgressText.textContent = `${percentage}%`;
+            setProgressColor(percentage);
+        }
+
+        function setProgressColor(percentage) {
+            goalProgressFill.classList.remove('progress-0-50', 'progress-51-75', 'progress-76-100');
+            if (percentage <= 50) {
+                goalProgressFill.classList.add('progress-0-50');
+            } else if (percentage <= 75) {
+                goalProgressFill.classList.add('progress-51-75');
+            } else {
+                goalProgressFill.classList.add('progress-76-100');
+            }
+        }
+
+        function formatFramework(framework) {
+            if (!framework) {
+                return 'Personal Goal';
+            }
+            return framework.charAt(0).toUpperCase() + framework.slice(1) + ' Goal';
+        }
+
+        function showGoalMessage(message, isSuccess) {
+            goalMessage.textContent = message;
+            goalMessage.classList.toggle('goal-message-success', Boolean(isSuccess));
+            goalMessage.classList.toggle('goal-message-error', !isSuccess);
+        }
+
+        function clearGoalMessage() {
+            goalMessage.textContent = '';
+            goalMessage.classList.remove('goal-message-success', 'goal-message-error');
+        }
+
+        renderGoals();
+    </script>
+</body>
+</html>

--- a/common/goals/update_goal_status.php
+++ b/common/goals/update_goal_status.php
@@ -1,0 +1,63 @@
+<?php
+if (!isset($ASL_BASE_PATH)) {
+    $ASL_BASE_PATH = dirname(__DIR__, 2) . '/asl1';
+}
+
+session_start();
+require_once $ASL_BASE_PATH . '/config.php';
+
+header('Content-Type: application/json');
+
+if (!isset($_SESSION['user_id'])) {
+    http_response_code(401);
+    echo json_encode(['success' => false, 'message' => 'Please log in to manage goals.']);
+    exit;
+}
+
+if (isset($_SESSION['is_teacher']) && $_SESSION['is_teacher']) {
+    http_response_code(403);
+    echo json_encode(['success' => false, 'message' => 'Teachers cannot update student goals.']);
+    exit;
+}
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    http_response_code(405);
+    echo json_encode(['success' => false, 'message' => 'Invalid request method.']);
+    exit;
+}
+
+$payload = json_decode(file_get_contents('php://input'), true);
+
+$goalId = isset($payload['goal_id']) ? (int) $payload['goal_id'] : 0;
+$status = $payload['status'] ?? '';
+
+if ($goalId <= 0 || !in_array($status, ['not_started', 'progressing', 'proficient'], true)) {
+    http_response_code(422);
+    echo json_encode(['success' => false, 'message' => 'Invalid goal status update.']);
+    exit;
+}
+
+try {
+    $checkStmt = $pdo->prepare('SELECT status FROM user_goals WHERE id = ? AND user_id = ?');
+    $checkStmt->execute([$goalId, $_SESSION['user_id']]);
+    $currentStatus = $checkStmt->fetchColumn();
+
+    if ($currentStatus === false) {
+        http_response_code(404);
+        echo json_encode(['success' => false, 'message' => 'Goal not found.']);
+        exit;
+    }
+
+    if ($currentStatus === $status) {
+        echo json_encode(['success' => true, 'goal_id' => $goalId, 'status' => $status]);
+        exit;
+    }
+
+    $stmt = $pdo->prepare('UPDATE user_goals SET status = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ? AND user_id = ?');
+    $stmt->execute([$status, $goalId, $_SESSION['user_id']]);
+
+    echo json_encode(['success' => true, 'goal_id' => $goalId, 'status' => $status]);
+} catch (Throwable $e) {
+    http_response_code(500);
+    echo json_encode(['success' => false, 'message' => 'Unable to update the goal right now.']);
+}


### PR DESCRIPTION
## Summary
- add a shared goals workspace with creation, status updates, deletion, and a per-student progress bar
- surface the new goals window from the ASL 1 and ASL 2 dashboards/skills pages and align the styling with the site theme
- ensure the user_goals table is available automatically and mirror the new styles for both ASL levels

## Testing
- php -l common/goals/index.php
- php -l common/goals/create_goal.php
- php -l common/goals/update_goal_status.php
- php -l common/goals/delete_goal.php
- php -l asl1/goals/index.php
- php -l asl1/goals/create_goal.php
- php -l asl1/goals/update_goal_status.php
- php -l asl1/goals/delete_goal.php
- php -l asl2/goals/index.php
- php -l asl2/goals/create_goal.php
- php -l asl2/goals/update_goal_status.php
- php -l asl2/goals/delete_goal.php

------
https://chatgpt.com/codex/tasks/task_e_68d83f94e5408327a810f0273ef1e041