### PR TITLE
Add whisper auto-open, safe positioning, and image attachments

### DIFF
--- a/dnd/css/style.css
+++ b/dnd/css/style.css
@@ -785,7 +785,26 @@ body {
     flex-direction: column;
     gap: 12px;
     z-index: 1500;
-    pointer-events: none;
+    pointer-events: auto;
+    max-height: calc(100vh - 140px);
+    overflow-y: auto;
+    justify-content: flex-end;
+    padding-right: 6px;
+    overscroll-behavior: contain;
+    scrollbar-width: thin;
+}
+
+.chat-whisper-popouts::-webkit-scrollbar {
+    width: 8px;
+}
+
+.chat-whisper-popouts::-webkit-scrollbar-thumb {
+    background: rgba(99, 102, 241, 0.35);
+    border-radius: 999px;
+}
+
+.chat-whisper-popouts::-webkit-scrollbar-track {
+    background: transparent;
 }
 
 .chat-whisper-popout {
@@ -855,6 +874,38 @@ body {
     gap: 4px;
 }
 
+.chat-whisper-popout__body {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.chat-whisper-popout__image {
+    display: flex;
+}
+
+.chat-whisper-popout__thumbnail-button {
+    background: transparent;
+    border: none;
+    padding: 0;
+    cursor: pointer;
+    border-radius: 10px;
+    overflow: hidden;
+    box-shadow: 0 6px 16px rgba(79, 70, 229, 0.2);
+}
+
+.chat-whisper-popout__thumbnail-button:focus-visible {
+    outline: 3px solid rgba(124, 58, 237, 0.45);
+    outline-offset: 2px;
+}
+
+.chat-whisper-popout__thumbnail {
+    display: block;
+    max-width: 100%;
+    max-height: 120px;
+    object-fit: cover;
+}
+
 .chat-whisper-popout__message--outgoing {
     background: #e9f5ff;
     align-self: flex-end;
@@ -895,7 +946,35 @@ body {
 .chat-whisper-popout__controls {
     display: flex;
     gap: 8px;
-    justify-content: flex-end;
+    align-items: center;
+}
+
+.chat-whisper-popout__attach {
+    background: #eef2ff;
+    border: none;
+    border-radius: 8px;
+    color: #4338ca;
+    font-size: 0.75rem;
+    font-weight: 600;
+    padding: 6px 10px;
+    cursor: pointer;
+    transition: background 0.2s ease, color 0.2s ease;
+}
+
+.chat-whisper-popout__attach:hover,
+.chat-whisper-popout__attach:focus-visible {
+    background: #c7d2fe;
+    color: #312e81;
+    outline: none;
+}
+
+.chat-whisper-popout__attach:disabled {
+    cursor: not-allowed;
+    opacity: 0.6;
+}
+
+.chat-whisper-popout__send {
+    margin-left: auto;
 }
 
 .chat-whisper-popout__textarea {


### PR DESCRIPTION
## Summary
- auto-open the recipient's whisper popout when a new message arrives while still showing the toast and chime
- limit the whisper popout stack height and add scrolling so windows never hide under the browser chrome
- allow whisper image attachments with an add-image button, thumbnail display, and lightbox preview

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da07b5d1dc83279d74eecd0a04fa51