### PR TITLE
Prevent whisper popout drag from blocking close button

### DIFF
--- a/dnd/js/chat-panel.js
+++ b/dnd/js/chat-panel.js
@@ -212,6 +212,9 @@
                 if (event.button !== undefined && event.button !== 0) {
                     return;
                 }
+                if (event.target && event.target.closest('.chat-whisper-popout__close')) {
+                    return;
+                }
                 event.preventDefault();
                 if (typeof dragHandle.setPointerCapture === 'function') {
                     dragHandle.setPointerCapture(event.pointerId);


### PR DESCRIPTION
## Summary
- ensure whisper popout drag handling ignores the close button so users can dismiss the window

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dae7ea9e5883278f5716977785dcc0