### PR TITLE
Add VTT chat sidebar and GM scene controls

### DIFF
--- a/dnd/css/vtt.css
+++ b/dnd/css/vtt.css
@@ -1,0 +1,326 @@
+:root {
+    --vtt-background: #0f172a;
+    --vtt-foreground: #e2e8f0;
+    --vtt-muted: #94a3b8;
+    --vtt-panel-bg: rgba(15, 23, 42, 0.95);
+    --vtt-panel-border: rgba(148, 163, 184, 0.35);
+    --vtt-accent: #38bdf8;
+    --settings-panel-width: 340px;
+    --settings-panel-offset: 20px;
+}
+
+.vtt-body {
+    margin: 0;
+    min-height: 100vh;
+    background: radial-gradient(circle at top, rgba(56, 189, 248, 0.12), transparent 48%), var(--vtt-background);
+    color: var(--vtt-foreground);
+    font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+}
+
+.vtt-container {
+    min-height: 100vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: clamp(1.5rem, 4vw, 4rem);
+    box-sizing: border-box;
+}
+
+.vtt-main {
+    width: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.scene-display {
+    width: min(960px, 92vw);
+    padding: clamp(2rem, 4vw, 3.75rem);
+    background: linear-gradient(135deg, rgba(56, 189, 248, 0.24), rgba(15, 23, 42, 0.92));
+    border: 1px solid rgba(148, 163, 184, 0.45);
+    border-radius: 32px;
+    box-shadow: 0 32px 80px rgba(15, 23, 42, 0.65);
+    backdrop-filter: blur(18px);
+    transition: background 220ms ease, border-color 220ms ease, box-shadow 220ms ease;
+}
+
+.scene-display__meta {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    margin-bottom: 1.25rem;
+    text-transform: uppercase;
+    letter-spacing: 0.18em;
+    font-size: 0.75rem;
+    color: rgba(148, 163, 184, 0.9);
+}
+
+.scene-display__badge {
+    padding: 0.25rem 0.9rem;
+    border-radius: 999px;
+    background: rgba(15, 23, 42, 0.65);
+    border: 1px solid rgba(148, 163, 184, 0.3);
+    font-size: 0.7rem;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: inherit;
+}
+
+.scene-display__name {
+    margin: 0 0 1.25rem;
+    font-size: clamp(2.25rem, 5vw, 3.25rem);
+    letter-spacing: 0.04em;
+}
+
+.scene-display__description {
+    margin: 0;
+    max-width: 70ch;
+    font-size: clamp(1rem, 2vw, 1.2rem);
+    line-height: 1.7;
+    color: rgba(226, 232, 240, 0.88);
+}
+
+.settings-panel {
+    position: fixed;
+    top: var(--settings-panel-offset);
+    bottom: var(--settings-panel-offset);
+    left: var(--settings-panel-offset);
+    width: min(var(--settings-panel-width), calc(100vw - (var(--settings-panel-offset) * 2)));
+    background: var(--vtt-panel-bg);
+    border: 1px solid var(--vtt-panel-border);
+    border-radius: 20px;
+    box-shadow: 0 24px 64px rgba(8, 15, 35, 0.65);
+    display: flex;
+    flex-direction: column;
+    transform: translate3d(calc(-100% - var(--settings-panel-offset)), 0, 0);
+    transition: transform 220ms ease;
+    z-index: 1400;
+}
+
+.settings-panel--open {
+    transform: translate3d(0, 0, 0);
+    pointer-events: auto;
+}
+
+.settings-panel--closed {
+    pointer-events: none;
+}
+
+.settings-panel__header {
+    padding: 1.25rem 1.5rem 1rem;
+    border-bottom: 1px solid rgba(148, 163, 184, 0.2);
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+}
+
+.settings-panel__title {
+    margin: 0;
+    font-size: 1.15rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: rgba(226, 232, 240, 0.94);
+}
+
+.settings-panel__close {
+    background: none;
+    border: 1px solid rgba(148, 163, 184, 0.3);
+    border-radius: 50%;
+    color: rgba(226, 232, 240, 0.88);
+    width: 32px;
+    height: 32px;
+    font-size: 1.1rem;
+    cursor: pointer;
+    transition: background 160ms ease, color 160ms ease;
+}
+
+.settings-panel__close:hover,
+.settings-panel__close:focus {
+    background: rgba(148, 163, 184, 0.2);
+    color: #fff;
+}
+
+.settings-panel__content {
+    padding: 1.5rem;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+}
+
+.settings-panel__group {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.settings-panel__group-title {
+    margin: 0;
+    font-size: 0.95rem;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: rgba(226, 232, 240, 0.75);
+}
+
+.settings-panel__text {
+    margin: 0;
+    color: rgba(226, 232, 240, 0.7);
+    line-height: 1.6;
+    font-size: 0.95rem;
+}
+
+.settings-panel__primary-action {
+    align-self: flex-start;
+    padding: 0.65rem 1.1rem;
+    border-radius: 999px;
+    border: 1px solid rgba(148, 163, 184, 0.35);
+    background: rgba(30, 41, 59, 0.85);
+    color: rgba(226, 232, 240, 0.92);
+    font-size: 0.9rem;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    cursor: pointer;
+    transition: background 160ms ease, color 160ms ease, border-color 160ms ease;
+}
+
+.settings-panel__primary-action:hover,
+.settings-panel__primary-action:focus {
+    background: rgba(56, 189, 248, 0.18);
+    border-color: rgba(56, 189, 248, 0.6);
+    color: #fff;
+}
+
+.settings-panel__scenes {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    padding: 0.5rem 0 0.25rem;
+}
+
+.scene-option {
+    text-align: left;
+    padding: 0.85rem 1rem;
+    border-radius: 14px;
+    border: 1px solid rgba(148, 163, 184, 0.25);
+    background: rgba(30, 41, 59, 0.7);
+    color: rgba(226, 232, 240, 0.92);
+    display: flex;
+    flex-direction: column;
+    gap: 0.3rem;
+    cursor: pointer;
+    transition: transform 160ms ease, border-color 160ms ease, background 160ms ease;
+}
+
+.scene-option:hover,
+.scene-option:focus {
+    transform: translateY(-2px);
+    border-color: rgba(56, 189, 248, 0.6);
+    background: rgba(56, 189, 248, 0.18);
+}
+
+.scene-option--active {
+    border-color: rgba(56, 189, 248, 0.85);
+    background: rgba(56, 189, 248, 0.22);
+    box-shadow: 0 12px 28px rgba(56, 189, 248, 0.18);
+}
+
+.scene-option__name {
+    font-size: 1rem;
+    font-weight: 600;
+}
+
+.scene-option__description {
+    font-size: 0.9rem;
+    color: rgba(226, 232, 240, 0.7);
+}
+
+.settings-panel__status {
+    min-height: 1.1rem;
+    font-size: 0.85rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: rgba(226, 232, 240, 0.65);
+}
+
+.settings-panel__status--success {
+    color: #4ade80;
+}
+
+.settings-panel__status--error {
+    color: #f87171;
+}
+
+.settings-panel-toggle {
+    position: fixed;
+    top: 50%;
+    left: 0;
+    transform: translate3d(-55%, -50%, 0);
+    padding: 0.75rem 1.6rem;
+    border-radius: 0 16px 16px 0;
+    border: 1px solid var(--vtt-panel-border);
+    background: var(--vtt-panel-bg);
+    color: rgba(226, 232, 240, 0.9);
+    font-size: 0.9rem;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    cursor: pointer;
+    box-shadow: 0 18px 48px rgba(8, 15, 35, 0.6);
+    transition: transform 220ms ease, background 160ms ease, color 160ms ease;
+    z-index: 1390;
+}
+
+.settings-panel-toggle:hover,
+.settings-panel-toggle:focus {
+    background: rgba(56, 189, 248, 0.2);
+    color: #fff;
+}
+
+.settings-panel-toggle[aria-expanded="true"] {
+    transform: translate3d(calc(var(--settings-panel-width) + var(--settings-panel-offset) - 20px), -50%, 0);
+}
+
+@media (max-width: 1024px) {
+    :root {
+        --settings-panel-width: 320px;
+    }
+}
+
+@media (max-width: 768px) {
+    :root {
+        --settings-panel-width: 300px;
+        --settings-panel-offset: 16px;
+    }
+
+    .scene-display {
+        border-radius: 26px;
+        padding: clamp(1.75rem, 6vw, 2.75rem);
+    }
+
+    .settings-panel-toggle[aria-expanded="true"] {
+        transform: translate3d(calc(var(--settings-panel-width) + var(--settings-panel-offset) - 12px), -50%, 0);
+    }
+}
+
+@media (max-width: 640px) {
+    :root {
+        --settings-panel-width: calc(100vw - 24px);
+        --settings-panel-offset: 12px;
+    }
+
+    .settings-panel {
+        border-radius: 18px;
+    }
+
+    .settings-panel-toggle {
+        top: auto;
+        bottom: 12px;
+        transform: translate3d(0, 0, 0);
+        left: 50%;
+        border-radius: 18px;
+    }
+
+    .settings-panel-toggle[aria-expanded="true"] {
+        transform: translate3d(-50%, 0, 0);
+    }
+}

--- a/dnd/js/chat-panel.js
+++ b/dnd/js/chat-panel.js
@@ -2,6 +2,9 @@
     const FETCH_INTERVAL_MS = 2500;
     const MAX_MESSAGES = 100;
     let escapeListenerAttached = false;
+    const CHAT_ENDPOINT = (typeof window !== 'undefined' && window.chatHandlerUrl)
+        ? window.chatHandlerUrl
+        : 'chat_handler.php';
 
     function initChatPanel(isGM, currentUser) {
         const panel = document.getElementById('chat-panel');
@@ -1220,7 +1223,7 @@
                 params.append('messageId', message.id);
                 params.append('status', status);
 
-                const response = await fetch('chat_handler.php', {
+                const response = await fetch(CHAT_ENDPOINT, {
                     method: 'POST',
                     headers: {
                         'Content-Type': 'application/x-www-form-urlencoded'
@@ -1378,7 +1381,7 @@
                     params.append('since', latestServerTimestamp);
                 }
 
-                const response = await fetch('chat_handler.php', {
+                const response = await fetch(CHAT_ENDPOINT, {
                     method: 'POST',
                     headers: {
                         'Content-Type': 'application/x-www-form-urlencoded'
@@ -1410,7 +1413,7 @@
             const params = new URLSearchParams();
             params.append('action', 'chat_clear');
 
-            const response = await fetch('chat_handler.php', {
+            const response = await fetch(CHAT_ENDPOINT, {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/x-www-form-urlencoded'
@@ -1656,7 +1659,7 @@
                     params.append('target', normalizedTarget);
                 }
 
-                const response = await fetch('chat_handler.php', {
+                const response = await fetch(CHAT_ENDPOINT, {
                     method: 'POST',
                     headers: {
                         'Content-Type': 'application/x-www-form-urlencoded'
@@ -1740,7 +1743,7 @@
             formData.append('action', 'chat_upload');
             formData.append('file', file);
 
-            const response = await fetch('chat_handler.php', {
+            const response = await fetch(CHAT_ENDPOINT, {
                 method: 'POST',
                 body: formData
             });

--- a/dnd/js/vtt.js
+++ b/dnd/js/vtt.js
@@ -1,0 +1,389 @@
+(function () {
+    const SCENE_POLL_INTERVAL_MS = 5000;
+
+    function initVtt() {
+        const config = window.vttConfig || {};
+        const isGM = Boolean(config.isGM);
+        const currentUser = typeof config.currentUser === 'string' ? config.currentUser : '';
+        const scenes = Array.isArray(config.scenes) ? config.scenes : [];
+        const sceneEndpoint = typeof config.sceneEndpoint === 'string' && config.sceneEndpoint.trim() !== ''
+            ? config.sceneEndpoint
+            : 'scenes_handler.php';
+        const initialSceneId = typeof config.activeSceneId === 'string' ? config.activeSceneId : null;
+        const initialScene = (config.activeScene && typeof config.activeScene === 'object') ? config.activeScene : null;
+
+        if (typeof initChatPanel === 'function') {
+            initChatPanel(isGM, currentUser);
+        }
+
+        initSettingsPanel({
+            isGM,
+            scenes,
+            sceneEndpoint,
+            initialSceneId,
+            initialScene,
+        });
+    }
+
+    function initSettingsPanel(options) {
+        const config = Object.assign({
+            isGM: false,
+            scenes: [],
+            sceneEndpoint: 'scenes_handler.php',
+            initialSceneId: null,
+            initialScene: null,
+        }, options || {});
+
+        const panel = document.getElementById('settings-panel');
+        const toggleButton = document.getElementById('settings-panel-toggle');
+        const closeButton = document.getElementById('settings-panel-close');
+        const scenesToggle = document.getElementById('settings-scenes-toggle');
+        const scenesList = document.getElementById('settings-scenes-list');
+        const statusElement = document.getElementById('settings-scenes-status');
+        const sceneDisplay = document.getElementById('scene-display');
+        const sceneName = document.getElementById('scene-display-name');
+        const sceneDescription = document.getElementById('scene-display-description');
+
+        if (!panel || !toggleButton || !sceneDisplay || !sceneName || !sceneDescription) {
+            return;
+        }
+
+        const sceneButtons = scenesList ? Array.from(scenesList.querySelectorAll('[data-scene-id]')) : [];
+        const state = {
+            isGM: Boolean(config.isGM),
+            scenes: config.scenes.slice(),
+            activeSceneId: config.initialSceneId,
+            sceneEndpoint: config.sceneEndpoint,
+            pendingRequest: null,
+            pollingTimer: null,
+            isFetching: false,
+            initialSceneStyles: {
+                background: sceneDisplay.style.background || '',
+                borderColor: sceneDisplay.style.borderColor || '',
+                boxShadow: sceneDisplay.style.boxShadow || '',
+            },
+        };
+
+        let isPanelOpen = false;
+        applySceneToDisplay(config.initialScene || getSceneById(state.scenes, state.activeSceneId), true);
+        updateSceneButtons(state.activeSceneId);
+
+        toggleButton.addEventListener('click', function () {
+            if (isPanelOpen) {
+                closePanel();
+            } else {
+                openPanel();
+            }
+        });
+
+        if (closeButton) {
+            closeButton.addEventListener('click', function () {
+                closePanel();
+                toggleButton.focus();
+            });
+        }
+
+        document.addEventListener('keydown', function (event) {
+            if (event.key === 'Escape' && isPanelOpen) {
+                closePanel();
+                toggleButton.focus();
+            }
+        });
+
+        if (scenesToggle && scenesList) {
+            scenesToggle.addEventListener('click', function () {
+                const expanded = scenesToggle.getAttribute('aria-expanded') === 'true';
+                if (expanded) {
+                    scenesToggle.setAttribute('aria-expanded', 'false');
+                    scenesList.hidden = true;
+                } else {
+                    scenesToggle.setAttribute('aria-expanded', 'true');
+                    scenesList.hidden = false;
+                }
+            });
+        }
+
+        if (state.isGM && sceneButtons.length > 0) {
+            sceneButtons.forEach(function (button) {
+                button.addEventListener('click', function () {
+                    const sceneId = button.getAttribute('data-scene-id') || '';
+                    if (!sceneId) {
+                        return;
+                    }
+
+                    if (state.activeSceneId === sceneId) {
+                        setStatus('Scene already active.', 'info');
+                        return;
+                    }
+
+                    activateScene(sceneId);
+                });
+            });
+        }
+
+        startScenePolling();
+
+        function openPanel() {
+            panel.classList.add('settings-panel--open');
+            panel.classList.remove('settings-panel--closed');
+            panel.setAttribute('aria-hidden', 'false');
+            toggleButton.setAttribute('aria-expanded', 'true');
+            isPanelOpen = true;
+        }
+
+        function closePanel() {
+            panel.classList.remove('settings-panel--open');
+            panel.classList.add('settings-panel--closed');
+            panel.setAttribute('aria-hidden', 'true');
+            toggleButton.setAttribute('aria-expanded', 'false');
+            isPanelOpen = false;
+        }
+
+        function setStatus(message, type) {
+            if (!statusElement) {
+                return;
+            }
+
+            statusElement.textContent = message || '';
+            statusElement.dataset.state = type || '';
+            statusElement.classList.toggle('settings-panel__status--error', type === 'error');
+            statusElement.classList.toggle('settings-panel__status--success', type === 'success');
+        }
+
+        function activateScene(sceneId) {
+            if (state.pendingRequest) {
+                return;
+            }
+
+            const scene = getSceneById(state.scenes, sceneId);
+            setStatus(scene ? `Activating “${scene.name}”…` : 'Activating scene…', 'info');
+
+            state.pendingRequest = true;
+
+            const body = new URLSearchParams({
+                action: 'activate',
+                scene_id: sceneId,
+            });
+
+            fetch(state.sceneEndpoint, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8',
+                    'Accept': 'application/json',
+                },
+                body,
+            })
+                .then((response) => {
+                    if (!response.ok) {
+                        throw new Error('Server error');
+                    }
+                    return response.json();
+                })
+                .then((data) => {
+                    if (!data || data.success !== true || !data.active_scene_id) {
+                        throw new Error((data && data.error) || 'Unable to activate scene.');
+                    }
+                    state.activeSceneId = data.active_scene_id;
+                    applySceneToDisplay(data.scene || getSceneById(state.scenes, data.active_scene_id));
+                    updateSceneButtons(state.activeSceneId);
+                    setStatus(data.scene && data.scene.name ? `Activated “${data.scene.name}.”` : 'Scene activated.', 'success');
+                })
+                .catch((error) => {
+                    console.error(error);
+                    setStatus('Unable to update the scene. Please try again.', 'error');
+                })
+                .finally(() => {
+                    state.pendingRequest = false;
+                });
+        }
+
+        function updateSceneButtons(activeSceneId) {
+            if (!state.isGM || sceneButtons.length === 0) {
+                return;
+            }
+
+            sceneButtons.forEach(function (button) {
+                const buttonSceneId = button.getAttribute('data-scene-id');
+                const isActive = buttonSceneId && buttonSceneId === activeSceneId;
+                button.classList.toggle('scene-option--active', Boolean(isActive));
+            });
+        }
+
+        function applySceneToDisplay(scene, skipStatus) {
+            const fallbackDescription = 'When the GM activates a scene it will appear here for everyone at the table.';
+
+            if (scene && typeof scene === 'object') {
+                if (sceneName) {
+                    sceneName.textContent = scene.name || 'Untitled Scene';
+                }
+                if (sceneDescription) {
+                    sceneDescription.textContent = scene.description || fallbackDescription;
+                }
+                if (sceneDisplay) {
+                    sceneDisplay.setAttribute('data-scene-id', scene.id || '');
+                    if (scene.accent) {
+                        applySceneAccent(scene.accent);
+                        sceneDisplay.setAttribute('data-scene-accent', scene.accent);
+                    } else {
+                        resetSceneAccent();
+                        sceneDisplay.removeAttribute('data-scene-accent');
+                    }
+                }
+            } else {
+                if (sceneName) {
+                    sceneName.textContent = 'Waiting for the GM to pick a scene';
+                }
+                if (sceneDescription) {
+                    sceneDescription.textContent = fallbackDescription;
+                }
+                resetSceneAccent();
+                if (sceneDisplay) {
+                    sceneDisplay.removeAttribute('data-scene-accent');
+                    sceneDisplay.setAttribute('data-scene-id', '');
+                }
+            }
+
+            if (!skipStatus) {
+                setStatus('', '');
+            }
+        }
+
+        function applySceneAccent(accentHex) {
+            if (!sceneDisplay) {
+                return;
+            }
+
+            const accent = typeof accentHex === 'string' ? accentHex.trim() : '';
+            if (!accent) {
+                resetSceneAccent();
+                return;
+            }
+
+            sceneDisplay.style.borderColor = accent;
+            sceneDisplay.style.boxShadow = `0 32px 88px ${hexToRgba(accent, 0.35)}`;
+            sceneDisplay.style.background = `linear-gradient(135deg, ${hexToRgba(accent, 0.22)}, rgba(15, 23, 42, 0.92))`;
+        }
+
+        function resetSceneAccent() {
+            if (!sceneDisplay) {
+                return;
+            }
+            sceneDisplay.style.background = state.initialSceneStyles.background;
+            sceneDisplay.style.borderColor = state.initialSceneStyles.borderColor;
+            sceneDisplay.style.boxShadow = state.initialSceneStyles.boxShadow;
+        }
+
+        function startScenePolling() {
+            if (state.pollingTimer !== null) {
+                window.clearInterval(state.pollingTimer);
+            }
+            state.pollingTimer = window.setInterval(fetchActiveScene, SCENE_POLL_INTERVAL_MS);
+            fetchActiveScene();
+        }
+
+        function fetchActiveScene() {
+            if (state.isGM && state.pendingRequest) {
+                return;
+            }
+            if (state.isFetching) {
+                return;
+            }
+            state.isFetching = true;
+
+            const requestUrl = buildSceneEndpointUrl(state.sceneEndpoint);
+
+            fetch(requestUrl, {
+                method: 'GET',
+                headers: {
+                    'Accept': 'application/json',
+                },
+            })
+                .then((response) => {
+                    if (!response.ok) {
+                        throw new Error('Failed to fetch scene.');
+                    }
+                    return response.json();
+                })
+                .then((data) => {
+                    if (!data || data.success !== true) {
+                        throw new Error('Invalid scene response.');
+                    }
+                    if (typeof data.active_scene_id !== 'string') {
+                        return;
+                    }
+                    if (state.activeSceneId !== data.active_scene_id) {
+                        state.activeSceneId = data.active_scene_id;
+                        applySceneToDisplay(data.scene || getSceneById(state.scenes, state.activeSceneId));
+                        updateSceneButtons(state.activeSceneId);
+                        if (statusElement && !state.isGM) {
+                            statusElement.textContent = '';
+                        }
+                    } else if (data.scene) {
+                        applySceneToDisplay(data.scene, true);
+                    }
+                })
+                .catch((error) => {
+                    if (statusElement && !state.isGM) {
+                        statusElement.textContent = '';
+                    }
+                    if (window.console && typeof window.console.warn === 'function') {
+                        console.warn('Scene polling error:', error);
+                    }
+                })
+                .finally(() => {
+                    state.isFetching = false;
+                });
+        }
+
+        function buildSceneEndpointUrl(endpoint) {
+            const baseEndpoint = typeof endpoint === 'string' && endpoint.trim() !== ''
+                ? endpoint
+                : 'scenes_handler.php';
+
+            if (typeof URL === 'function') {
+                try {
+                    const url = new URL(baseEndpoint, window.location.href);
+                    url.searchParams.set('action', 'get_active');
+                    return url.toString();
+                } catch (error) {
+                    // fall back to manual concatenation below
+                }
+            }
+
+            const separator = baseEndpoint.indexOf('?') >= 0 ? '&' : '?';
+            return `${baseEndpoint}${separator}action=get_active`;
+        }
+    }
+
+    function getSceneById(scenes, sceneId) {
+        if (!Array.isArray(scenes) || !sceneId) {
+            return null;
+        }
+        return scenes.find(function (scene) {
+            return scene && typeof scene === 'object' && scene.id === sceneId;
+        }) || null;
+    }
+
+    function hexToRgba(hex, alpha) {
+        const trimmed = typeof hex === 'string' ? hex.trim().replace(/^#/, '') : '';
+        if (trimmed.length === 3) {
+            const r = trimmed[0];
+            const g = trimmed[1];
+            const b = trimmed[2];
+            return `rgba(${parseInt(r + r, 16)}, ${parseInt(g + g, 16)}, ${parseInt(b + b, 16)}, ${typeof alpha === 'number' ? alpha : 1})`;
+        }
+        if (trimmed.length === 6) {
+            const r = parseInt(trimmed.slice(0, 2), 16);
+            const g = parseInt(trimmed.slice(2, 4), 16);
+            const b = parseInt(trimmed.slice(4, 6), 16);
+            return `rgba(${r}, ${g}, ${b}, ${typeof alpha === 'number' ? alpha : 1})`;
+        }
+        return `rgba(56, 189, 248, ${typeof alpha === 'number' ? alpha : 1})`;
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', initVtt);
+    } else {
+        initVtt();
+    }
+})();

--- a/dnd/vtt/index.php
+++ b/dnd/vtt/index.php
@@ -10,83 +10,217 @@ if (!isset($_SESSION['logged_in']) || $_SESSION['logged_in'] !== true) {
 
 $user = $_SESSION['user'] ?? 'Adventurer';
 $isGm = strtolower($user) === 'gm';
+
+$chatParticipantsMap = require __DIR__ . '/../includes/chat_participants.php';
+$chatParticipantList = [];
+foreach ($chatParticipantsMap as $participantId => $participantLabel) {
+    $chatParticipantList[] = [
+        'id' => $participantId,
+        'label' => $participantLabel,
+    ];
+}
+
+$scenes = require __DIR__ . '/scenes.php';
+if (!is_array($scenes)) {
+    $scenes = [];
+}
+
+$sceneLookup = [];
+foreach ($scenes as $scene) {
+    if (!is_array($scene) || !isset($scene['id'])) {
+        continue;
+    }
+    $sceneLookup[$scene['id']] = $scene;
+}
+
+$defaultSceneId = null;
+if (!empty($scenes)) {
+    $firstScene = reset($scenes);
+    if (is_array($firstScene) && isset($firstScene['id'])) {
+        $defaultSceneId = $firstScene['id'];
+    }
+}
+
+$sceneStateFile = __DIR__ . '/../data/vtt_active_scene.json';
+$sceneStateDir = dirname($sceneStateFile);
+if (!is_dir($sceneStateDir)) {
+    mkdir($sceneStateDir, 0755, true);
+}
+
+$activeSceneId = $defaultSceneId;
+if (file_exists($sceneStateFile)) {
+    $rawSceneState = file_get_contents($sceneStateFile);
+    $decodedSceneState = json_decode($rawSceneState, true);
+    if (is_array($decodedSceneState) && isset($decodedSceneState['active_scene_id'])) {
+        $storedSceneId = $decodedSceneState['active_scene_id'];
+        if (isset($sceneLookup[$storedSceneId])) {
+            $activeSceneId = $storedSceneId;
+        }
+    }
+} elseif ($defaultSceneId !== null) {
+    file_put_contents(
+        $sceneStateFile,
+        json_encode(['active_scene_id' => $defaultSceneId], JSON_PRETTY_PRINT),
+        LOCK_EX
+    );
+}
+
+if ($activeSceneId === null && !empty($sceneLookup)) {
+    $activeSceneId = array_key_first($sceneLookup);
+}
+
+$activeScene = $activeSceneId !== null && isset($sceneLookup[$activeSceneId])
+    ? $sceneLookup[$activeSceneId]
+    : null;
+$activeSceneAccent = is_array($activeScene) && isset($activeScene['accent'])
+    ? (string) $activeScene['accent']
+    : '';
+
+$vttConfig = [
+    'isGM' => $isGm,
+    'currentUser' => $user,
+    'scenes' => array_values($scenes),
+    'activeSceneId' => $activeSceneId,
+    'activeScene' => $activeScene,
+    'sceneEndpoint' => 'scenes_handler.php',
+];
 ?>
 <!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Virtual Tabletop Placeholder</title>
-    <style>
-        body {
-            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-            background: #111827;
-            color: #f9fafb;
-            margin: 0;
-            min-height: 100vh;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-        }
-
-        .placeholder-card {
-            background: rgba(30, 41, 59, 0.9);
-            border: 1px solid rgba(148, 163, 184, 0.3);
-            border-radius: 16px;
-            padding: 3rem;
-            max-width: 520px;
-            text-align: center;
-            box-shadow: 0 20px 40px rgba(15, 23, 42, 0.45);
-        }
-
-        .placeholder-card h1 {
-            margin-top: 0;
-            font-size: 2.25rem;
-            letter-spacing: 0.04em;
-            text-transform: uppercase;
-        }
-
-        .placeholder-card p {
-            font-size: 1.05rem;
-            line-height: 1.6;
-            color: #cbd5f5;
-        }
-
-        .placeholder-card .badge {
-            display: inline-block;
-            margin-bottom: 1.5rem;
-            padding: 0.35rem 1rem;
-            border-radius: 999px;
-            background: rgba(59, 130, 246, 0.2);
-            color: #93c5fd;
-            font-size: 0.85rem;
-            letter-spacing: 0.08em;
-            text-transform: uppercase;
-        }
-
-        .placeholder-card a {
-            color: #38bdf8;
-            text-decoration: none;
-            font-weight: 600;
-        }
-
-        .placeholder-card a:hover,
-        .placeholder-card a:focus {
-            text-decoration: underline;
-        }
-    </style>
+    <title>Virtual Tabletop</title>
+    <link rel="stylesheet" href="../css/style.css">
+    <link rel="stylesheet" href="../css/vtt.css">
 </head>
-<body>
-    <div class="placeholder-card">
-        <div class="badge"><?php echo $isGm ? 'GM Preview' : 'Player Preview'; ?></div>
-        <h1>VTT Coming Soon</h1>
-        <p>
-            This space will soon transform into the fully featured Virtual Tabletop experience
-            for your Strixhaven adventures. Stay tuned for maps, tokens, interactive combat, and more!
-        </p>
-        <p>
-            Need to get back? <a href="../dashboard.php" target="_self">Return to the Dashboard</a>.
-        </p>
+<body class="vtt-body">
+    <div class="vtt-container">
+        <main class="vtt-main" role="main">
+            <div
+                id="scene-display"
+                class="scene-display"
+                data-scene-id="<?php echo htmlspecialchars($activeSceneId ?? '', ENT_QUOTES); ?>"
+                data-scene-accent="<?php echo htmlspecialchars($activeSceneAccent, ENT_QUOTES); ?>"
+            >
+                <div class="scene-display__meta">
+                    <span class="scene-display__label">Active Scene</span>
+                    <?php if ($isGm): ?>
+                        <span class="scene-display__badge">GM View</span>
+                    <?php else: ?>
+                        <span class="scene-display__badge">Player View</span>
+                    <?php endif; ?>
+                </div>
+                <h1 id="scene-display-name" class="scene-display__name">
+                    <?php echo htmlspecialchars($activeScene['name'] ?? 'Waiting for the GM to pick a scene', ENT_QUOTES); ?>
+                </h1>
+                <p id="scene-display-description" class="scene-display__description">
+                    <?php
+                    if ($activeScene && isset($activeScene['description'])) {
+                        echo htmlspecialchars($activeScene['description'], ENT_QUOTES);
+                    } else {
+                        echo 'When the GM activates a scene it will appear here for everyone at the table.';
+                    }
+                    ?>
+                </p>
+            </div>
+        </main>
     </div>
+
+    <div id="settings-panel" class="settings-panel settings-panel--closed" aria-hidden="true">
+        <div class="settings-panel__header">
+            <h2 class="settings-panel__title">Tabletop Settings</h2>
+            <button type="button" id="settings-panel-close" class="settings-panel__close" aria-label="Close settings">&times;</button>
+        </div>
+        <div class="settings-panel__content">
+            <?php if ($isGm && !empty($sceneLookup)): ?>
+                <div class="settings-panel__group settings-panel__group--scenes">
+                    <button
+                        type="button"
+                        id="settings-scenes-toggle"
+                        class="settings-panel__primary-action"
+                        aria-expanded="true"
+                        aria-controls="settings-scenes-list"
+                    >
+                        Scenes
+                    </button>
+                    <div id="settings-scenes-list" class="settings-panel__scenes">
+                        <?php foreach ($scenes as $scene): ?>
+                            <?php
+                            $sceneId = $scene['id'] ?? '';
+                            if ($sceneId === '') {
+                                continue;
+                            }
+                            $isActive = $sceneId === $activeSceneId;
+                            $sceneAccent = isset($scene['accent']) ? (string) $scene['accent'] : '';
+                            ?>
+                            <button
+                                type="button"
+                                class="scene-option<?php echo $isActive ? ' scene-option--active' : ''; ?>"
+                                data-scene-id="<?php echo htmlspecialchars($sceneId, ENT_QUOTES); ?>"
+                                data-scene-accent="<?php echo htmlspecialchars($sceneAccent, ENT_QUOTES); ?>"
+                            >
+                                <span class="scene-option__name"><?php echo htmlspecialchars($scene['name'] ?? 'Untitled Scene', ENT_QUOTES); ?></span>
+                                <?php if (!empty($scene['description'])): ?>
+                                    <span class="scene-option__description"><?php echo htmlspecialchars($scene['description'], ENT_QUOTES); ?></span>
+                                <?php endif; ?>
+                            </button>
+                        <?php endforeach; ?>
+                    </div>
+                    <p id="settings-scenes-status" class="settings-panel__status" role="status" aria-live="polite"></p>
+                </div>
+            <?php else: ?>
+                <div class="settings-panel__group settings-panel__group--scenes-info">
+                    <h3 class="settings-panel__group-title">Scenes</h3>
+                    <p class="settings-panel__text">The GM controls which scene is active. Updates will appear automatically when the GM makes a change.</p>
+                </div>
+            <?php endif; ?>
+            <div class="settings-panel__group">
+                <h3 class="settings-panel__group-title">More Settings Coming Soon</h3>
+                <p class="settings-panel__text">We&rsquo;re just getting started. Future updates will unlock map uploads, tokens, and other table tools.</p>
+            </div>
+        </div>
+    </div>
+    <button
+        id="settings-panel-toggle"
+        class="settings-panel-toggle"
+        type="button"
+        aria-expanded="false"
+        aria-controls="settings-panel"
+    >
+        Settings
+    </button>
+
+    <div id="chat-panel" class="chat-panel chat-panel--closed" aria-hidden="true">
+        <div class="chat-panel__header">
+            <h3 class="chat-panel__title">Table Chat</h3>
+            <div class="chat-panel__actions">
+                <?php if ($isGm): ?>
+                    <button type="button" id="chat-clear-btn" class="chat-panel__clear">Clear Chat</button>
+                <?php endif; ?>
+                <button type="button" id="chat-panel-close" class="chat-panel__close" aria-label="Close chat">&times;</button>
+            </div>
+        </div>
+        <div id="chat-message-list" class="chat-panel__history" role="log" aria-live="polite"></div>
+        <div id="chat-whisper-targets" class="chat-panel__whispers" role="group" aria-label="Whisper targets"></div>
+        <form id="chat-input-form" class="chat-panel__input" autocomplete="off">
+            <textarea id="chat-input" class="chat-panel__textarea" rows="2" placeholder="Type a message..."></textarea>
+            <button type="submit" id="chat-send-btn" class="chat-panel__send">Send</button>
+        </form>
+    </div>
+    <button id="chat-panel-toggle" class="chat-panel-toggle" type="button" aria-expanded="false" aria-controls="chat-panel">
+        Open Chat
+    </button>
+    <div id="chat-drop-target" class="chat-drop-target" hidden aria-hidden="true">Drop images or image links to share</div>
+    <div id="chat-whisper-popouts" class="chat-whisper-popouts" aria-live="polite" aria-atomic="false"></div>
+    <div id="chat-whisper-alerts" class="chat-whisper-alerts" aria-live="assertive" aria-atomic="true"></div>
+
+    <script>
+        window.chatParticipants = <?php echo json_encode($chatParticipantList, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE); ?>;
+        window.chatHandlerUrl = '../chat_handler.php';
+        window.vttConfig = <?php echo json_encode($vttConfig, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE); ?>;
+    </script>
+    <script src="../js/chat-panel.js"></script>
+    <script src="../js/vtt.js"></script>
 </body>
 </html>

--- a/dnd/vtt/scenes.php
+++ b/dnd/vtt/scenes.php
@@ -1,0 +1,27 @@
+<?php
+return [
+    [
+        'id' => 'mystic-archives',
+        'name' => 'Mystic Archives',
+        'description' => 'Stacks of arcane tomes glow in the vaulted study hall as candles drift lazily overhead.',
+        'accent' => '#7c3aed',
+    ],
+    [
+        'id' => 'detention-bog',
+        'name' => 'Detention Bog',
+        'description' => 'Mist curls above murky waters while will-o’-wisps circle the detainment platforms.',
+        'accent' => '#0ea5e9',
+    ],
+    [
+        'id' => 'lorehold-forge',
+        'name' => 'Lorehold Forge',
+        'description' => 'Ancient statues spark to life beside roaring furnaces and floating chisels.',
+        'accent' => '#f97316',
+    ],
+    [
+        'id' => 'first-year-quad',
+        'name' => 'First-Year Quad',
+        'description' => 'Lush lawns and vibrant banners welcome new students to the heart of campus.',
+        'accent' => '#22c55e',
+    ],
+];

--- a/dnd/vtt/scenes_handler.php
+++ b/dnd/vtt/scenes_handler.php
@@ -1,0 +1,161 @@
+<?php
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
+
+header('Content-Type: application/json');
+
+if (!isset($_SESSION['logged_in']) || $_SESSION['logged_in'] !== true) {
+    http_response_code(403);
+    echo json_encode(['success' => false, 'error' => 'Authentication required.']);
+    exit;
+}
+
+$user = $_SESSION['user'] ?? '';
+$isGm = strtolower($user) === 'gm';
+
+$scenes = require __DIR__ . '/scenes.php';
+if (!is_array($scenes)) {
+    $scenes = [];
+}
+
+$sceneLookup = [];
+$defaultSceneId = null;
+foreach ($scenes as $scene) {
+    if (!is_array($scene) || !isset($scene['id'])) {
+        continue;
+    }
+    $sceneId = (string) $scene['id'];
+    if ($sceneId === '') {
+        continue;
+    }
+    if ($defaultSceneId === null) {
+        $defaultSceneId = $sceneId;
+    }
+    $sceneLookup[$sceneId] = $scene;
+}
+
+$sceneStateFile = __DIR__ . '/../data/vtt_active_scene.json';
+ensureSceneStateFile($sceneStateFile, $defaultSceneId);
+
+$action = $_REQUEST['action'] ?? 'get_active';
+$action = is_string($action) ? strtolower(trim($action)) : 'get_active';
+
+switch ($action) {
+    case 'activate':
+        if (!$isGm) {
+            http_response_code(403);
+            echo json_encode(['success' => false, 'error' => 'Only the GM can activate scenes.']);
+            exit;
+        }
+
+        $sceneId = $_POST['scene_id'] ?? '';
+        $sceneId = is_string($sceneId) ? trim($sceneId) : '';
+        if ($sceneId === '' || !isset($sceneLookup[$sceneId])) {
+            http_response_code(400);
+            echo json_encode(['success' => false, 'error' => 'Invalid scene identifier.']);
+            exit;
+        }
+
+        if (!saveActiveSceneId($sceneStateFile, $sceneId)) {
+            http_response_code(500);
+            echo json_encode(['success' => false, 'error' => 'Unable to update the active scene.']);
+            exit;
+        }
+
+        echo json_encode([
+            'success' => true,
+            'active_scene_id' => $sceneId,
+            'scene' => $sceneLookup[$sceneId],
+        ]);
+        exit;
+
+    case 'get_active':
+    default:
+        $activeSceneId = loadActiveSceneId($sceneStateFile, $defaultSceneId, $sceneLookup);
+        $scene = $activeSceneId !== null && isset($sceneLookup[$activeSceneId])
+            ? $sceneLookup[$activeSceneId]
+            : null;
+
+        echo json_encode([
+            'success' => true,
+            'active_scene_id' => $activeSceneId,
+            'scene' => $scene,
+        ]);
+        exit;
+}
+
+function ensureSceneStateFile($filePath, $defaultSceneId)
+{
+    $directory = dirname($filePath);
+    if (!is_dir($directory)) {
+        mkdir($directory, 0755, true);
+    }
+
+    if (!file_exists($filePath) && $defaultSceneId !== null) {
+        file_put_contents(
+            $filePath,
+            json_encode(['active_scene_id' => $defaultSceneId], JSON_PRETTY_PRINT),
+            LOCK_EX
+        );
+    }
+}
+
+function loadActiveSceneId($filePath, $defaultSceneId, array $sceneLookup)
+{
+    if (!file_exists($filePath)) {
+        return $defaultSceneId;
+    }
+
+    $fp = fopen($filePath, 'r');
+    if ($fp === false) {
+        return $defaultSceneId;
+    }
+
+    $content = '';
+    if (flock($fp, LOCK_SH)) {
+        $content = stream_get_contents($fp);
+        flock($fp, LOCK_UN);
+    }
+    fclose($fp);
+
+    $data = json_decode($content, true);
+    if (is_array($data) && isset($data['active_scene_id'])) {
+        $sceneId = (string) $data['active_scene_id'];
+        if ($sceneId !== '' && isset($sceneLookup[$sceneId])) {
+            return $sceneId;
+        }
+    }
+
+    if ($defaultSceneId !== null) {
+        saveActiveSceneId($filePath, $defaultSceneId);
+    }
+
+    return $defaultSceneId;
+}
+
+function saveActiveSceneId($filePath, $sceneId)
+{
+    $directory = dirname($filePath);
+    if (!is_dir($directory)) {
+        mkdir($directory, 0755, true);
+    }
+
+    $fp = fopen($filePath, 'c+');
+    if ($fp === false) {
+        return false;
+    }
+
+    $result = false;
+    if (flock($fp, LOCK_EX)) {
+        ftruncate($fp, 0);
+        rewind($fp);
+        $bytesWritten = fwrite($fp, json_encode(['active_scene_id' => $sceneId], JSON_PRETTY_PRINT));
+        fflush($fp);
+        flock($fp, LOCK_UN);
+        $result = $bytesWritten !== false;
+    }
+
+    fclose($fp);
+    return $result;
+}


### PR DESCRIPTION
## Summary
- replace the VTT placeholder with a full layout that includes the scene display, a collapsible settings drawer, and the shared table chat
- connect the VTT chat UI to the existing dashboard chat handler and add dedicated styling/behaviour for the new panels
- implement GM-only scene activation with polling, backed by a new scenes data file and PHP handler

## Testing
- php -l dnd/vtt/index.php
- php -l dnd/vtt/scenes_handler.php

------
https://chatgpt.com/codex/tasks/task_e_68db40468fa48327b20d592dbf0611d6