### PR TITLE
feat(vtt): add scene folders and map management

### DIFF
--- a/dnd/css/vtt.css
+++ b/dnd/css/vtt.css
@@ -80,6 +80,56 @@
     color: rgba(226, 232, 240, 0.88);
 }
 
+.scene-display__map {
+    margin-top: 2rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.scene-display__map-inner {
+    position: relative;
+    display: inline-flex;
+    border-radius: 18px;
+    overflow: hidden;
+    background: rgba(15, 23, 42, 0.75);
+    border: 1px solid rgba(148, 163, 184, 0.35);
+    box-shadow: 0 18px 48px rgba(15, 23, 42, 0.55);
+}
+
+.scene-display__map-image {
+    display: block;
+    max-width: min(100%, 720px);
+    height: auto;
+    object-fit: cover;
+}
+
+.scene-display__map-image--hidden {
+    display: none;
+}
+
+.scene-display__map-grid {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    background-image: linear-gradient(to right, rgba(226, 232, 240, 0.12) 1px, transparent 1px),
+        linear-gradient(to bottom, rgba(226, 232, 240, 0.12) 1px, transparent 1px);
+    background-size: var(--grid-size, 50px) var(--grid-size, 50px);
+    mix-blend-mode: screen;
+}
+
+.scene-display__map-empty {
+    margin: 0;
+    font-size: 0.95rem;
+    color: rgba(226, 232, 240, 0.7);
+}
+
+.scene-display__map--empty .scene-display__map-inner {
+    min-height: 220px;
+    align-items: center;
+    justify-content: center;
+}
+
 .settings-panel {
     position: fixed;
     top: var(--settings-panel-offset);
@@ -196,6 +246,229 @@
     flex-direction: column;
     gap: 0.75rem;
     padding: 0.5rem 0 0.25rem;
+}
+
+.scene-management {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.scene-management__folders {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+}
+
+.scene-folder__button {
+    padding: 0.45rem 0.9rem;
+    border-radius: 999px;
+    border: 1px solid rgba(148, 163, 184, 0.3);
+    background: rgba(30, 41, 59, 0.7);
+    color: rgba(226, 232, 240, 0.85);
+    font-size: 0.85rem;
+    letter-spacing: 0.04em;
+    cursor: pointer;
+    transition: background 160ms ease, border-color 160ms ease, color 160ms ease;
+}
+
+.scene-folder__button:hover,
+.scene-folder__button:focus {
+    background: rgba(56, 189, 248, 0.18);
+    border-color: rgba(56, 189, 248, 0.6);
+    color: #fff;
+}
+
+.scene-folder__button--active {
+    background: rgba(56, 189, 248, 0.24);
+    border-color: rgba(56, 189, 248, 0.75);
+    color: #fff;
+    box-shadow: 0 10px 24px rgba(56, 189, 248, 0.2);
+}
+
+.scene-management__scene-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.scene-management__empty {
+    margin: 0;
+    font-size: 0.9rem;
+    color: rgba(226, 232, 240, 0.7);
+}
+
+.scene-management__add-folder,
+.scene-management__add-scene {
+    align-self: flex-start;
+    padding: 0.45rem 0.9rem;
+    border-radius: 10px;
+    border: 1px solid rgba(148, 163, 184, 0.3);
+    background: rgba(30, 41, 59, 0.7);
+    color: rgba(226, 232, 240, 0.85);
+    font-size: 0.85rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    cursor: pointer;
+    transition: background 160ms ease, border-color 160ms ease, color 160ms ease;
+}
+
+.scene-management__add-folder:hover,
+.scene-management__add-folder:focus,
+.scene-management__add-scene:hover,
+.scene-management__add-scene:focus {
+    background: rgba(56, 189, 248, 0.18);
+    border-color: rgba(56, 189, 248, 0.6);
+    color: #fff;
+}
+
+.scene-management__map-settings {
+    padding: 1rem;
+    border-radius: 16px;
+    border: 1px solid rgba(148, 163, 184, 0.25);
+    background: rgba(15, 23, 42, 0.65);
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.scene-management__map-title {
+    margin: 0;
+    font-size: 0.9rem;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: rgba(226, 232, 240, 0.7);
+}
+
+.scene-management__field {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+}
+
+.scene-management__label {
+    font-size: 0.85rem;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    color: rgba(226, 232, 240, 0.65);
+}
+
+.scene-management__file {
+    font-size: 0.9rem;
+    color: rgba(226, 232, 240, 0.85);
+}
+
+.scene-management__file-name {
+    margin: 0;
+    font-size: 0.85rem;
+    color: rgba(226, 232, 240, 0.7);
+}
+
+.scene-management__grid-controls {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.scene-management__grid-range {
+    flex: 1;
+}
+
+.scene-management__grid-value {
+    width: 70px;
+    padding: 0.35rem 0.5rem;
+    border-radius: 8px;
+    border: 1px solid rgba(148, 163, 184, 0.4);
+    background: rgba(15, 23, 42, 0.6);
+    color: rgba(226, 232, 240, 0.85);
+}
+
+.scene-management__grid-unit {
+    font-size: 0.8rem;
+    color: rgba(226, 232, 240, 0.6);
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+}
+
+.scene-card {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    padding: 0.75rem 0.9rem;
+    border-radius: 14px;
+    border: 1px solid rgba(148, 163, 184, 0.25);
+    background: rgba(30, 41, 59, 0.7);
+    transition: border-color 160ms ease, background 160ms ease, box-shadow 160ms ease;
+}
+
+.scene-card--selected {
+    border-color: rgba(56, 189, 248, 0.65);
+    background: rgba(56, 189, 248, 0.18);
+    box-shadow: 0 12px 26px rgba(56, 189, 248, 0.18);
+}
+
+.scene-card__body {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    background: none;
+    border: none;
+    color: inherit;
+    font-size: 0.95rem;
+    font-weight: 600;
+    cursor: pointer;
+}
+
+.scene-card__badge {
+    padding: 0.2rem 0.55rem;
+    border-radius: 999px;
+    background: rgba(56, 189, 248, 0.2);
+    border: 1px solid rgba(56, 189, 248, 0.5);
+    font-size: 0.7rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+}
+
+.scene-card__actions {
+    display: flex;
+    gap: 0.5rem;
+}
+
+.scene-card__action {
+    padding: 0.35rem 0.75rem;
+    border-radius: 8px;
+    border: 1px solid rgba(148, 163, 184, 0.3);
+    background: rgba(15, 23, 42, 0.6);
+    color: rgba(226, 232, 240, 0.85);
+    font-size: 0.8rem;
+    letter-spacing: 0.05em;
+    cursor: pointer;
+    transition: background 160ms ease, border-color 160ms ease, color 160ms ease;
+}
+
+.scene-card__action:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+}
+
+.scene-card__action--primary:hover,
+.scene-card__action--primary:focus {
+    background: rgba(56, 189, 248, 0.2);
+    border-color: rgba(56, 189, 248, 0.6);
+    color: #fff;
+}
+
+.scene-card__action--danger {
+    border-color: rgba(248, 113, 113, 0.35);
+    color: rgba(248, 113, 113, 0.85);
+}
+
+.scene-card__action--danger:hover,
+.scene-card__action--danger:focus {
+    background: rgba(248, 113, 113, 0.2);
+    border-color: rgba(248, 113, 113, 0.6);
+    color: #fff;
 }
 
 .scene-option {

--- a/dnd/data/vtt_scenes.json
+++ b/dnd/data/vtt_scenes.json
@@ -1,0 +1,4 @@
+{
+    "folders": [],
+    "rootScenes": []
+}

--- a/dnd/images/vtt/maps/.gitignore
+++ b/dnd/images/vtt/maps/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/dnd/vtt/scenes.php
+++ b/dnd/vtt/scenes.php
@@ -1,27 +1,7 @@
 <?php
-return [
-    [
-        'id' => 'mystic-archives',
-        'name' => 'Mystic Archives',
-        'description' => 'Stacks of arcane tomes glow in the vaulted study hall as candles drift lazily overhead.',
-        'accent' => '#7c3aed',
-    ],
-    [
-        'id' => 'detention-bog',
-        'name' => 'Detention Bog',
-        'description' => 'Mist curls above murky waters while will-o’-wisps circle the detainment platforms.',
-        'accent' => '#0ea5e9',
-    ],
-    [
-        'id' => 'lorehold-forge',
-        'name' => 'Lorehold Forge',
-        'description' => 'Ancient statues spark to life beside roaring furnaces and floating chisels.',
-        'accent' => '#f97316',
-    ],
-    [
-        'id' => 'first-year-quad',
-        'name' => 'First-Year Quad',
-        'description' => 'Lush lawns and vibrant banners welcome new students to the heart of campus.',
-        'accent' => '#22c55e',
-    ],
-];
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/scenes_repository.php';
+
+return loadScenesData();

--- a/dnd/vtt/scenes_handler.php
+++ b/dnd/vtt/scenes_handler.php
@@ -11,29 +11,22 @@ if (!isset($_SESSION['logged_in']) || $_SESSION['logged_in'] !== true) {
     exit;
 }
 
+require_once __DIR__ . '/scenes_repository.php';
+
 $user = $_SESSION['user'] ?? '';
-$isGm = strtolower($user) === 'gm';
+$isGm = strtolower((string) $user) === 'gm';
 
-$scenes = require __DIR__ . '/scenes.php';
-if (!is_array($scenes)) {
-    $scenes = [];
-}
-
+$sceneData = loadScenesData();
+$scenes = flattenScenes($sceneData);
 $sceneLookup = [];
-$defaultSceneId = null;
 foreach ($scenes as $scene) {
     if (!is_array($scene) || !isset($scene['id'])) {
         continue;
     }
-    $sceneId = (string) $scene['id'];
-    if ($sceneId === '') {
-        continue;
-    }
-    if ($defaultSceneId === null) {
-        $defaultSceneId = $sceneId;
-    }
-    $sceneLookup[$sceneId] = $scene;
+    $sceneLookup[$scene['id']] = $scene;
 }
+
+$defaultSceneId = getFirstSceneId($sceneData);
 
 $sceneStateFile = __DIR__ . '/../data/vtt_active_scene.json';
 ensureSceneStateFile($sceneStateFile, $defaultSceneId);
@@ -42,6 +35,252 @@ $action = $_REQUEST['action'] ?? 'get_active';
 $action = is_string($action) ? strtolower(trim($action)) : 'get_active';
 
 switch ($action) {
+    case 'list':
+        if (!$isGm) {
+            http_response_code(403);
+            echo json_encode(['success' => false, 'error' => 'Only the GM can manage scenes.']);
+            exit;
+        }
+
+        $activeSceneId = loadActiveSceneId($sceneStateFile, $defaultSceneId, $sceneLookup);
+        echo json_encode([
+            'success' => true,
+            'sceneData' => $sceneData,
+            'scenes' => array_values($scenes),
+            'active_scene_id' => $activeSceneId,
+        ]);
+        exit;
+
+    case 'create_folder':
+        if (!$isGm) {
+            http_response_code(403);
+            echo json_encode(['success' => false, 'error' => 'Only the GM can manage scenes.']);
+            exit;
+        }
+
+        $name = isset($_POST['name']) && is_string($_POST['name']) ? trim($_POST['name']) : '';
+        [$sceneData, $folder] = createFolder($sceneData, $name);
+        if (!saveScenesData($sceneData)) {
+            http_response_code(500);
+            echo json_encode(['success' => false, 'error' => 'Unable to save folder.']);
+            exit;
+        }
+
+        $scenes = flattenScenes($sceneData);
+        $sceneLookup = [];
+        foreach ($scenes as $scene) {
+            if (!is_array($scene) || !isset($scene['id'])) {
+                continue;
+            }
+            $sceneLookup[$scene['id']] = $scene;
+        }
+        $activeSceneId = loadActiveSceneId($sceneStateFile, $defaultSceneId, $sceneLookup);
+
+        echo json_encode([
+            'success' => true,
+            'folder' => $folder,
+            'sceneData' => $sceneData,
+            'scenes' => array_values($scenes),
+            'active_scene_id' => $activeSceneId,
+        ]);
+        exit;
+
+    case 'create_scene':
+        if (!$isGm) {
+            http_response_code(403);
+            echo json_encode(['success' => false, 'error' => 'Only the GM can manage scenes.']);
+            exit;
+        }
+
+        $folderId = isset($_POST['folder_id']) && is_string($_POST['folder_id']) ? trim($_POST['folder_id']) : null;
+        if ($folderId === '') {
+            $folderId = null;
+        }
+
+        $name = isset($_POST['name']) && is_string($_POST['name']) ? trim($_POST['name']) : null;
+
+        [$sceneData, $scene] = createScene($sceneData, $folderId, $name);
+        if (!saveScenesData($sceneData)) {
+            http_response_code(500);
+            echo json_encode(['success' => false, 'error' => 'Unable to save scene.']);
+            exit;
+        }
+
+        $defaultSceneId = getFirstSceneId($sceneData);
+        $scenes = flattenScenes($sceneData);
+        $sceneLookup = [];
+        foreach ($scenes as $item) {
+            if (!is_array($item) || !isset($item['id'])) {
+                continue;
+            }
+            $sceneLookup[$item['id']] = $item;
+        }
+
+        $activeSceneId = loadActiveSceneId($sceneStateFile, $defaultSceneId, $sceneLookup);
+        if ($activeSceneId === null) {
+            $firstSceneId = getFirstSceneId($sceneData);
+            if ($firstSceneId !== null) {
+                saveActiveSceneId($sceneStateFile, $firstSceneId);
+                $activeSceneId = $firstSceneId;
+            }
+        }
+
+        echo json_encode([
+            'success' => true,
+            'scene' => $scene,
+            'sceneData' => $sceneData,
+            'scenes' => array_values($scenes),
+            'active_scene_id' => $activeSceneId,
+        ]);
+        exit;
+
+    case 'delete_scene':
+        if (!$isGm) {
+            http_response_code(403);
+            echo json_encode(['success' => false, 'error' => 'Only the GM can manage scenes.']);
+            exit;
+        }
+
+        $sceneId = isset($_POST['scene_id']) && is_string($_POST['scene_id']) ? trim($_POST['scene_id']) : '';
+        if ($sceneId === '') {
+            http_response_code(400);
+            echo json_encode(['success' => false, 'error' => 'Invalid scene identifier.']);
+            exit;
+        }
+
+        [$sceneData, $removed] = deleteScene($sceneData, $sceneId);
+        if (!$removed) {
+            http_response_code(404);
+            echo json_encode(['success' => false, 'error' => 'Scene not found.']);
+            exit;
+        }
+
+        if (!saveScenesData($sceneData)) {
+            http_response_code(500);
+            echo json_encode(['success' => false, 'error' => 'Unable to remove scene.']);
+            exit;
+        }
+
+        $defaultSceneId = getFirstSceneId($sceneData);
+        $scenes = flattenScenes($sceneData);
+        $sceneLookup = [];
+        foreach ($scenes as $item) {
+            if (!is_array($item) || !isset($item['id'])) {
+                continue;
+            }
+            $sceneLookup[$item['id']] = $item;
+        }
+
+        $activeSceneId = loadActiveSceneId($sceneStateFile, $defaultSceneId, $sceneLookup);
+        if ($activeSceneId === $sceneId) {
+            $newSceneId = getFirstSceneId($sceneData);
+            if ($newSceneId !== null) {
+                saveActiveSceneId($sceneStateFile, $newSceneId);
+                $activeSceneId = $newSceneId;
+            } else {
+                saveActiveSceneId($sceneStateFile, '');
+                $activeSceneId = null;
+            }
+        }
+
+        echo json_encode([
+            'success' => true,
+            'sceneData' => $sceneData,
+            'scenes' => array_values($scenes),
+            'active_scene_id' => $activeSceneId,
+        ]);
+        exit;
+
+    case 'update_scene_map':
+        if (!$isGm) {
+            http_response_code(403);
+            echo json_encode(['success' => false, 'error' => 'Only the GM can manage scenes.']);
+            exit;
+        }
+
+        $sceneId = isset($_POST['scene_id']) && is_string($_POST['scene_id']) ? trim($_POST['scene_id']) : '';
+        if ($sceneId === '') {
+            http_response_code(400);
+            echo json_encode(['success' => false, 'error' => 'Invalid scene identifier.']);
+            exit;
+        }
+
+        $gridScale = null;
+        if (isset($_POST['grid_scale'])) {
+            $gridScale = filter_var($_POST['grid_scale'], FILTER_VALIDATE_INT);
+            if ($gridScale === false) {
+                $gridScale = null;
+            }
+        }
+
+        $imagePath = null;
+        if (!empty($_FILES['map_image']) && is_array($_FILES['map_image'])) {
+            $file = $_FILES['map_image'];
+            if (($file['error'] ?? UPLOAD_ERR_OK) !== UPLOAD_ERR_OK) {
+                http_response_code(400);
+                echo json_encode(['success' => false, 'error' => 'Unable to process uploaded image.']);
+                exit;
+            }
+
+            $originalName = $file['name'] ?? '';
+            $extension = sanitizeFileExtension($originalName);
+            if ($extension === '') {
+                http_response_code(400);
+                echo json_encode(['success' => false, 'error' => 'Unsupported image format.']);
+                exit;
+            }
+
+            ensureMapUploadDirectory();
+            try {
+                $random = bin2hex(random_bytes(4));
+            } catch (Throwable $exception) {
+                $random = uniqid();
+            }
+            $filename = sprintf('scene-%s-%s.%s', $sceneId, $random, $extension);
+            $destination = VTT_MAP_UPLOAD_DIR . '/' . $filename;
+            if (!move_uploaded_file($file['tmp_name'], $destination)) {
+                http_response_code(500);
+                echo json_encode(['success' => false, 'error' => 'Failed to store uploaded image.']);
+                exit;
+            }
+
+            $imagePath = buildMapImagePath($filename);
+        }
+
+        [$sceneData, $updatedScene] = updateSceneMap($sceneData, $sceneId, $imagePath, $gridScale);
+        if ($updatedScene === null) {
+            http_response_code(404);
+            echo json_encode(['success' => false, 'error' => 'Scene not found.']);
+            exit;
+        }
+
+        if (!saveScenesData($sceneData)) {
+            http_response_code(500);
+            echo json_encode(['success' => false, 'error' => 'Unable to update scene map.']);
+            exit;
+        }
+
+        $defaultSceneId = getFirstSceneId($sceneData);
+        $scenes = flattenScenes($sceneData);
+        $sceneLookup = [];
+        foreach ($scenes as $item) {
+            if (!is_array($item) || !isset($item['id'])) {
+                continue;
+            }
+            $sceneLookup[$item['id']] = $item;
+        }
+
+        $activeSceneId = loadActiveSceneId($sceneStateFile, $defaultSceneId, $sceneLookup);
+
+        echo json_encode([
+            'success' => true,
+            'scene' => $updatedScene,
+            'sceneData' => $sceneData,
+            'scenes' => array_values($scenes),
+            'active_scene_id' => $activeSceneId,
+        ]);
+        exit;
+
     case 'activate':
         if (!$isGm) {
             http_response_code(403);
@@ -122,7 +361,10 @@ function loadActiveSceneId($filePath, $defaultSceneId, array $sceneLookup)
     $data = json_decode($content, true);
     if (is_array($data) && isset($data['active_scene_id'])) {
         $sceneId = (string) $data['active_scene_id'];
-        if ($sceneId !== '' && isset($sceneLookup[$sceneId])) {
+        if ($sceneId === '') {
+            return null;
+        }
+        if (isset($sceneLookup[$sceneId])) {
             return $sceneId;
         }
     }

--- a/dnd/vtt/scenes_repository.php
+++ b/dnd/vtt/scenes_repository.php
@@ -1,0 +1,379 @@
+<?php
+
+declare(strict_types=1);
+
+const VTT_SCENES_FILE = __DIR__ . '/../data/vtt_scenes.json';
+const VTT_MAP_UPLOAD_DIR = __DIR__ . '/../images/vtt/maps';
+
+function loadScenesData(): array
+{
+    ensureScenesDataFile();
+
+    $content = @file_get_contents(VTT_SCENES_FILE);
+    if ($content === false) {
+        return [
+            'folders' => [],
+            'rootScenes' => [],
+        ];
+    }
+
+    $data = json_decode($content, true);
+    if (!is_array($data)) {
+        return [
+            'folders' => [],
+            'rootScenes' => [],
+        ];
+    }
+
+    $folders = [];
+    if (isset($data['folders']) && is_array($data['folders'])) {
+        foreach ($data['folders'] as $folder) {
+            if (!is_array($folder)) {
+                continue;
+            }
+            $folderId = isset($folder['id']) ? (string) $folder['id'] : '';
+            if ($folderId === '') {
+                $folderId = generateIdentifier('folder');
+            }
+            $folders[] = [
+                'id' => $folderId,
+                'name' => isset($folder['name']) ? (string) $folder['name'] : 'Untitled Folder',
+                'scenes' => normalizeScenesList($folder['scenes'] ?? []),
+            ];
+        }
+    }
+
+    $rootScenes = normalizeScenesList($data['rootScenes'] ?? []);
+
+    return [
+        'folders' => $folders,
+        'rootScenes' => $rootScenes,
+    ];
+}
+
+function saveScenesData(array $data): bool
+{
+    ensureScenesDataFile();
+
+    $payload = json_encode([
+        'folders' => $data['folders'] ?? [],
+        'rootScenes' => $data['rootScenes'] ?? [],
+    ], JSON_PRETTY_PRINT);
+
+    if ($payload === false) {
+        return false;
+    }
+
+    $fp = fopen(VTT_SCENES_FILE, 'c+');
+    if ($fp === false) {
+        return false;
+    }
+
+    $result = false;
+    if (flock($fp, LOCK_EX)) {
+        ftruncate($fp, 0);
+        rewind($fp);
+        $bytesWritten = fwrite($fp, $payload);
+        fflush($fp);
+        flock($fp, LOCK_UN);
+        $result = $bytesWritten !== false;
+    }
+
+    fclose($fp);
+    return $result;
+}
+
+function ensureScenesDataFile(): void
+{
+    $directory = dirname(VTT_SCENES_FILE);
+    if (!is_dir($directory)) {
+        mkdir($directory, 0755, true);
+    }
+
+    if (!file_exists(VTT_SCENES_FILE)) {
+        file_put_contents(
+            VTT_SCENES_FILE,
+            json_encode([
+                'folders' => [],
+                'rootScenes' => [],
+            ], JSON_PRETTY_PRINT),
+            LOCK_EX
+        );
+    }
+}
+
+function normalizeScenesList($scenes): array
+{
+    if (!is_array($scenes)) {
+        return [];
+    }
+
+    $normalized = [];
+    foreach ($scenes as $scene) {
+        if (!is_array($scene)) {
+            continue;
+        }
+        $sceneId = isset($scene['id']) ? (string) $scene['id'] : generateIdentifier('scene');
+        $map = isset($scene['map']) && is_array($scene['map']) ? $scene['map'] : [];
+        $gridScale = isset($map['gridScale']) ? (int) $map['gridScale'] : 50;
+        if ($gridScale < 10) {
+            $gridScale = 10;
+        }
+        if ($gridScale > 300) {
+            $gridScale = 300;
+        }
+        $normalized[] = [
+            'id' => $sceneId,
+            'name' => isset($scene['name']) ? (string) $scene['name'] : 'New Scene',
+            'description' => isset($scene['description']) ? (string) $scene['description'] : '',
+            'accent' => isset($scene['accent']) ? (string) $scene['accent'] : '',
+            'map' => [
+                'image' => isset($map['image']) ? (string) $map['image'] : '',
+                'gridScale' => $gridScale,
+            ],
+        ];
+    }
+
+    return $normalized;
+}
+
+function generateIdentifier(string $prefix): string
+{
+    try {
+        return sprintf('%s-%s', $prefix, bin2hex(random_bytes(6)));
+    } catch (Throwable $exception) {
+        return sprintf('%s-%s', $prefix, uniqid());
+    }
+}
+
+function flattenScenes(array $data): array
+{
+    $scenes = [];
+    foreach ($data['rootScenes'] ?? [] as $scene) {
+        if (!is_array($scene)) {
+            continue;
+        }
+        $scene['folderId'] = null;
+        $scenes[] = $scene;
+    }
+
+    foreach ($data['folders'] ?? [] as $folder) {
+        if (!is_array($folder) || !isset($folder['scenes'])) {
+            continue;
+        }
+        $folderId = $folder['id'] ?? null;
+        foreach ($folder['scenes'] as $scene) {
+            if (!is_array($scene)) {
+                continue;
+            }
+            $scene['folderId'] = $folderId;
+            $scenes[] = $scene;
+        }
+    }
+
+    return $scenes;
+}
+
+function createFolder(array $data, string $name): array
+{
+    $folder = [
+        'id' => generateIdentifier('folder'),
+        'name' => $name !== '' ? $name : 'Untitled Folder',
+        'scenes' => [],
+    ];
+
+    $data['folders'][] = $folder;
+
+    return [$data, $folder];
+}
+
+function createScene(array $data, ?string $folderId = null, ?string $name = null): array
+{
+    $scene = [
+        'id' => generateIdentifier('scene'),
+        'name' => $name !== null && $name !== '' ? $name : 'New Scene',
+        'description' => '',
+        'accent' => '',
+        'map' => [
+            'image' => '',
+            'gridScale' => 50,
+        ],
+    ];
+
+    $folderAttached = false;
+    if ($folderId !== null) {
+        foreach ($data['folders'] as &$folder) {
+            if (isset($folder['id']) && $folder['id'] === $folderId) {
+                if (!isset($folder['scenes']) || !is_array($folder['scenes'])) {
+                    $folder['scenes'] = [];
+                }
+                $folder['scenes'][] = $scene;
+                $folderAttached = true;
+                break;
+            }
+        }
+        unset($folder);
+    }
+
+    if (!$folderAttached) {
+        if (!isset($data['rootScenes']) || !is_array($data['rootScenes'])) {
+            $data['rootScenes'] = [];
+        }
+        $data['rootScenes'][] = $scene;
+    }
+
+    return [$data, $scene];
+}
+
+function deleteScene(array $data, string $sceneId): array
+{
+    $removed = false;
+
+    if (isset($data['rootScenes']) && is_array($data['rootScenes'])) {
+        foreach ($data['rootScenes'] as $index => $scene) {
+            if (isset($scene['id']) && $scene['id'] === $sceneId) {
+                array_splice($data['rootScenes'], $index, 1);
+                $removed = true;
+                break;
+            }
+        }
+    }
+
+    if (!$removed && isset($data['folders']) && is_array($data['folders'])) {
+        foreach ($data['folders'] as &$folder) {
+            if (!isset($folder['scenes']) || !is_array($folder['scenes'])) {
+                continue;
+            }
+            foreach ($folder['scenes'] as $index => $scene) {
+                if (isset($scene['id']) && $scene['id'] === $sceneId) {
+                    array_splice($folder['scenes'], $index, 1);
+                    $removed = true;
+                    break 2;
+                }
+            }
+        }
+        unset($folder);
+    }
+
+    return [$data, $removed];
+}
+
+function getSceneById(array $data, string $sceneId): ?array
+{
+    foreach ($data['rootScenes'] ?? [] as $scene) {
+        if (isset($scene['id']) && $scene['id'] === $sceneId) {
+            $scene['folderId'] = null;
+            return $scene;
+        }
+    }
+
+    foreach ($data['folders'] ?? [] as $folder) {
+        foreach ($folder['scenes'] ?? [] as $scene) {
+            if (isset($scene['id']) && $scene['id'] === $sceneId) {
+                $scene['folderId'] = $folder['id'] ?? null;
+                return $scene;
+            }
+        }
+    }
+
+    return null;
+}
+
+function updateSceneMap(array $data, string $sceneId, ?string $imagePath, ?int $gridScale): array
+{
+    $updatedScene = null;
+
+    if (isset($data['rootScenes']) && is_array($data['rootScenes'])) {
+        foreach ($data['rootScenes'] as &$scene) {
+            if (isset($scene['id']) && $scene['id'] === $sceneId) {
+                $scene = applySceneMapChanges($scene, $imagePath, $gridScale);
+                $updatedScene = $scene;
+                break;
+            }
+        }
+        unset($scene);
+    }
+
+    if ($updatedScene === null && isset($data['folders']) && is_array($data['folders'])) {
+        foreach ($data['folders'] as &$folder) {
+            if (!isset($folder['scenes']) || !is_array($folder['scenes'])) {
+                continue;
+            }
+            foreach ($folder['scenes'] as &$scene) {
+                if (isset($scene['id']) && $scene['id'] === $sceneId) {
+                    $scene = applySceneMapChanges($scene, $imagePath, $gridScale);
+                    $updatedScene = $scene;
+                    break 2;
+                }
+            }
+            unset($scene);
+        }
+        unset($folder);
+    }
+
+    return [$data, $updatedScene];
+}
+
+function applySceneMapChanges(array $scene, ?string $imagePath, ?int $gridScale): array
+{
+    if (!isset($scene['map']) || !is_array($scene['map'])) {
+        $scene['map'] = [];
+    }
+
+    if ($imagePath !== null) {
+        $scene['map']['image'] = $imagePath;
+    }
+
+    if ($gridScale !== null) {
+        if ($gridScale < 10) {
+            $gridScale = 10;
+        }
+        if ($gridScale > 300) {
+            $gridScale = 300;
+        }
+        $scene['map']['gridScale'] = $gridScale;
+    }
+
+    return $scene;
+}
+
+function getFirstSceneId(array $data): ?string
+{
+    if (!empty($data['rootScenes'])) {
+        $first = $data['rootScenes'][0];
+        if (isset($first['id'])) {
+            return $first['id'];
+        }
+    }
+
+    foreach ($data['folders'] ?? [] as $folder) {
+        if (!empty($folder['scenes'])) {
+            $first = $folder['scenes'][0];
+            if (isset($first['id'])) {
+                return $first['id'];
+            }
+        }
+    }
+
+    return null;
+}
+
+function ensureMapUploadDirectory(): void
+{
+    if (!is_dir(VTT_MAP_UPLOAD_DIR)) {
+        mkdir(VTT_MAP_UPLOAD_DIR, 0755, true);
+    }
+}
+
+function buildMapImagePath(string $filename): string
+{
+    return '../images/vtt/maps/' . ltrim($filename, '/');
+}
+
+function sanitizeFileExtension(string $filename): string
+{
+    $extension = strtolower(pathinfo($filename, PATHINFO_EXTENSION));
+    $allowed = ['jpg', 'jpeg', 'png', 'gif', 'webp'];
+    return in_array($extension, $allowed, true) ? $extension : '';
+}
+


### PR DESCRIPTION
## Summary
- replace the static scene list with a JSON-backed repository that supports folders and persistence
- add GM-only UI for managing folders, scenes, map images, and grid scale with a responsive map display
- update the scene handler to expose CRUD APIs for scenes, folders, and map settings including secure image uploads

## Testing
- php -l dnd/vtt/index.php
- php -l dnd/vtt/scenes_handler.php
- php -l dnd/vtt/scenes_repository.php

------
https://chatgpt.com/codex/tasks/task_e_68db45c8dd1883279f35583982266fe0