### PR TITLE
Revamp VTT scene management layout

### DIFF
--- a/dnd/css/vtt.css
+++ b/dnd/css/vtt.css
@@ -15,33 +15,42 @@
     background: radial-gradient(circle at top, rgba(56, 189, 248, 0.12), transparent 48%), var(--vtt-background);
     color: var(--vtt-foreground);
     font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+    display: flex;
+    flex-direction: column;
 }
 
 .vtt-container {
-    min-height: 100vh;
+    flex: 1;
     display: flex;
-    align-items: center;
+    align-items: stretch;
     justify-content: center;
-    padding: clamp(1.5rem, 4vw, 4rem);
+    padding: clamp(1rem, 3vw, 2.75rem);
     box-sizing: border-box;
 }
 
 .vtt-main {
     width: 100%;
     display: flex;
-    align-items: center;
+    align-items: stretch;
     justify-content: center;
+    min-height: 0;
 }
 
 .scene-display {
-    width: min(960px, 92vw);
-    padding: clamp(2rem, 4vw, 3.75rem);
+    width: 100%;
+    max-width: none;
+    height: 100%;
+    padding: clamp(1.75rem, 3vw, 3.25rem);
     background: linear-gradient(135deg, rgba(56, 189, 248, 0.24), rgba(15, 23, 42, 0.92));
     border: 1px solid rgba(148, 163, 184, 0.45);
     border-radius: 32px;
     box-shadow: 0 32px 80px rgba(15, 23, 42, 0.65);
     backdrop-filter: blur(18px);
     transition: background 220ms ease, border-color 220ms ease, box-shadow 220ms ease;
+    display: flex;
+    flex-direction: column;
+    gap: clamp(1rem, 2vw, 2rem);
+    overflow: hidden;
 }
 
 .scene-display__meta {
@@ -81,27 +90,35 @@
 }
 
 .scene-display__map {
-    margin-top: 2rem;
+    margin-top: 0;
     display: flex;
     flex-direction: column;
     gap: 0.75rem;
+    flex: 1;
+    min-height: 0;
 }
 
 .scene-display__map-inner {
     position: relative;
-    display: inline-flex;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex: 1;
+    width: 100%;
+    max-height: 100%;
     border-radius: 18px;
     overflow: hidden;
     background: rgba(15, 23, 42, 0.75);
     border: 1px solid rgba(148, 163, 184, 0.35);
     box-shadow: 0 18px 48px rgba(15, 23, 42, 0.55);
+    aspect-ratio: var(--map-aspect-ratio, 16 / 9);
 }
 
 .scene-display__map-image {
     display: block;
-    max-width: min(100%, 720px);
-    height: auto;
-    object-fit: cover;
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
 }
 
 .scene-display__map-image--hidden {
@@ -115,6 +132,7 @@
     background-image: linear-gradient(to right, rgba(226, 232, 240, 0.12) 1px, transparent 1px),
         linear-gradient(to bottom, rgba(226, 232, 240, 0.12) 1px, transparent 1px);
     background-size: var(--grid-size, 50px) var(--grid-size, 50px);
+    background-position: center;
     mix-blend-mode: screen;
 }
 
@@ -126,8 +144,6 @@
 
 .scene-display__map--empty .scene-display__map-inner {
     min-height: 220px;
-    align-items: center;
-    justify-content: center;
 }
 
 .settings-panel {
@@ -222,16 +238,18 @@
 
 .settings-panel__primary-action {
     align-self: flex-start;
-    padding: 0.65rem 1.1rem;
+    padding: 0.45rem 0.85rem;
     border-radius: 999px;
     border: 1px solid rgba(148, 163, 184, 0.35);
     background: rgba(30, 41, 59, 0.85);
     color: rgba(226, 232, 240, 0.92);
-    font-size: 0.9rem;
-    letter-spacing: 0.16em;
+    font-size: 0.75rem;
+    letter-spacing: 0.2em;
     text-transform: uppercase;
     cursor: pointer;
     transition: background 160ms ease, color 160ms ease, border-color 160ms ease;
+    margin-left: 0;
+    margin-right: auto;
 }
 
 .settings-panel__primary-action:hover,

--- a/dnd/vtt/index.php
+++ b/dnd/vtt/index.php
@@ -151,7 +151,7 @@ $vttConfig = [
                     class="scene-display__map<?php echo $activeSceneMap['image'] === '' ? ' scene-display__map--empty' : ''; ?>"
                     data-grid-scale="<?php echo (int) $activeSceneMap['gridScale']; ?>"
                 >
-                    <div class="scene-display__map-inner">
+                    <div id="scene-map-inner" class="scene-display__map-inner">
                         <img
                             id="scene-map-image"
                             class="scene-display__map-image<?php echo $activeSceneMap['image'] === '' ? ' scene-display__map-image--hidden' : ''; ?>"

--- a/dnd/vtt/scenes_repository.php
+++ b/dnd/vtt/scenes_repository.php
@@ -189,9 +189,10 @@ function createFolder(array $data, string $name): array
 
 function createScene(array $data, ?string $folderId = null, ?string $name = null): array
 {
+    $trimmedName = $name !== null ? trim($name) : '';
     $scene = [
         'id' => generateIdentifier('scene'),
-        'name' => $name !== null && $name !== '' ? $name : 'New Scene',
+        'name' => $trimmedName !== '' ? $trimmedName : 'New Scene',
         'description' => '',
         'accent' => '',
         'map' => [
@@ -256,6 +257,46 @@ function deleteScene(array $data, string $sceneId): array
     }
 
     return [$data, $removed];
+}
+
+function renameScene(array $data, string $sceneId, string $name): array
+{
+    $trimmedName = trim($name);
+    if ($trimmedName === '') {
+        return [$data, null];
+    }
+
+    $updatedScene = null;
+
+    if (isset($data['rootScenes']) && is_array($data['rootScenes'])) {
+        foreach ($data['rootScenes'] as &$scene) {
+            if (isset($scene['id']) && $scene['id'] === $sceneId) {
+                $scene['name'] = $trimmedName;
+                $updatedScene = $scene;
+                break;
+            }
+        }
+        unset($scene);
+    }
+
+    if ($updatedScene === null && isset($data['folders']) && is_array($data['folders'])) {
+        foreach ($data['folders'] as &$folder) {
+            if (!isset($folder['scenes']) || !is_array($folder['scenes'])) {
+                continue;
+            }
+            foreach ($folder['scenes'] as &$scene) {
+                if (isset($scene['id']) && $scene['id'] === $sceneId) {
+                    $scene['name'] = $trimmedName;
+                    $updatedScene = $scene;
+                    break 2;
+                }
+            }
+            unset($scene);
+        }
+        unset($folder);
+    }
+
+    return [$data, $updatedScene];
 }
 
 function getSceneById(array $data, string $sceneId): ?array


### PR DESCRIPTION
## Summary
- expand the virtual tabletop canvas to fill the viewport and dynamically match each map image’s aspect ratio
- streamline scene actions by moving controls into the context menu, prompting for names on creation, and supporting server-side renaming
- restyle the Scenes toggle to leave room for future actions while keeping the GM tools responsive

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68db4ffdbef483279638dd987b48c971