### PR TITLE
Embed map settings within selected scenes

### DIFF
--- a/dnd/css/vtt.css
+++ b/dnd/css/vtt.css
@@ -574,6 +574,27 @@
     z-index: 20;
 }
 
+.scene-card__map-settings {
+    margin: 0.85rem 1rem 1.1rem;
+    position: relative;
+    z-index: 1;
+}
+
+.scene-card__map-settings::before {
+    content: '';
+    position: absolute;
+    inset: -1px;
+    border-radius: 16px;
+    border: 1px solid rgba(56, 189, 248, 0.2);
+    pointer-events: none;
+    opacity: 0;
+    transition: opacity 160ms ease;
+}
+
+.scene-card--selected .scene-card__map-settings::before {
+    opacity: 1;
+}
+
 .scene-card__menu-item {
     width: 100%;
     padding: 0.5rem 0.75rem;

--- a/dnd/vtt/index.php
+++ b/dnd/vtt/index.php
@@ -199,22 +199,6 @@ $vttConfig = [
                             <button type="button" id="scene-add-folder" class="scene-management__add-folder">+ Folder</button>
                             <div id="scene-list" class="scene-management__scene-list" role="list"></div>
                             <button type="button" id="scene-add" class="scene-management__add-scene">+ Scene</button>
-                            <div id="scene-map-settings" class="scene-management__map-settings" hidden>
-                                <h4 class="scene-management__map-title">Map Settings</h4>
-                                <div class="scene-management__field">
-                                    <label for="scene-map-image-input" class="scene-management__label">Scene Image</label>
-                                    <input type="file" id="scene-map-image-input" class="scene-management__file" accept="image/*">
-                                    <p id="scene-map-image-name" class="scene-management__file-name">No image selected</p>
-                                </div>
-                                <div class="scene-management__field">
-                                    <label for="scene-grid-scale" class="scene-management__label">Grid Scale</label>
-                                    <div class="scene-management__grid-controls">
-                                        <input type="range" id="scene-grid-scale" class="scene-management__grid-range" min="10" max="300" step="5" value="50">
-                                        <input type="number" id="scene-grid-scale-value" class="scene-management__grid-value" min="10" max="300" step="5" value="50">
-                                        <span class="scene-management__grid-unit">px</span>
-                                    </div>
-                                </div>
-                            </div>
                         </div>
                     </div>
                     <p id="settings-scenes-status" class="settings-panel__status" role="status" aria-live="polite"></p>


### PR DESCRIPTION
## Summary
- render map upload and grid controls inside the selected scene card instead of a detached panel
- update VTT scene management script to use delegated events per scene and keep selections in sync
- adjust styling so inline map settings fit the scene card layout

## Testing
- not run (frontend change only)


------
https://chatgpt.com/codex/tasks/task_e_68db558d945883278deac94da00b3898