### PR TITLE
Fix scene menu popover visibility and reduce display header spacing

### DIFF
--- a/dnd/css/vtt.css
+++ b/dnd/css/vtt.css
@@ -40,7 +40,7 @@
     width: 100%;
     max-width: none;
     height: 100%;
-    padding: clamp(1.75rem, 3vw, 3.25rem);
+    padding: clamp(1rem, 2.5vw, 1.75rem) clamp(1.75rem, 3vw, 3.25rem);
     background: linear-gradient(135deg, rgba(56, 189, 248, 0.24), rgba(15, 23, 42, 0.92));
     border: 1px solid rgba(148, 163, 184, 0.45);
     border-radius: 32px;
@@ -49,19 +49,19 @@
     transition: background 220ms ease, border-color 220ms ease, box-shadow 220ms ease;
     display: flex;
     flex-direction: column;
-    gap: clamp(1rem, 2vw, 2rem);
+    gap: clamp(0.75rem, 1.75vw, 1.5rem);
     overflow: hidden;
 }
 
 .scene-display__meta {
     display: flex;
     align-items: center;
-    gap: 0.75rem;
-    margin-bottom: 1.25rem;
+    gap: 0.5rem;
+    margin-bottom: 0.35rem;
     text-transform: uppercase;
-    letter-spacing: 0.18em;
-    font-size: 0.75rem;
-    color: rgba(148, 163, 184, 0.9);
+    letter-spacing: 0.14em;
+    font-size: 0.65rem;
+    color: rgba(148, 163, 184, 0.8);
 }
 
 .scene-display__badge {
@@ -76,9 +76,9 @@
 }
 
 .scene-display__name {
-    margin: 0 0 1.25rem;
-    font-size: clamp(2.25rem, 5vw, 3.25rem);
-    letter-spacing: 0.04em;
+    margin: 0 0 0.5rem;
+    font-size: clamp(1.6rem, 3.5vw, 2.4rem);
+    letter-spacing: 0.02em;
 }
 
 .scene-display__description {
@@ -568,10 +568,14 @@
     border: 1px solid rgba(148, 163, 184, 0.35);
     background: rgba(15, 23, 42, 0.95);
     box-shadow: 0 18px 36px rgba(15, 23, 42, 0.55);
-    display: flex;
+    display: none;
     flex-direction: column;
     gap: 0.25rem;
     z-index: 20;
+}
+
+.scene-card__menu-popover[hidden] {
+    display: none !important;
 }
 
 .scene-card__map-settings {


### PR DESCRIPTION
## Summary
- hide scene card actions until the three-dot menu is toggled
- shrink the active scene display header so the map sits closer to the top

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68db655d34888327a90c383adc6f2149