### PR TITLE
Fix scene menu toggle and add map zoom interactions

### DIFF
--- a/dnd/css/vtt.css
+++ b/dnd/css/vtt.css
@@ -101,7 +101,7 @@
 .scene-display__map-inner {
     position: relative;
     display: flex;
-    align-items: center;
+    align-items: stretch;
     justify-content: center;
     flex: 1;
     width: 100%;
@@ -112,6 +112,27 @@
     border: 1px solid rgba(148, 163, 184, 0.35);
     box-shadow: 0 18px 48px rgba(15, 23, 42, 0.55);
     aspect-ratio: var(--map-aspect-ratio, 16 / 9);
+    touch-action: none;
+    user-select: none;
+}
+
+.scene-display__map-content {
+    position: relative;
+    flex: 1 1 auto;
+    width: 100%;
+    height: 100%;
+    transform-origin: top left;
+    cursor: grab;
+    user-select: none;
+    will-change: transform;
+}
+
+.scene-display__map-content--inactive {
+    cursor: default;
+}
+
+.scene-display__map-content--dragging {
+    cursor: grabbing;
 }
 
 .scene-display__map-image {

--- a/dnd/vtt/index.php
+++ b/dnd/vtt/index.php
@@ -152,13 +152,15 @@ $vttConfig = [
                     data-grid-scale="<?php echo (int) $activeSceneMap['gridScale']; ?>"
                 >
                     <div id="scene-map-inner" class="scene-display__map-inner">
-                        <img
-                            id="scene-map-image"
-                            class="scene-display__map-image<?php echo $activeSceneMap['image'] === '' ? ' scene-display__map-image--hidden' : ''; ?>"
-                            src="<?php echo htmlspecialchars($activeSceneMap['image'], ENT_QUOTES); ?>"
-                            alt="Scene map"
-                        >
-                        <div id="scene-map-grid" class="scene-display__map-grid"></div>
+                        <div id="scene-map-content" class="scene-display__map-content">
+                            <img
+                                id="scene-map-image"
+                                class="scene-display__map-image<?php echo $activeSceneMap['image'] === '' ? ' scene-display__map-image--hidden' : ''; ?>"
+                                src="<?php echo htmlspecialchars($activeSceneMap['image'], ENT_QUOTES); ?>"
+                                alt="Scene map"
+                            >
+                            <div id="scene-map-grid" class="scene-display__map-grid"></div>
+                        </div>
                     </div>
                     <p
                         id="scene-map-empty"


### PR DESCRIPTION
## Summary
- fix the scene card menu trigger so the popover stays open after clicking
- restructure the map markup and styles so the image and grid transform together
- add zoom, pan, and reset interactions to the tabletop map while keeping the grid aligned

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc6889bb648327b49ef3ac943fa802