### PR TITLE
Adjust VTT interactions and settings toggle

### DIFF
--- a/dnd/css/vtt.css
+++ b/dnd/css/vtt.css
@@ -717,7 +717,7 @@
     top: 50%;
     left: 0;
     transform: translate3d(-55%, -50%, 0);
-    padding: 0.75rem 1.6rem;
+    padding: 1.6rem 0.75rem;
     border-radius: 0 16px 16px 0;
     border: 1px solid var(--vtt-panel-border);
     background: var(--vtt-panel-bg);
@@ -729,6 +729,12 @@
     box-shadow: 0 18px 48px rgba(8, 15, 35, 0.6);
     transition: transform 220ms ease, background 160ms ease, color 160ms ease;
     z-index: 1390;
+    writing-mode: vertical-rl;
+    text-orientation: mixed;
+    white-space: nowrap;
+    display: flex;
+    align-items: center;
+    justify-content: center;
 }
 
 .settings-panel-toggle:hover,
@@ -779,6 +785,9 @@
         transform: translate3d(0, 0, 0);
         left: 50%;
         border-radius: 18px;
+        writing-mode: horizontal-tb;
+        text-orientation: initial;
+        padding: 0.65rem 1.4rem;
     }
 
     .settings-panel-toggle[aria-expanded="true"] {

--- a/dnd/js/chat-panel.js
+++ b/dnd/js/chat-panel.js
@@ -19,6 +19,8 @@
         const whisperContainer = document.getElementById('chat-whisper-targets');
         const whisperPopoutHost = document.getElementById('chat-whisper-popouts');
         const whisperAlertHost = document.getElementById('chat-whisper-alerts');
+        const sceneDisplay = document.getElementById('scene-display');
+        const sceneMap = document.getElementById('scene-map');
 
         if (!panel || !toggleButton || !messageList || !form || !textarea || !sendButton) {
             return;
@@ -1722,7 +1724,52 @@
                 return false;
             }
             const types = Array.from(event.dataTransfer.types || []);
-            return types.includes('Files') || types.includes('text/uri-list') || types.includes('text/plain');
+            const hasSupportedType = types.includes('Files') || types.includes('text/uri-list') || types.includes('text/plain');
+            if (!hasSupportedType) {
+                return false;
+            }
+            if (isDragOverScene(event)) {
+                return false;
+            }
+            return true;
+        }
+
+        function isDragOverScene(event) {
+            if (isEventWithinElement(event, sceneMap)) {
+                return true;
+            }
+            if (!sceneMap && isEventWithinElement(event, sceneDisplay)) {
+                return true;
+            }
+            return false;
+        }
+
+        function isEventWithinElement(event, element) {
+            if (!event || !element) {
+                return false;
+            }
+
+            if (event.target instanceof Node && element.contains(event.target)) {
+                return true;
+            }
+
+            if (typeof event.composedPath === 'function') {
+                const path = event.composedPath();
+                if (Array.isArray(path) && path.includes(element)) {
+                    return true;
+                }
+            }
+
+            if (Number.isFinite(event.clientX) && Number.isFinite(event.clientY)) {
+                const rect = element.getBoundingClientRect();
+                const x = event.clientX;
+                const y = event.clientY;
+                if (x >= rect.left && x <= rect.right && y >= rect.top && y <= rect.bottom) {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         function isImageFile(file) {
@@ -1842,6 +1889,8 @@
             if (shouldHandleDrag(event)) {
                 event.preventDefault();
                 showDropTarget();
+            } else {
+                hideDropTarget();
             }
         });
 
@@ -1851,6 +1900,8 @@
                 if (event.dataTransfer) {
                     event.dataTransfer.dropEffect = 'copy';
                 }
+            } else {
+                hideDropTarget();
             }
         });
 

--- a/dnd/js/vtt.js
+++ b/dnd/js/vtt.js
@@ -566,6 +566,7 @@
             } catch (error) {
                 sceneMapInner.addEventListener('wheel', onMapWheel, false);
             }
+            sceneMapInner.addEventListener('contextmenu', onMapContextMenu);
             sceneMapInner.addEventListener('pointerdown', onMapPointerDown);
             sceneMapInner.addEventListener('pointermove', onMapPointerMove);
             sceneMapInner.addEventListener('pointerup', onMapPointerUp);
@@ -707,8 +708,13 @@
             if (!event.isPrimary) {
                 return;
             }
-            if (event.pointerType === 'mouse' && event.button !== 0) {
-                return;
+            if (event.pointerType === 'mouse') {
+                if (event.button !== 2) {
+                    return;
+                }
+                if (typeof event.preventDefault === 'function') {
+                    event.preventDefault();
+                }
             }
             state.mapDragState.pointerId = event.pointerId;
             state.mapDragState.active = true;
@@ -726,6 +732,10 @@
 
         function onMapPointerMove(event) {
             if (!state.mapDragState.active || event.pointerId !== state.mapDragState.pointerId) {
+                return;
+            }
+            if (event.pointerType === 'mouse' && event.buttons !== 2) {
+                endMapDrag();
                 return;
             }
             const dx = event.clientX - state.mapDragState.lastX;
@@ -774,6 +784,16 @@
                 event.preventDefault();
             }
             resetMapTransform();
+        }
+
+        function onMapContextMenu(event) {
+            if (!sceneMapInner) {
+                return;
+            }
+            if (!state.mapHasImage) {
+                return;
+            }
+            event.preventDefault();
         }
 
         function onMapViewportResize() {


### PR DESCRIPTION
## Summary
- require right-click for virtual tabletop map dragging, prevent the default context menu, and keep non-mouse dragging intact
- stop the chat image drop target from appearing over the scene area so it no longer blocks map interactions
- orient the settings drawer toggle vertically on desktop while reverting to a horizontal layout on small screens

## Testing
- Manual: Loaded /dnd/vtt/index.php and verified the settings toggle orientation and right-click drag behaviour


------
https://chatgpt.com/codex/tasks/task_e_68dc6d16dba483279a3b5b4b3e8f0208