### PR TITLE
Improve VTT map viewport and panning

### DIFF
--- a/dnd/css/vtt.css
+++ b/dnd/css/vtt.css
@@ -17,6 +17,7 @@
     font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
     display: flex;
     flex-direction: column;
+    overflow: hidden;
 }
 
 .vtt-container {
@@ -26,6 +27,7 @@
     justify-content: center;
     padding: clamp(1rem, 3vw, 2.75rem);
     box-sizing: border-box;
+    height: 100vh;
 }
 
 .vtt-main {
@@ -34,6 +36,8 @@
     align-items: stretch;
     justify-content: center;
     min-height: 0;
+    height: 100%;
+    max-height: 100%;
 }
 
 .scene-display {
@@ -51,6 +55,7 @@
     flex-direction: column;
     gap: clamp(0.75rem, 1.75vw, 1.5rem);
     overflow: hidden;
+    max-height: 100%;
 }
 
 .scene-display__meta {
@@ -101,19 +106,19 @@
 .scene-display__map-inner {
     position: relative;
     display: flex;
-    align-items: stretch;
+    align-items: center;
     justify-content: center;
     flex: 1;
     width: 100%;
     max-height: 100%;
     border-radius: 18px;
     overflow: hidden;
-    background: rgba(15, 23, 42, 0.75);
+    background: #000;
     border: 1px solid rgba(148, 163, 184, 0.35);
     box-shadow: 0 18px 48px rgba(15, 23, 42, 0.55);
-    aspect-ratio: var(--map-aspect-ratio, 16 / 9);
     touch-action: none;
     user-select: none;
+    height: 100%;
 }
 
 .scene-display__map-content {
@@ -125,6 +130,7 @@
     cursor: grab;
     user-select: none;
     will-change: transform;
+    background: #000;
 }
 
 .scene-display__map-content--inactive {
@@ -716,7 +722,7 @@
     position: fixed;
     top: 50%;
     left: 0;
-    transform: translate3d(-55%, -50%, 0);
+    transform: translate3d(-40%, -50%, 0);
     padding: 1.6rem 0.75rem;
     border-radius: 0 16px 16px 0;
     border: 1px solid var(--vtt-panel-border);


### PR DESCRIPTION
## Summary
- adjust the VTT layout so the settings toggle is visible and the scene viewport fits the browser window
- render the map against a black background and drop the fixed aspect ratio so the container no longer stretches past the screen
- add buffered panning bounds so the map can be dragged past its edges while keeping reset centring behaviour

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68dc7178e6188327b87c63bcc6d4cfc5