### PR TITLE
Adjust VTT map layout and pan bounds

### DIFF
--- a/dnd/css/vtt.css
+++ b/dnd/css/vtt.css
@@ -44,7 +44,7 @@
     width: 100%;
     max-width: none;
     height: 100%;
-    padding: clamp(1rem, 2.5vw, 1.75rem) clamp(1.75rem, 3vw, 3.25rem);
+    padding: clamp(0.5rem, 1.25vw, 1.25rem);
     background: linear-gradient(135deg, rgba(56, 189, 248, 0.24), rgba(15, 23, 42, 0.92));
     border: 1px solid rgba(148, 163, 184, 0.45);
     border-radius: 32px;
@@ -53,20 +53,14 @@
     transition: background 220ms ease, border-color 220ms ease, box-shadow 220ms ease;
     display: flex;
     flex-direction: column;
-    gap: clamp(0.75rem, 1.75vw, 1.5rem);
+    gap: 0;
     overflow: hidden;
     max-height: 100%;
+    position: relative;
 }
 
 .scene-display__meta {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    margin-bottom: 0.35rem;
-    text-transform: uppercase;
-    letter-spacing: 0.14em;
-    font-size: 0.65rem;
-    color: rgba(148, 163, 184, 0.8);
+    display: none;
 }
 
 .scene-display__badge {
@@ -81,17 +75,28 @@
 }
 
 .scene-display__name {
-    margin: 0 0 0.5rem;
-    font-size: clamp(1.6rem, 3.5vw, 2.4rem);
-    letter-spacing: 0.02em;
+    position: absolute;
+    top: clamp(0.75rem, 1vw, 1.1rem);
+    left: clamp(0.75rem, 1vw, 1.1rem);
+    margin: 0;
+    font-size: clamp(0.85rem, 1.35vw, 1.05rem);
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    font-weight: 600;
+    background: rgba(15, 23, 42, 0.75);
+    border: 1px solid rgba(148, 163, 184, 0.4);
+    border-radius: 999px;
+    padding: 0.35rem 0.85rem;
+    pointer-events: none;
+    z-index: 2;
+    max-width: calc(100% - clamp(1.5rem, 2vw, 2.2rem));
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 .scene-display__description {
-    margin: 0;
-    max-width: 70ch;
-    font-size: clamp(1rem, 2vw, 1.2rem);
-    line-height: 1.7;
-    color: rgba(226, 232, 240, 0.88);
+    display: none;
 }
 
 .scene-display__map {

--- a/dnd/js/vtt.js
+++ b/dnd/js/vtt.js
@@ -64,8 +64,8 @@
         const MAP_MIN_SCALE = 0.5;
         const MAP_MAX_SCALE = 4;
         const MAP_WHEEL_SENSITIVITY = 0.002;
-        const MAP_PAN_BUFFER_PX = 220;
-        const MAP_PAN_BUFFER_RATIO = 0.12;
+        const MAP_DRAG_BUFFER_MIN_PX = 220;
+        const MAP_DRAG_BUFFER_SCALE = 0.5;
 
         const state = {
             isGM: Boolean(config.isGM),
@@ -661,10 +661,10 @@
             const scaledHeight = contentHeight * scale;
 
             const bufferX = state.mapHasImage
-                ? Math.max(MAP_PAN_BUFFER_PX, viewportWidth * MAP_PAN_BUFFER_RATIO)
+                ? Math.max(MAP_DRAG_BUFFER_MIN_PX, scaledWidth * MAP_DRAG_BUFFER_SCALE)
                 : 0;
             const bufferY = state.mapHasImage
-                ? Math.max(MAP_PAN_BUFFER_PX, viewportHeight * MAP_PAN_BUFFER_RATIO)
+                ? Math.max(MAP_DRAG_BUFFER_MIN_PX, scaledHeight * MAP_DRAG_BUFFER_SCALE)
                 : 0;
 
             let minX;


### PR DESCRIPTION
## Summary
- shrink the scene header footprint so the map can extend to the top of the viewport
- hide descriptive copy and restyle the scene name as a compact overlay badge
- expand map panning limits to allow dragging roughly half the map dimensions in any direction

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dc76dd519083279b85dc750d84ae16