### PR TITLE
Prevent VTT polling from resetting map zoom

### DIFF
--- a/dnd/js/vtt.js
+++ b/dnd/js/vtt.js
@@ -1417,7 +1417,9 @@
             const imageChanged = state.mapImageSrc !== imagePath;
 
             if (hasImage) {
-                sceneMapImage.src = imagePath;
+                if (imageChanged || !sceneMapImage.hasAttribute('src')) {
+                    sceneMapImage.src = imagePath;
+                }
                 sceneMapImage.classList.remove('scene-display__map-image--hidden');
                 sceneMapEmpty.hidden = true;
                 sceneMap.classList.remove('scene-display__map--empty');
@@ -1425,7 +1427,9 @@
                     applyMapAspectRatioFromImage();
                 }
             } else {
-                sceneMapImage.removeAttribute('src');
+                if (sceneMapImage.hasAttribute('src')) {
+                    sceneMapImage.removeAttribute('src');
+                }
                 sceneMapImage.classList.add('scene-display__map-image--hidden');
                 sceneMapEmpty.hidden = false;
                 sceneMap.classList.add('scene-display__map--empty');


### PR DESCRIPTION
## Summary
- avoid reapplying the map image source during polling when it has not changed
- guard removal of the image source attribute when clearing the map

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dc7a8963e883278077edb11f196c5b