### PR TITLE
Allow VTT layout to scroll within viewport

### DIFF
--- a/dnd/css/vtt.css
+++ b/dnd/css/vtt.css
@@ -17,7 +17,7 @@
     font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
     display: flex;
     flex-direction: column;
-    overflow: hidden;
+    overflow: auto;
 }
 
 .vtt-container {
@@ -27,7 +27,7 @@
     justify-content: center;
     padding: clamp(1rem, 3vw, 2.75rem);
     box-sizing: border-box;
-    height: 100vh;
+    min-height: 100vh;
 }
 
 .vtt-main {


### PR DESCRIPTION
## Summary
- allow the VTT body to scroll so the entire map container can be reached on smaller screens
- rely on min-height instead of fixed viewport height for the main VTT container to avoid clipping

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc7e38f9008327ac11e3d8b11a73e5