### PR TITLE
Fix VTT container exceeding viewport height

### DIFF
--- a/dnd/css/vtt.css
+++ b/dnd/css/vtt.css
@@ -12,12 +12,13 @@
 .vtt-body {
     margin: 0;
     min-height: 100vh;
+    height: 100vh;
     background: radial-gradient(circle at top, rgba(56, 189, 248, 0.12), transparent 48%), var(--vtt-background);
     color: var(--vtt-foreground);
     font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
     display: flex;
     flex-direction: column;
-    overflow: auto;
+    overflow: hidden;
 }
 
 .vtt-container {
@@ -27,7 +28,10 @@
     justify-content: center;
     padding: clamp(1rem, 3vw, 2.75rem);
     box-sizing: border-box;
-    min-height: 100vh;
+    min-height: 0;
+    height: 100%;
+    max-height: 100vh;
+    overflow: hidden;
 }
 
 .vtt-main {


### PR DESCRIPTION
## Summary
- constrain the virtual tabletop body and container elements to the viewport height so the interface no longer extends past the bottom of the screen

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dc81b097908327b7441f515c4187f0