### PR TITLE
Update Strixhaven UI close buttons

### DIFF
--- a/dnd/strixhaven/locations/index.php
+++ b/dnd/strixhaven/locations/index.php
@@ -499,7 +499,7 @@ $locationData = loadLocationData();
     <!-- Top Navigation Bar -->
     <div class="top-nav">
         <div class="nav-buttons">
-            <button class="nav-btn" onclick="window.location.href='../../dashboard.php'">← Back to Dashboard</button>
+            <button class="nav-btn" onclick="window.close()">Close Locations</button>
             <button class="nav-btn logout-btn" onclick="window.location.href='../../logout.php'">Logout</button>
         </div>
         <h1 class="nav-title">Strixhaven Locations<?php echo $is_gm ? ' - GM View' : ' - Player View'; ?></h1>

--- a/dnd/strixhaven/staff/index.php
+++ b/dnd/strixhaven/staff/index.php
@@ -498,7 +498,7 @@ $staffData = loadStaffData();
     <!-- Top Navigation Bar -->
     <div class="top-nav">
         <div class="nav-buttons">
-            <button class="nav-btn" onclick="window.location.href='../../dashboard.php'">← Back to Dashboard</button>
+            <button class="nav-btn" onclick="window.close()">Close Staff</button>
             <button class="nav-btn logout-btn" onclick="window.location.href='../../logout.php'">Logout</button>
         </div>
         <h1 class="nav-title">Strixhaven Staff<?php echo $is_gm ? ' - GM View' : ' - Player View'; ?></h1>

--- a/dnd/strixhaven/students/index.php
+++ b/dnd/strixhaven/students/index.php
@@ -602,7 +602,7 @@ $studentData = loadStudentData();
     <!-- Top Navigation Bar -->
     <div class="top-nav">
         <div class="nav-buttons">
-            <button class="nav-btn" onclick="window.location.href='../../dashboard.php'">← Back to Dashboard</button>
+            <button class="nav-btn" onclick="window.close()">Close Students</button>
             <button class="nav-btn logout-btn" onclick="window.location.href='../../logout.php'">Logout</button>
         </div>
         <h1 class="nav-title">Strixhaven Students<?php echo $is_gm ? ' - GM View' : ' - Player View'; ?></h1>


### PR DESCRIPTION
## Summary
- replace the "Back to Dashboard" buttons on the Strixhaven students, staff, and locations pages with close buttons
- update each button to close the browser tab instead of redirecting to the dashboard

## Testing
- no tests were run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dc80b8a48c8327adae191616427cf1