### PR TITLE
Fix chat entity decoding and improve VTT map scaling

### DIFF
--- a/dnd/css/vtt.css
+++ b/dnd/css/vtt.css
@@ -155,6 +155,8 @@
     width: 100%;
     height: 100%;
     object-fit: contain;
+    max-width: none;
+    max-height: none;
 }
 
 .scene-display__map-image--hidden {


### PR DESCRIPTION
## Summary
- decode stored chat and whisper text so HTML entities are rendered correctly in the dashboard chat interfaces
- normalize chat history payloads and reuse the decoding for optimistic updates to keep copy consistent
- size VTT map imagery by its intrinsic dimensions and clamp zoom with a dynamic minimum to preserve detail when zooming

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dcb2d9c9cc832797b6c3b54dc94ff5