### PR TITLE
Fix VTT map sizing when images are smaller than the viewport

### DIFF
--- a/dnd/js/vtt.js
+++ b/dnd/js/vtt.js
@@ -561,9 +561,20 @@
                 return;
             }
 
-            sceneMapContent.style.width = `${width}px`;
-            sceneMapContent.style.height = `${height}px`;
-            sceneMapContent.style.flex = '0 0 auto';
+            const viewportWidth = sceneMapInner ? sceneMapInner.clientWidth : 0;
+            const viewportHeight = sceneMapInner ? sceneMapInner.clientHeight : 0;
+            const shouldUseIntrinsicSize = (
+                (viewportWidth > 0 && width > viewportWidth) ||
+                (viewportHeight > 0 && height > viewportHeight)
+            );
+
+            if (shouldUseIntrinsicSize) {
+                sceneMapContent.style.width = `${width}px`;
+                sceneMapContent.style.height = `${height}px`;
+                sceneMapContent.style.flex = '0 0 auto';
+            } else {
+                clearMapContentSizing();
+            }
         }
 
         function applyMapAspectRatioFromImage() {


### PR DESCRIPTION
## Summary
- only apply intrinsic map sizing when the uploaded image is larger than the scene viewport so small maps still fill the play area

## Testing
- ✅ `browser_container.run_playwright_script` (manual verification of VTT map scaling)


------
https://chatgpt.com/codex/tasks/task_e_68dccbf9743c832794d76bd88affac68