### PR TITLE
Fix VTT grid overlay rendering

### DIFF
--- a/dnd/css/vtt.css
+++ b/dnd/css/vtt.css
@@ -171,7 +171,7 @@
         linear-gradient(to bottom, rgba(226, 232, 240, 0.12) 1px, transparent 1px);
     background-size: var(--grid-size, 50px) var(--grid-size, 50px);
     background-position: center;
-    mix-blend-mode: screen;
+    opacity: 0.7;
 }
 
 .scene-display__map-empty {


### PR DESCRIPTION
## Summary
- remove the `mix-blend-mode` setting on the tabletop grid overlay so it no longer blacks out the map on some browsers
- apply an opacity-based grid styling that still keeps the map visible beneath the lines

## Testing
- manual frontend test: loaded `/dnd/vtt/index.php` and confirmed the grid appears over the map without obscuring it


------
https://chatgpt.com/codex/tasks/task_e_68dcd04f92b0832786bfa7e0427e25b3