### PR TITLE
Adjust VTT map rendering for very large images

### DIFF
--- a/dnd/css/vtt.css
+++ b/dnd/css/vtt.css
@@ -142,6 +142,10 @@
     background: #000;
 }
 
+.scene-display__map-content--no-accel {
+    will-change: auto;
+}
+
 .scene-display__map-content--inactive {
     cursor: default;
 }

--- a/dnd/js/vtt.js
+++ b/dnd/js/vtt.js
@@ -67,6 +67,7 @@
         const MAP_WHEEL_SENSITIVITY = 0.002;
         const MAP_DRAG_BUFFER_MIN_PX = 220;
         const MAP_DRAG_BUFFER_SCALE = 0.5;
+        const MAP_ACCELERATION_DIMENSION_LIMIT = 8192;
 
         const state = {
             isGM: Boolean(config.isGM),
@@ -548,6 +549,7 @@
             sceneMapContent.style.removeProperty('width');
             sceneMapContent.style.removeProperty('height');
             sceneMapContent.style.removeProperty('flex');
+            enableMapAcceleration();
         }
 
         function applyMapContentIntrinsicSize() {
@@ -561,6 +563,7 @@
                 return;
             }
 
+            updateMapAcceleration(width, height);
             const viewportWidth = sceneMapInner ? sceneMapInner.clientWidth : 0;
             const viewportHeight = sceneMapInner ? sceneMapInner.clientHeight : 0;
             const hasViewportSize = viewportWidth > 0 && viewportHeight > 0;
@@ -600,6 +603,26 @@
             state.mapAspectRatio = null;
             clearMapContentSizing();
             state.mapMinScale = MAP_MIN_SCALE;
+            enableMapAcceleration();
+        }
+
+        function updateMapAcceleration(width, height) {
+            if (!sceneMapContent) {
+                return;
+            }
+            const maxDimension = Math.max(width, height);
+            if (Number.isFinite(maxDimension) && maxDimension > MAP_ACCELERATION_DIMENSION_LIMIT) {
+                sceneMapContent.classList.add('scene-display__map-content--no-accel');
+            } else {
+                sceneMapContent.classList.remove('scene-display__map-content--no-accel');
+            }
+        }
+
+        function enableMapAcceleration() {
+            if (!sceneMapContent) {
+                return;
+            }
+            sceneMapContent.classList.remove('scene-display__map-content--no-accel');
         }
 
         function initMapInteractions() {


### PR DESCRIPTION
## Summary
- detect oversized VTT map images and disable transform acceleration to prevent them from being blanked out after load
- add a CSS helper class so oversized maps keep rendering without GPU promotion issues

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68dd4fc141cc83278ea074fcc7224baf