### PR TITLE
Fix large VTT map rendering

### DIFF
--- a/dnd/js/vtt.js
+++ b/dnd/js/vtt.js
@@ -673,7 +673,21 @@
             if (!state.mapHasImage && state.mapTransform.scale === 1 && clamped.translateX === 0 && clamped.translateY === 0) {
                 sceneMapContent.style.transform = '';
             } else {
-                sceneMapContent.style.transform = `translate3d(${clamped.translateX}px, ${clamped.translateY}px, 0) scale(${state.mapTransform.scale})`;
+                const baseOffsetX = typeof sceneMapContent.offsetLeft === 'number'
+                    ? sceneMapContent.offsetLeft
+                    : 0;
+                const baseOffsetY = typeof sceneMapContent.offsetTop === 'number'
+                    ? sceneMapContent.offsetTop
+                    : 0;
+                const translateX = clamped.translateX - baseOffsetX;
+                const translateY = clamped.translateY - baseOffsetY;
+                const scale = state.mapTransform.scale;
+                const accelerationDisabled = sceneMapContent.classList.contains('scene-display__map-content--no-accel');
+                if (accelerationDisabled) {
+                    sceneMapContent.style.transform = `translate(${translateX}px, ${translateY}px) scale(${scale})`;
+                } else {
+                    sceneMapContent.style.transform = `translate3d(${translateX}px, ${translateY}px, 0) scale(${scale})`;
+                }
             }
 
             updateMapInteractionState();


### PR DESCRIPTION
## Summary
- adjust the map transform logic to counteract flex centering offsets
- fall back to 2D transforms when GPU acceleration is disabled for oversized images

## Testing
- manual verification of loading a 7350x8550 scene image in the VTT

------
https://chatgpt.com/codex/tasks/task_e_68df3bd1aab48327be9b5c5c1ab45614