### PR TITLE
Add grid opacity control and share Strixhaven GM images

### DIFF
--- a/dnd/css/vtt.css
+++ b/dnd/css/vtt.css
@@ -110,6 +110,7 @@
     gap: 0.75rem;
     flex: 1;
     min-height: 0;
+    position: relative;
 }
 
 .scene-display__map-inner {
@@ -168,14 +169,86 @@
 }
 
 .scene-display__map-grid {
+    --grid-opacity: 0.7;
+    --grid-line-size: 1px;
     position: absolute;
     inset: 0;
     pointer-events: none;
-    background-image: linear-gradient(to right, rgba(226, 232, 240, 0.12) 1px, transparent 1px),
-        linear-gradient(to bottom, rgba(226, 232, 240, 0.12) 1px, transparent 1px);
+    background-image:
+        linear-gradient(
+            to right,
+            rgba(226, 232, 240, var(--grid-opacity)) 0,
+            rgba(226, 232, 240, var(--grid-opacity)) var(--grid-line-size),
+            transparent var(--grid-line-size),
+            transparent var(--grid-size, 50px)
+        ),
+        linear-gradient(
+            to bottom,
+            rgba(226, 232, 240, var(--grid-opacity)) 0,
+            rgba(226, 232, 240, var(--grid-opacity)) var(--grid-line-size),
+            transparent var(--grid-line-size),
+            transparent var(--grid-size, 50px)
+        );
     background-size: var(--grid-size, 50px) var(--grid-size, 50px);
     background-position: center;
-    opacity: 0.7;
+}
+
+.scene-display__grid-controls {
+    position: absolute;
+    bottom: 1.25rem;
+    right: 1.25rem;
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.75rem 1rem;
+    background: rgba(15, 23, 42, 0.72);
+    border: 1px solid rgba(148, 163, 184, 0.35);
+    border-radius: 12px;
+    color: #e2e8f0;
+    font-size: 0.85rem;
+    line-height: 1.2;
+    box-shadow: 0 18px 48px rgba(15, 23, 42, 0.45);
+    backdrop-filter: blur(10px);
+    z-index: 20;
+    pointer-events: auto;
+}
+
+.scene-display__grid-controls:focus-within {
+    border-color: rgba(94, 234, 212, 0.65);
+    box-shadow: 0 0 0 2px rgba(94, 234, 212, 0.25);
+}
+
+.scene-display__grid-label {
+    font-weight: 500;
+    white-space: nowrap;
+}
+
+.scene-display__grid-range {
+    width: 140px;
+    accent-color: #38bdf8;
+}
+
+.scene-display__grid-value {
+    min-width: 3ch;
+    text-align: right;
+    font-variant-numeric: tabular-nums;
+    color: rgba(226, 232, 240, 0.9);
+}
+
+@media (max-width: 680px) {
+    .scene-display__grid-controls {
+        left: 50%;
+        right: auto;
+        transform: translateX(-50%);
+        flex-wrap: wrap;
+        justify-content: center;
+        gap: 0.5rem;
+        padding: 0.65rem 0.85rem;
+    }
+
+    .scene-display__grid-range {
+        width: min(220px, 60vw);
+    }
 }
 
 .scene-display__map-empty {

--- a/dnd/strixhaven/map/index.php
+++ b/dnd/strixhaven/map/index.php
@@ -220,8 +220,12 @@ $isGM = ($user === 'GM');
         
         .hex-image-upload {
             margin-bottom: 15px;
+            display: flex;
+            flex-wrap: wrap;
+            align-items: center;
+            gap: 10px;
         }
-        
+
         .hex-image-upload .upload-btn {
             background: #667eea;
             color: white;
@@ -233,11 +237,32 @@ $isGM = ($user === 'GM');
             transition: all 0.3s ease;
             box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
         }
-        
+
         .hex-image-upload .upload-btn:hover {
             background: #5a67d8;
             transform: translateY(-1px);
             box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
+        }
+
+        .hex-image-upload .upload-btn--secondary {
+            background: rgba(102, 126, 234, 0.18);
+            color: #3248c4;
+            box-shadow: none;
+        }
+
+        .hex-image-upload .upload-btn--secondary:hover {
+            background: rgba(102, 126, 234, 0.28);
+            color: #2537a0;
+            box-shadow: 0 2px 6px rgba(37, 55, 160, 0.25);
+        }
+
+        .hex-image-upload .upload-btn:disabled,
+        .hex-image-upload .upload-btn--disabled {
+            background: rgba(148, 163, 184, 0.35);
+            color: rgba(44, 62, 80, 0.6);
+            cursor: not-allowed;
+            transform: none;
+            box-shadow: none;
         }
         
         .hex-images-gallery {
@@ -585,7 +610,7 @@ $isGM = ($user === 'GM');
                 <div class="hex-images-container">
                     <h3>GM Images</h3>
                     <div class="hex-image-upload">
-                        <button onclick="uploadHexImage('gm')" class="upload-btn">Upload Image</button>
+                        <button type="button" onclick="uploadHexImage('gm')" class="upload-btn">Upload Image</button>
                         <input type="file" id="gm-image-upload" accept="image/*" style="display: none;">
                     </div>
                     <div id="gm-images" class="hex-images-gallery">
@@ -621,8 +646,13 @@ $isGM = ($user === 'GM');
                 <div class="hex-images-container">
                     <h3>Images</h3>
                     <div class="hex-image-upload">
-                        <button onclick="uploadHexImage('player')" class="upload-btn">Upload Image</button>
+                        <button type="button" onclick="uploadHexImage('player')" class="upload-btn">Upload Image</button>
                         <input type="file" id="player-image-upload" accept="image/*" style="display: none;">
+                        <?php if ($isGM): ?>
+                            <button type="button" id="player-use-gm-image" class="upload-btn upload-btn--secondary" onclick="useGmImagesForPlayers()">
+                                Use GM Image
+                            </button>
+                        <?php endif; ?>
                     </div>
                     <div id="player-images" class="hex-images-gallery">
                         <!-- Images will be populated here -->

--- a/dnd/vtt/index.php
+++ b/dnd/vtt/index.php
@@ -162,6 +162,19 @@ $vttConfig = [
                             <div id="scene-map-grid" class="scene-display__map-grid"></div>
                         </div>
                     </div>
+                    <div id="scene-grid-controls" class="scene-display__grid-controls">
+                        <label for="scene-grid-opacity" class="scene-display__grid-label">Grid Opacity</label>
+                        <input
+                            type="range"
+                            id="scene-grid-opacity"
+                            class="scene-display__grid-range"
+                            min="0"
+                            max="100"
+                            step="1"
+                            value="70"
+                        >
+                        <span id="scene-grid-opacity-value" class="scene-display__grid-value">70%</span>
+                    </div>
                     <p
                         id="scene-map-empty"
                         class="scene-display__map-empty"


### PR DESCRIPTION
## Summary
- add a floating grid opacity control and smoother grid rendering to the VTT map
- persist the chosen opacity per user and adjust grid line density when zooming
- let GMs reuse their Strixhaven map images for players and keep shared copies in sync

## Testing
- php -l dnd/strixhaven/map/hex-data-handler.php
- php -l dnd/vtt/index.php

------
https://chatgpt.com/codex/tasks/task_e_68df43a871f48327b1862231a0fb9884