### PR TITLE
Fix Strixhaven map hex duplication to persist copied data

### DIFF
--- a/dnd/strixhaven/map/js/hex-popup.js
+++ b/dnd/strixhaven/map/js/hex-popup.js
@@ -796,9 +796,11 @@ async function executeCopy(sourceQ, sourceR, targetQ, targetR) {
     formData.append('q', targetQ);
     formData.append('r', targetR);
     formData.append('copy_player_data', copyPlayerData);
+    formData.append('copy_player_notes', copyPlayerNotes);
+    formData.append('copy_player_images', copyPlayerImages);
     formData.append('copy_gm_data', copyGMData);
-    formData.append('copy_notes', copyPlayerNotes || copyGMNotes);
-    formData.append('copy_images', copyPlayerImages || copyGMImages);
+    formData.append('copy_gm_notes', copyGMNotes);
+    formData.append('copy_gm_images', copyGMImages);
     
     try {
         const response = await fetch('hex-data-handler.php', {


### PR DESCRIPTION
## Summary
- send granular copy settings when duplicating a hex so the backend knows which sections to replicate
- update the hex duplication handler to copy titles, notes, and images reliably while replacing old assets safely

## Testing
- php -l dnd/strixhaven/map/hex-data-handler.php

------
https://chatgpt.com/codex/tasks/task_e_68df470c80e083278e74707cb6e62934