### PR TITLE
Fix copy mode activation on Strixhaven map

### DIFF
--- a/dnd/strixhaven/map/index.php
+++ b/dnd/strixhaven/map/index.php
@@ -518,6 +518,9 @@ $isGM = ($user === 'GM');
             
             mapInterface = new MapInterface();
             mapInterface.initialize();
+
+            // Expose the interface globally for popup helpers (copy mode, etc.)
+            window.mapInterface = mapInterface;
             
             // Update info panel on mouse move
             document.getElementById('hex-canvas').addEventListener('mousemove', function(e) {


### PR DESCRIPTION
## Summary
- expose the map interface instance on `window` so popup helpers can reach it
- ensure copy-mode actions invoked from the hex popup operate on the active map

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df4b02e054832780c699443705a411