### PR TITLE
Ensure settings tabs show only active section

### DIFF
--- a/dnd/css/vtt.css
+++ b/dnd/css/vtt.css
@@ -396,6 +396,10 @@
     gap: 1.5rem;
 }
 
+.settings-panel__tabpanel[hidden] {
+    display: none;
+}
+
 .settings-panel__primary-action {
     align-self: flex-start;
     padding: 0.45rem 0.85rem;

--- a/dnd/js/vtt.js
+++ b/dnd/js/vtt.js
@@ -234,7 +234,9 @@
                     button.setAttribute('tabindex', isActive ? '0' : '-1');
                 });
                 tabPanels.forEach(function (panel) {
-                    panel.hidden = panel.id !== targetId;
+                    const isActivePanel = panel.id === targetId;
+                    panel.hidden = !isActivePanel;
+                    panel.setAttribute('aria-hidden', isActivePanel ? 'false' : 'true');
                 });
             }
         }


### PR DESCRIPTION
## Summary
- hide inactive settings tab panels and mark them aria-hidden when switching tabs
- add CSS to make sure hidden panels stay out of view so only the active section is visible

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68df5d012c908327b0999f1e88b99578