### PR TITLE
Fix token image dropzone being blocked by chat drop target

### DIFF
--- a/dnd/js/chat-panel.js
+++ b/dnd/js/chat-panel.js
@@ -961,11 +961,34 @@
             const target = isElement
                 ? event.target
                 : (event.target && event.target.nodeType === 1 ? event.target : null);
-            if (!target) {
+            if (target && target.closest('[data-chat-drop-ignore="true"]')) {
+                return true;
+            }
+
+            const x = Number.isFinite(event.clientX) ? event.clientX : null;
+            const y = Number.isFinite(event.clientY) ? event.clientY : null;
+            if (x === null || y === null) {
                 return false;
             }
 
-            return Boolean(target.closest('[data-chat-drop-ignore="true"]'));
+            if (typeof document !== 'undefined') {
+                if (typeof document.elementsFromPoint === 'function') {
+                    const elements = document.elementsFromPoint(x, y) || [];
+                    return elements.some(function (element) {
+                        return element instanceof Element
+                            && Boolean(element.closest('[data-chat-drop-ignore="true"]'));
+                    });
+                }
+
+                if (typeof document.elementFromPoint === 'function') {
+                    const element = document.elementFromPoint(x, y);
+                    if (element && element.closest('[data-chat-drop-ignore="true"]')) {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
         }
 
         function closeImageLightbox() {


### PR DESCRIPTION
## Summary
- ensure the chat drag handler respects drop-ignore regions even when another element is on top
- use pointer coordinates to find underlying elements that should opt out of chat drops

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68df64db86c48327aacd056670cc8fa2