### PR TITLE
Implement change-tracked scene persistence

### DIFF
--- a/dnd/vtt/index.php
+++ b/dnd/vtt/index.php
@@ -106,6 +106,7 @@ $vttConfig = [
     'activeSceneId' => $activeSceneId,
     'activeScene' => $activeScene,
     'sceneEndpoint' => 'scenes_handler.php',
+    'latestChangeId' => getLatestChangeId(),
 ];
 ?>
 <!DOCTYPE html>


### PR DESCRIPTION
## Summary
- add version metadata and change-log utilities so scenes and folders record updates
- expand the VTT scene handler with read-only state and incremental change endpoints that surface the latest change id
- update the client to track the latest change id, poll for deltas, and merge active-scene payloads while continuing to load full state when needed

## Testing
- php -l dnd/vtt/scenes_repository.php
- php -l dnd/vtt/scenes_handler.php

------
https://chatgpt.com/codex/tasks/task_e_68e165fb4a3883278e81a4adc1c53920