### PR TITLE
Add scene token placement and editing support

### DIFF
--- a/dnd/css/vtt.css
+++ b/dnd/css/vtt.css
@@ -193,6 +193,40 @@
     background-position: center;
 }
 
+.scene-display__token-layer {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    z-index: 15;
+}
+
+.scene-token {
+    position: absolute;
+    pointer-events: auto;
+    border-radius: 999px;
+    background-size: cover;
+    background-position: center;
+    background-repeat: no-repeat;
+    box-shadow: 0 6px 22px rgba(15, 23, 42, 0.55);
+    border: 3px solid rgba(15, 23, 42, 0.85);
+    transition: box-shadow 120ms ease, transform 120ms ease;
+    cursor: pointer;
+}
+
+.scene-token:focus {
+    outline: none;
+    box-shadow: 0 0 0 3px rgba(56, 189, 248, 0.7), 0 10px 28px rgba(15, 23, 42, 0.65);
+}
+
+.scene-token--selected {
+    box-shadow: 0 0 0 4px rgba(56, 189, 248, 0.9), 0 18px 32px rgba(56, 189, 248, 0.35);
+    border-color: rgba(56, 189, 248, 0.9);
+}
+
+.scene-token--drag-target {
+    box-shadow: 0 0 0 4px rgba(96, 165, 250, 0.55), 0 12px 24px rgba(96, 165, 250, 0.25);
+}
+
 .scene-display__grid-controls {
     position: absolute;
     bottom: 1.25rem;
@@ -923,6 +957,40 @@
     text-align: center;
     font-size: 0.95rem;
     color: rgba(226, 232, 240, 0.7);
+}
+
+.token-context-menu {
+    position: fixed;
+    min-width: 180px;
+    background: rgba(15, 23, 42, 0.95);
+    border: 1px solid rgba(148, 163, 184, 0.4);
+    border-radius: 10px;
+    box-shadow: 0 20px 50px rgba(15, 23, 42, 0.65);
+    padding: 0.35rem;
+    z-index: 2000;
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    backdrop-filter: blur(12px);
+}
+
+.token-context-menu__button {
+    appearance: none;
+    border: none;
+    background: transparent;
+    color: rgba(226, 232, 240, 0.95);
+    text-align: left;
+    padding: 0.5rem 0.75rem;
+    border-radius: 8px;
+    font-size: 0.9rem;
+    cursor: pointer;
+}
+
+.token-context-menu__button:hover,
+.token-context-menu__button:focus {
+    outline: none;
+    background: rgba(56, 189, 248, 0.18);
+    color: #e0f2fe;
 }
 
 .scene-management {

--- a/dnd/vtt/index.php
+++ b/dnd/vtt/index.php
@@ -161,6 +161,7 @@ $vttConfig = [
                                 alt="Scene map"
                             >
                             <div id="scene-map-grid" class="scene-display__map-grid"></div>
+                            <div id="scene-token-layer" class="scene-display__token-layer" aria-live="polite"></div>
                         </div>
                     </div>
                     <div id="scene-grid-controls" class="scene-display__grid-controls">


### PR DESCRIPTION
## Summary
- implement a custom context menu for token cards so existing tokens can be edited from the library
- enable dragging saved tokens onto the scene with grid-aligned placement, persistence, and keyboard movement controls
- render a dedicated token overlay above the map with updated styling for on-scene tokens

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e16f2c361c832798d3258fda1ce3f3