### PR TITLE
Fix grid misalignment for token snapping

### DIFF
--- a/dnd/css/vtt.css
+++ b/dnd/css/vtt.css
@@ -190,7 +190,7 @@
             transparent var(--grid-size, 50px)
         );
     background-size: var(--grid-size, 50px) var(--grid-size, 50px);
-    background-position: center;
+    background-position: top left;
 }
 
 .scene-display__token-layer {


### PR DESCRIPTION
## Summary
- align the rendered grid with the map's origin so snapped tokens sit on grid intersections

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e176ab32848327b0045ac0ab8f423c