### PR TITLE
Persist VTT tokens on the server

### DIFF
--- a/dnd/vtt/index.php
+++ b/dnd/vtt/index.php
@@ -21,6 +21,7 @@ foreach ($chatParticipantsMap as $participantId => $participantLabel) {
 }
 
 require_once __DIR__ . '/scenes_repository.php';
+require_once __DIR__ . '/token_repository.php';
 
 $sceneData = require __DIR__ . '/scenes.php';
 if (!is_array($sceneData)) {
@@ -98,6 +99,11 @@ if (is_array($activeScene) && isset($activeScene['map']) && is_array($activeScen
     $activeSceneMap['gridScale'] = $gridScale;
 }
 
+$tokenLibrary = loadTokenLibrary();
+$activeSceneTokens = $activeSceneId !== null
+    ? loadSceneTokensByScene($activeSceneId)
+    : [];
+
 $vttConfig = [
     'isGM' => $isGm,
     'currentUser' => $user,
@@ -106,6 +112,9 @@ $vttConfig = [
     'activeSceneId' => $activeSceneId,
     'activeScene' => $activeScene,
     'sceneEndpoint' => 'scenes_handler.php',
+    'tokenEndpoint' => 'token_handler.php',
+    'tokenLibrary' => $tokenLibrary,
+    'activeSceneTokens' => $activeSceneTokens,
     'latestChangeId' => getLatestChangeId(),
 ];
 ?>

--- a/dnd/vtt/token_handler.php
+++ b/dnd/vtt/token_handler.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
+
+header('Content-Type: application/json');
+
+if (!isset($_SESSION['logged_in']) || $_SESSION['logged_in'] !== true) {
+    http_response_code(403);
+    echo json_encode(['success' => false, 'error' => 'Authentication required.']);
+    exit;
+}
+
+require_once __DIR__ . '/token_repository.php';
+
+$user = $_SESSION['user'] ?? '';
+$isGm = strtolower((string) $user) === 'gm';
+
+$action = $_REQUEST['action'] ?? '';
+$action = is_string($action) ? strtolower(trim($action)) : '';
+if ($action === '') {
+    $action = $_SERVER['REQUEST_METHOD'] === 'POST' ? 'save_library' : 'library';
+}
+
+switch ($action) {
+    case 'library':
+    case 'get_library':
+        handleGetLibrary();
+        break;
+
+    case 'save_library':
+        if (!$isGm) {
+            http_response_code(403);
+            echo json_encode(['success' => false, 'error' => 'Only the GM can modify the token library.']);
+            exit;
+        }
+        handleSaveLibrary();
+        break;
+
+    case 'scene_tokens':
+    case 'get_scene_tokens':
+        handleGetSceneTokens();
+        break;
+
+    case 'save_scene_tokens':
+        if (!$isGm) {
+            http_response_code(403);
+            echo json_encode(['success' => false, 'error' => 'Only the GM can update scene tokens.']);
+            exit;
+        }
+        handleSaveSceneTokens();
+        break;
+
+    default:
+        http_response_code(400);
+        echo json_encode(['success' => false, 'error' => 'Unsupported action.']);
+        break;
+}
+
+function handleGetLibrary(): void
+{
+    $tokens = loadTokenLibrary();
+    echo json_encode([
+        'success' => true,
+        'tokens' => $tokens,
+        'latest_change_id' => getLatestChangeId(),
+    ]);
+}
+
+function handleSaveLibrary(): void
+{
+    $payload = readJsonPayload();
+    $tokens = $payload['tokens'] ?? null;
+    if (!is_array($tokens)) {
+        http_response_code(400);
+        echo json_encode(['success' => false, 'error' => 'A token list is required.']);
+        return;
+    }
+
+    $saved = saveTokenLibrary($tokens);
+    if ($saved === null) {
+        http_response_code(500);
+        echo json_encode(['success' => false, 'error' => 'Unable to save the token library.']);
+        return;
+    }
+
+    echo json_encode([
+        'success' => true,
+        'tokens' => $saved,
+        'latest_change_id' => getLatestChangeId(),
+    ]);
+}
+
+function handleGetSceneTokens(): void
+{
+    $sceneId = isset($_REQUEST['scene_id']) && is_string($_REQUEST['scene_id'])
+        ? trim($_REQUEST['scene_id'])
+        : '';
+    if ($sceneId === '') {
+        http_response_code(400);
+        echo json_encode(['success' => false, 'error' => 'A scene identifier is required.']);
+        return;
+    }
+
+    $tokens = loadSceneTokensByScene($sceneId);
+    echo json_encode([
+        'success' => true,
+        'scene_id' => $sceneId,
+        'tokens' => $tokens,
+        'latest_change_id' => getLatestChangeId(),
+    ]);
+}
+
+function handleSaveSceneTokens(): void
+{
+    $payload = readJsonPayload();
+    $sceneId = isset($payload['sceneId']) && is_string($payload['sceneId'])
+        ? trim($payload['sceneId'])
+        : '';
+    if ($sceneId === '') {
+        http_response_code(400);
+        echo json_encode(['success' => false, 'error' => 'A scene identifier is required.']);
+        return;
+    }
+
+    $tokens = $payload['tokens'] ?? null;
+    if (!is_array($tokens)) {
+        http_response_code(400);
+        echo json_encode(['success' => false, 'error' => 'A list of tokens is required.']);
+        return;
+    }
+
+    $saved = saveSceneTokensByScene($sceneId, $tokens);
+    if ($saved === null) {
+        http_response_code(500);
+        echo json_encode(['success' => false, 'error' => 'Unable to save scene tokens.']);
+        return;
+    }
+
+    echo json_encode([
+        'success' => true,
+        'scene_id' => $sceneId,
+        'tokens' => $saved,
+        'latest_change_id' => getLatestChangeId(),
+    ]);
+}
+
+function readJsonPayload(): array
+{
+    $raw = file_get_contents('php://input');
+    if ($raw === false || trim($raw) === '') {
+        return [];
+    }
+
+    $decoded = json_decode($raw, true);
+    if (!is_array($decoded)) {
+        return [];
+    }
+
+    return $decoded;
+}

--- a/dnd/vtt/token_repository.php
+++ b/dnd/vtt/token_repository.php
@@ -1,0 +1,394 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/scenes_repository.php';
+
+const VTT_TOKEN_LIBRARY_FILE = __DIR__ . '/../data/vtt_token_library.json';
+const VTT_SCENE_TOKENS_FILE = __DIR__ . '/../data/vtt_scene_tokens.json';
+
+/**
+ * Load the token library entries from disk.
+ */
+function loadTokenLibrary(): array
+{
+    ensureTokenLibraryFile();
+
+    $raw = @file_get_contents(VTT_TOKEN_LIBRARY_FILE);
+    if ($raw === false) {
+        return [];
+    }
+
+    $decoded = json_decode($raw, true);
+    if (!is_array($decoded)) {
+        return [];
+    }
+
+    return normalizeTokenLibraryEntries($decoded);
+}
+
+/**
+ * Persist the token library to disk and return the normalized payload.
+ */
+function saveTokenLibrary(array $tokens): ?array
+{
+    ensureTokenLibraryFile();
+
+    $normalized = normalizeTokenLibraryEntries($tokens);
+    $payload = json_encode($normalized, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+    if ($payload === false) {
+        return null;
+    }
+
+    if (!writeFileWithLock(VTT_TOKEN_LIBRARY_FILE, $payload)) {
+        return null;
+    }
+
+    recordTokenLibraryChange();
+
+    return $normalized;
+}
+
+/**
+ * Load the scene token entries for a specific scene.
+ */
+function loadSceneTokensByScene(string $sceneId): array
+{
+    $sceneId = trim($sceneId);
+    if ($sceneId === '') {
+        return [];
+    }
+
+    $state = loadSceneTokenState();
+    $tokens = $state[$sceneId] ?? [];
+
+    if (!is_array($tokens)) {
+        return [];
+    }
+
+    return normalizeSceneTokenEntries($tokens);
+}
+
+/**
+ * Save scene tokens for a given scene and return the normalized payload.
+ */
+function saveSceneTokensByScene(string $sceneId, array $tokens): ?array
+{
+    $sceneId = trim($sceneId);
+    if ($sceneId === '') {
+        return null;
+    }
+
+    $state = loadSceneTokenState();
+    $normalized = normalizeSceneTokenEntries($tokens);
+    $state[$sceneId] = $normalized;
+
+    $payload = json_encode($state, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+    if ($payload === false) {
+        return null;
+    }
+
+    if (!writeFileWithLock(VTT_SCENE_TOKENS_FILE, $payload)) {
+        return null;
+    }
+
+    recordSceneTokensChange($sceneId);
+
+    return $normalized;
+}
+
+function ensureTokenLibraryFile(): void
+{
+    $directory = dirname(VTT_TOKEN_LIBRARY_FILE);
+    if (!is_dir($directory)) {
+        mkdir($directory, 0755, true);
+    }
+
+    if (!file_exists(VTT_TOKEN_LIBRARY_FILE)) {
+        file_put_contents(VTT_TOKEN_LIBRARY_FILE, json_encode([], JSON_PRETTY_PRINT), LOCK_EX);
+    }
+}
+
+function ensureSceneTokenFile(): void
+{
+    $directory = dirname(VTT_SCENE_TOKENS_FILE);
+    if (!is_dir($directory)) {
+        mkdir($directory, 0755, true);
+    }
+
+    if (!file_exists(VTT_SCENE_TOKENS_FILE)) {
+        file_put_contents(VTT_SCENE_TOKENS_FILE, json_encode([], JSON_PRETTY_PRINT), LOCK_EX);
+    }
+}
+
+function loadSceneTokenState(): array
+{
+    ensureSceneTokenFile();
+
+    $raw = @file_get_contents(VTT_SCENE_TOKENS_FILE);
+    if ($raw === false) {
+        return [];
+    }
+
+    $decoded = json_decode($raw, true);
+    if (!is_array($decoded)) {
+        return [];
+    }
+
+    $state = [];
+    foreach ($decoded as $sceneId => $tokens) {
+        if (!is_string($sceneId) || $sceneId === '') {
+            continue;
+        }
+        if (!is_array($tokens)) {
+            continue;
+        }
+        $state[$sceneId] = normalizeSceneTokenEntries($tokens);
+    }
+
+    return $state;
+}
+
+function normalizeTokenLibraryEntries($entries): array
+{
+    if (!is_array($entries)) {
+        return [];
+    }
+
+    $normalized = [];
+    foreach ($entries as $entry) {
+        $normalizedEntry = normalizeTokenLibraryEntry($entry);
+        if ($normalizedEntry !== null) {
+            $normalized[] = $normalizedEntry;
+        }
+    }
+
+    return $normalized;
+}
+
+function normalizeTokenLibraryEntry($entry): ?array
+{
+    if (!is_array($entry)) {
+        return null;
+    }
+
+    $id = isset($entry['id']) ? trim((string) $entry['id']) : '';
+    if ($id === '') {
+        $id = generateIdentifier('token');
+    }
+
+    $name = isset($entry['name']) ? trim((string) $entry['name']) : '';
+    if ($name === '') {
+        return null;
+    }
+
+    $imageData = isset($entry['imageData']) ? (string) $entry['imageData'] : '';
+    if ($imageData === '') {
+        return null;
+    }
+
+    $allowedFolders = ['pcs', 'npcs', 'monsters'];
+    $folderId = isset($entry['folderId']) ? (string) $entry['folderId'] : 'pcs';
+    if (!in_array($folderId, $allowedFolders, true)) {
+        $folderId = 'pcs';
+    }
+
+    $allowedSchools = ['lorehold', 'prismari', 'quandrix', 'silverquill', 'witherbloom', 'other'];
+    $schoolId = isset($entry['schoolId']) ? (string) $entry['schoolId'] : 'other';
+    if (!in_array($schoolId, $allowedSchools, true)) {
+        $schoolId = 'other';
+    }
+
+    $size = isset($entry['size']) && is_array($entry['size']) ? $entry['size'] : [];
+    $width = clampTokenDimension($size['width'] ?? null);
+    $height = clampTokenDimension($size['height'] ?? null);
+
+    $stamina = clampTokenStamina($entry['stamina'] ?? 0);
+
+    $createdAt = normalizeTimestamp($entry['createdAt'] ?? null);
+    $updatedAt = normalizeTimestamp($entry['updatedAt'] ?? $createdAt);
+
+    return [
+        'id' => $id,
+        'name' => $name,
+        'folderId' => $folderId,
+        'schoolId' => $schoolId,
+        'size' => [
+            'width' => $width,
+            'height' => $height,
+        ],
+        'stamina' => $stamina,
+        'imageData' => $imageData,
+        'createdAt' => $createdAt,
+        'updatedAt' => $updatedAt,
+    ];
+}
+
+function normalizeSceneTokenEntries($entries): array
+{
+    if (!is_array($entries)) {
+        return [];
+    }
+
+    $normalized = [];
+    foreach ($entries as $entry) {
+        $normalizedEntry = normalizeSceneTokenEntry($entry);
+        if ($normalizedEntry !== null) {
+            $normalized[] = $normalizedEntry;
+        }
+    }
+
+    return $normalized;
+}
+
+function normalizeSceneTokenEntry($entry): ?array
+{
+    if (!is_array($entry)) {
+        return null;
+    }
+
+    $id = isset($entry['id']) ? trim((string) $entry['id']) : '';
+    $imageData = isset($entry['imageData']) ? (string) $entry['imageData'] : '';
+    if ($id === '' || $imageData === '') {
+        return null;
+    }
+
+    $name = isset($entry['name']) ? (string) $entry['name'] : '';
+    $libraryId = isset($entry['libraryId']) ? (string) $entry['libraryId'] : '';
+    $stamina = clampTokenStamina($entry['stamina'] ?? 0);
+
+    $size = isset($entry['size']) && is_array($entry['size']) ? $entry['size'] : [];
+    $width = clampTokenDimension($size['width'] ?? null);
+    $height = clampTokenDimension($size['height'] ?? null);
+
+    $position = isset($entry['position']) && is_array($entry['position']) ? $entry['position'] : [];
+    $x = normalizeCoordinate($position['x'] ?? 0);
+    $y = normalizeCoordinate($position['y'] ?? 0);
+
+    return [
+        'id' => $id,
+        'libraryId' => $libraryId,
+        'name' => $name,
+        'imageData' => $imageData,
+        'stamina' => $stamina,
+        'size' => [
+            'width' => $width,
+            'height' => $height,
+        ],
+        'position' => [
+            'x' => $x,
+            'y' => $y,
+        ],
+    ];
+}
+
+function clampTokenDimension($value): int
+{
+    if (is_int($value)) {
+        $numeric = $value;
+    } elseif (is_float($value) || is_numeric($value)) {
+        $numeric = (int) round((float) $value);
+    } else {
+        $numeric = 1;
+    }
+
+    if ($numeric < 1) {
+        return 1;
+    }
+    if ($numeric > 12) {
+        return 12;
+    }
+
+    return $numeric;
+}
+
+function clampTokenStamina($value): int
+{
+    if (!is_numeric($value)) {
+        return 0;
+    }
+
+    $numeric = (int) round((float) $value);
+    if ($numeric < 0) {
+        return 0;
+    }
+
+    return $numeric;
+}
+
+function normalizeTimestamp($value): int
+{
+    if (!is_numeric($value)) {
+        return (int) floor(microtime(true) * 1000);
+    }
+
+    $timestamp = (int) round((float) $value);
+    if ($timestamp < 0) {
+        $timestamp = 0;
+    }
+
+    return $timestamp;
+}
+
+function normalizeCoordinate($value): float
+{
+    if (!is_numeric($value)) {
+        return 0.0;
+    }
+
+    $numeric = (float) $value;
+    if ($numeric < 0) {
+        $numeric = 0.0;
+    }
+
+    return round($numeric, 4);
+}
+
+function writeFileWithLock(string $filePath, string $contents): bool
+{
+    $fp = fopen($filePath, 'c+');
+    if ($fp === false) {
+        return false;
+    }
+
+    $result = false;
+    if (flock($fp, LOCK_EX)) {
+        ftruncate($fp, 0);
+        rewind($fp);
+        $bytes = fwrite($fp, $contents);
+        fflush($fp);
+        flock($fp, LOCK_UN);
+        $result = $bytes !== false;
+    }
+
+    fclose($fp);
+
+    return $result;
+}
+
+function recordTokenLibraryChange(): void
+{
+    appendChangeLogEntry([
+        'entityType' => 'token_library',
+        'entityId' => 'library',
+        'operation' => 'updated',
+        'version' => null,
+        'payload' => [
+            'updatedAt' => currentUtcTimestamp(),
+        ],
+    ]);
+}
+
+function recordSceneTokensChange(string $sceneId): void
+{
+    appendChangeLogEntry([
+        'entityType' => 'scene_tokens',
+        'entityId' => $sceneId,
+        'operation' => 'updated',
+        'version' => null,
+        'payload' => [
+            'sceneId' => $sceneId,
+            'updatedAt' => currentUtcTimestamp(),
+        ],
+    ]);
+}


### PR DESCRIPTION
## Summary
- add a PHP token repository and handler that persist the token library and scene tokens on disk while recording change-log entries
- expose the new token endpoint and initial token payloads through the VTT index bootstrap
- refactor the VTT client to load and save tokens via the server, including reacting to change log updates for libraries and scenes

## Testing
- php -l dnd/vtt/token_repository.php
- php -l dnd/vtt/token_handler.php
- php -l dnd/vtt/index.php

------
https://chatgpt.com/codex/tasks/task_e_68e17815cd2883279dcb1a058610c0d4