### PR TITLE
Fix VTT active scene loading on older PHP versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,9 @@ pnpm-lock.yaml
 /dnd/data/pcs.json
 /dnd/data/characters_backup_*.json
 /dnd/data/characters_emergency_*.json
+/dnd/data/vtt_change_log.json
+/dnd/data/vtt_scene_tokens.json
+/dnd/data/vtt_token_library.json
 
 # Schedule data
 /dnd/schedule/data/schedules.json

--- a/dnd/vtt/index.php
+++ b/dnd/vtt/index.php
@@ -41,13 +41,7 @@ foreach ($scenes as $scene) {
     $sceneLookup[$scene['id']] = $scene;
 }
 
-$defaultSceneId = null;
-if (!empty($scenes)) {
-    $firstScene = reset($scenes);
-    if (is_array($firstScene) && isset($firstScene['id'])) {
-        $defaultSceneId = $firstScene['id'];
-    }
-}
+$defaultSceneId = getFirstSceneId($sceneData);
 
 $sceneStateFile = __DIR__ . '/../data/vtt_active_scene.json';
 $sceneStateDir = dirname($sceneStateFile);
@@ -73,8 +67,15 @@ if (file_exists($sceneStateFile)) {
     );
 }
 
+if ($activeSceneId === null && $defaultSceneId !== null) {
+    $activeSceneId = $defaultSceneId;
+}
+
 if ($activeSceneId === null && !empty($sceneLookup)) {
-    $activeSceneId = array_key_first($sceneLookup);
+    foreach ($sceneLookup as $sceneId => $_scene) {
+        $activeSceneId = $sceneId;
+        break;
+    }
 }
 
 $activeScene = $activeSceneId !== null && isset($sceneLookup[$activeSceneId])


### PR DESCRIPTION
## Summary
- replace the VTT default scene lookup to rely on repository helpers and drop usage of array_key_first so the page works on older PHP releases
- ignore VTT runtime data files to keep generated change logs and token caches out of version control

## Testing
- php -d display_errors=1 -r 'session_start(); $_SESSION["logged_in"]=true; $_SESSION["user"]= "gm"; include "dnd/vtt/index.php";'

------
https://chatgpt.com/codex/tasks/task_e_68e17f138f44832796cb40f1ab92cf93