### PR TITLE
Remove void return types for PHP 7 compatibility

### DIFF
--- a/dnd/vtt/token_handler.php
+++ b/dnd/vtt/token_handler.php
@@ -58,7 +58,7 @@ switch ($action) {
         break;
 }
 
-function handleGetLibrary(): void
+function handleGetLibrary()
 {
     $tokens = loadTokenLibrary();
     echo json_encode([
@@ -68,7 +68,7 @@ function handleGetLibrary(): void
     ]);
 }
 
-function handleSaveLibrary(): void
+function handleSaveLibrary()
 {
     $payload = readJsonPayload();
     $tokens = $payload['tokens'] ?? null;
@@ -92,7 +92,7 @@ function handleSaveLibrary(): void
     ]);
 }
 
-function handleGetSceneTokens(): void
+function handleGetSceneTokens()
 {
     $sceneId = isset($_REQUEST['scene_id']) && is_string($_REQUEST['scene_id'])
         ? trim($_REQUEST['scene_id'])
@@ -112,7 +112,7 @@ function handleGetSceneTokens(): void
     ]);
 }
 
-function handleSaveSceneTokens(): void
+function handleSaveSceneTokens()
 {
     $payload = readJsonPayload();
     $sceneId = isset($payload['sceneId']) && is_string($payload['sceneId'])


### PR DESCRIPTION
## Summary
- remove PHP 7.1+ void return type declarations from token handler functions to support PHP 7.0

## Testing
- php -l dnd/vtt/token_handler.php

------
https://chatgpt.com/codex/tasks/task_e_68e1c194f7a0832782040f916faee12b