### PR TITLE
Implement persistent scene storage and change tracking for VTT

### DIFF
--- a/dnd/vtt/index.php
+++ b/dnd/vtt/index.php
@@ -106,6 +106,7 @@ $vttConfig = [
     'activeSceneId' => $activeSceneId,
     'activeScene' => $activeScene,
     'sceneEndpoint' => 'scenes_handler.php',
+    'latestChangeId' => getLatestSceneChangeId(),
 ];
 ?>
 <!DOCTYPE html>

--- a/dnd/vtt/scenes_repository.php
+++ b/dnd/vtt/scenes_repository.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 const VTT_SCENES_FILE = __DIR__ . '/../data/vtt_scenes.json';
 const VTT_MAP_UPLOAD_DIR = __DIR__ . '/../images/vtt/maps';
+const VTT_SCENE_CHANGES_FILE = __DIR__ . '/../data/vtt_scene_changes.json';
 
 function loadScenesData(): array
 {
@@ -100,6 +101,8 @@ function ensureScenesDataFile(): void
             LOCK_EX
         );
     }
+
+    ensureSceneChangesFile();
 }
 
 function normalizeScenesList($scenes): array
@@ -397,6 +400,195 @@ function getFirstSceneId(array $data): ?string
     }
 
     return null;
+}
+
+function ensureSceneChangesFile(): void
+{
+    $directory = dirname(VTT_SCENE_CHANGES_FILE);
+    if (!is_dir($directory)) {
+        mkdir($directory, 0755, true);
+    }
+
+    if (!file_exists(VTT_SCENE_CHANGES_FILE)) {
+        file_put_contents(
+            VTT_SCENE_CHANGES_FILE,
+            json_encode([
+                'latest_change_id' => 0,
+                'changes' => [],
+            ], JSON_PRETTY_PRINT),
+            LOCK_EX
+        );
+    }
+}
+
+function loadSceneChangeState(): array
+{
+    ensureSceneChangesFile();
+
+    $state = [
+        'latest_change_id' => 0,
+        'changes' => [],
+    ];
+
+    $fp = fopen(VTT_SCENE_CHANGES_FILE, 'c+');
+    if ($fp === false) {
+        return $state;
+    }
+
+    if (flock($fp, LOCK_SH)) {
+        $content = stream_get_contents($fp);
+        if (is_string($content) && $content !== '') {
+            $decoded = json_decode($content, true);
+            if (is_array($decoded)) {
+                if (isset($decoded['latest_change_id'])) {
+                    $state['latest_change_id'] = (int) $decoded['latest_change_id'];
+                }
+                if (isset($decoded['changes']) && is_array($decoded['changes'])) {
+                    $state['changes'] = array_values(array_filter($decoded['changes'], 'is_array'));
+                }
+            }
+        }
+        flock($fp, LOCK_UN);
+    }
+
+    fclose($fp);
+
+    return $state;
+}
+
+function saveSceneChangeState(array $state): bool
+{
+    ensureSceneChangesFile();
+
+    $payload = json_encode([
+        'latest_change_id' => isset($state['latest_change_id']) ? (int) $state['latest_change_id'] : 0,
+        'changes' => isset($state['changes']) && is_array($state['changes']) ? array_values($state['changes']) : [],
+    ], JSON_PRETTY_PRINT);
+
+    if ($payload === false) {
+        return false;
+    }
+
+    $fp = fopen(VTT_SCENE_CHANGES_FILE, 'c+');
+    if ($fp === false) {
+        return false;
+    }
+
+    $result = false;
+    if (flock($fp, LOCK_EX)) {
+        ftruncate($fp, 0);
+        rewind($fp);
+        $bytesWritten = fwrite($fp, $payload);
+        fflush($fp);
+        flock($fp, LOCK_UN);
+        $result = $bytesWritten !== false;
+    }
+
+    fclose($fp);
+
+    return $result;
+}
+
+function recordSceneChange(string $entityType, ?string $entityId, array $payload = []): ?int
+{
+    ensureSceneChangesFile();
+
+    $fp = fopen(VTT_SCENE_CHANGES_FILE, 'c+');
+    if ($fp === false) {
+        return null;
+    }
+
+    $recordedId = null;
+
+    if (flock($fp, LOCK_EX)) {
+        $content = stream_get_contents($fp);
+        $state = [
+            'latest_change_id' => 0,
+            'changes' => [],
+        ];
+
+        if (is_string($content) && $content !== '') {
+            $decoded = json_decode($content, true);
+            if (is_array($decoded)) {
+                if (isset($decoded['latest_change_id'])) {
+                    $state['latest_change_id'] = (int) $decoded['latest_change_id'];
+                }
+                if (isset($decoded['changes']) && is_array($decoded['changes'])) {
+                    $state['changes'] = array_values(array_filter($decoded['changes'], 'is_array'));
+                }
+            }
+        }
+
+        $nextId = $state['latest_change_id'] + 1;
+        $entry = [
+            'id' => $nextId,
+            'entityType' => $entityType,
+            'entityId' => $entityId !== null ? (string) $entityId : null,
+            'payload' => $payload,
+            'timestamp' => time(),
+        ];
+
+        $state['latest_change_id'] = $nextId;
+        $state['changes'][] = $entry;
+
+        $maxEntries = 200;
+        if (count($state['changes']) > $maxEntries) {
+            $state['changes'] = array_slice($state['changes'], -$maxEntries);
+        }
+
+        $payloadEncoded = json_encode([
+            'latest_change_id' => $state['latest_change_id'],
+            'changes' => $state['changes'],
+        ], JSON_PRETTY_PRINT);
+
+        if ($payloadEncoded !== false) {
+            ftruncate($fp, 0);
+            rewind($fp);
+            $bytesWritten = fwrite($fp, $payloadEncoded);
+            fflush($fp);
+            if ($bytesWritten !== false) {
+                $recordedId = $nextId;
+            }
+        }
+
+        flock($fp, LOCK_UN);
+    }
+
+    fclose($fp);
+
+    return $recordedId;
+}
+
+function getSceneChangesSince(int $sinceId): array
+{
+    $state = loadSceneChangeState();
+
+    $latestId = isset($state['latest_change_id']) ? (int) $state['latest_change_id'] : 0;
+    $changes = [];
+
+    foreach ($state['changes'] as $entry) {
+        if (!is_array($entry)) {
+            continue;
+        }
+        $entryId = isset($entry['id']) ? (int) $entry['id'] : 0;
+        if ($entryId > $sinceId) {
+            $changes[] = [
+                'id' => $entryId,
+                'entityType' => isset($entry['entityType']) ? (string) $entry['entityType'] : '',
+                'entityId' => isset($entry['entityId']) ? $entry['entityId'] : null,
+                'payload' => isset($entry['payload']) && is_array($entry['payload']) ? $entry['payload'] : [],
+                'timestamp' => isset($entry['timestamp']) ? (int) $entry['timestamp'] : time(),
+            ];
+        }
+    }
+
+    return [$changes, $latestId];
+}
+
+function getLatestSceneChangeId(): int
+{
+    $state = loadSceneChangeState();
+    return isset($state['latest_change_id']) ? (int) $state['latest_change_id'] : 0;
 }
 
 function ensureMapUploadDirectory(): void


### PR DESCRIPTION
## Summary
- add a JSON-backed change log to persist scene updates across sessions
- expose scene state and change polling endpoints while recording change ids for GM actions
- initialize the client with the latest change id so reloads and polling keep the active scene in sync

## Testing
- php -l dnd/vtt/scenes_repository.php
- php -l dnd/vtt/scenes_handler.php
- php -l dnd/vtt/index.php

------
https://chatgpt.com/codex/tasks/task_e_68e1dc0129808327a17a09ad8a3f1189