### PR TITLE
Fix VTT script merge markers to restore panel toggles

### DIFF
--- a/dnd/js/vtt.js
+++ b/dnd/js/vtt.js
@@ -338,7 +338,6 @@
             updateTokenFormMode();
             refreshTokenLibraryFromServer(false);
 
-<<<<<<< HEAD
             function ensureTokenContextMenuElement() {
                 if (tokenContextMenu) {
                     return;
@@ -435,9 +434,6 @@
                     closeTokenContextMenu();
                 }
             }
-
-=======
->>>>>>> parent of de66a72 (Merge pull request #85 from Tastanis/codex/fix-browse-button-under-token-artwork)
             if (tokenForm && dropzone && fileInput && cropperImage && cropperStage && cropperContainer) {
                 dropzone.addEventListener('click', function (event) {
                     event.stopPropagation();


### PR DESCRIPTION
## Summary
- remove stray merge conflict markers from `dnd/js/vtt.js` so the VTT initialization script can run again

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68e1de80ea40832785534e9688064da0