### PR TITLE
Fix token artwork browse button

### DIFF
--- a/dnd/vtt/index.php
+++ b/dnd/vtt/index.php
@@ -284,7 +284,15 @@ $vttConfig = [
                                             <input type="file" id="token-image-input" class="token-dropzone__input" accept="image/*">
                                         </div>
                                         <div class="token-dropzone__actions">
-                                            <button type="button" id="token-image-browse" class="token-dropzone__browse">Browse</button>
+                                            <label
+                                                for="token-image-input"
+                                                id="token-image-browse"
+                                                class="token-dropzone__browse"
+                                                role="button"
+                                                tabindex="0"
+                                            >
+                                                Browse
+                                            </label>
                                         </div>
                                         <div id="token-image-cropper" class="token-cropper" hidden>
                                             <div id="token-cropper-stage" class="token-cropper__stage">


### PR DESCRIPTION
## Summary
- replace the token artwork browse control with a label linked to the hidden file input so the native file picker always opens

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e1e08d12d48327a7c31632d7a422cf