### PR TITLE
Fix token art browse button

### DIFF
--- a/dnd/js/vtt.js
+++ b/dnd/js/vtt.js
@@ -435,6 +435,25 @@
                 }
             }
             if (tokenForm && dropzone && fileInput && cropperImage && cropperStage && cropperContainer) {
+                function openTokenImagePicker() {
+                    if (!fileInput) {
+                        return;
+                    }
+                    if (typeof fileInput.showPicker === 'function') {
+                        try {
+                            fileInput.showPicker();
+                            return;
+                        } catch (error) {
+                            if (!(error && error.name === 'AbortError')) {
+                                if (typeof console !== 'undefined' && console && typeof console.warn === 'function') {
+                                    console.warn('Unable to open file picker with showPicker()', error);
+                                }
+                            }
+                        }
+                    }
+                    fileInput.click();
+                }
+
                 dropzone.addEventListener('click', function (event) {
                     event.stopPropagation();
                     if (event.defaultPrevented) {
@@ -446,16 +465,14 @@
                         return;
                     }
                     event.preventDefault();
-                    if (fileInput) {
-                        fileInput.click();
-                    }
+                    openTokenImagePicker();
                 });
 
                 dropzone.addEventListener('keydown', function (event) {
                     event.stopPropagation();
                     if (event.key === 'Enter' || event.key === ' ') {
                         event.preventDefault();
-                        fileInput.click();
+                        openTokenImagePicker();
                     }
                 });
 
@@ -486,13 +503,13 @@
                     browseButton.addEventListener('click', function (event) {
                         event.preventDefault();
                         event.stopPropagation();
-                        fileInput.click();
+                        openTokenImagePicker();
                     });
                     browseButton.addEventListener('keydown', function (event) {
                         if (event.key === 'Enter' || event.key === ' ') {
                             event.preventDefault();
                             event.stopPropagation();
-                            fileInput.click();
+                            openTokenImagePicker();
                         }
                     });
                 }

--- a/dnd/vtt/index.php
+++ b/dnd/vtt/index.php
@@ -284,15 +284,13 @@ $vttConfig = [
                                             <input type="file" id="token-image-input" class="token-dropzone__input" accept="image/*">
                                         </div>
                                         <div class="token-dropzone__actions">
-                                            <label
-                                                for="token-image-input"
+                                            <button
+                                                type="button"
                                                 id="token-image-browse"
                                                 class="token-dropzone__browse"
-                                                role="button"
-                                                tabindex="0"
                                             >
                                                 Browse
-                                            </label>
+                                            </button>
                                         </div>
                                         <div id="token-image-cropper" class="token-cropper" hidden>
                                             <div id="token-cropper-stage" class="token-cropper__stage">


### PR DESCRIPTION
## Summary
- replace the token artwork "Browse" control with a real button so it receives clicks reliably
- centralize opening of the file picker and use `showPicker()` when available before falling back to `click()`

## Testing
- php -l vtt/index.php

------
https://chatgpt.com/codex/tasks/task_e_68e1e309ee3c83279c9e5176c04518fd