### PR TITLE
Persist VTT scene state across sessions

### DIFF
--- a/dnd/vtt/index.php
+++ b/dnd/vtt/index.php
@@ -21,6 +21,7 @@ foreach ($chatParticipantsMap as $participantId => $participantLabel) {
 }
 
 require_once __DIR__ . '/scenes_repository.php';
+require_once __DIR__ . '/scene_state_repository.php';
 
 $sceneData = require __DIR__ . '/scenes.php';
 if (!is_array($sceneData)) {
@@ -48,33 +49,9 @@ if (!empty($scenes)) {
     }
 }
 
-$sceneStateFile = __DIR__ . '/../data/vtt_active_scene.json';
-$sceneStateDir = dirname($sceneStateFile);
-if (!is_dir($sceneStateDir)) {
-    mkdir($sceneStateDir, 0755, true);
-}
-
-$activeSceneId = $defaultSceneId;
-if (file_exists($sceneStateFile)) {
-    $rawSceneState = file_get_contents($sceneStateFile);
-    $decodedSceneState = json_decode($rawSceneState, true);
-    if (is_array($decodedSceneState) && isset($decodedSceneState['active_scene_id'])) {
-        $storedSceneId = $decodedSceneState['active_scene_id'];
-        if (isset($sceneLookup[$storedSceneId])) {
-            $activeSceneId = $storedSceneId;
-        }
-    }
-} elseif ($defaultSceneId !== null) {
-    file_put_contents(
-        $sceneStateFile,
-        json_encode(['active_scene_id' => $defaultSceneId], JSON_PRETTY_PRINT),
-        LOCK_EX
-    );
-}
-
-if ($activeSceneId === null && !empty($sceneLookup)) {
-    $activeSceneId = array_key_first($sceneLookup);
-}
+$sceneStateFile = getSceneStateFilePath();
+ensureSceneStateFile($sceneStateFile, $defaultSceneId);
+$activeSceneId = loadActiveSceneId($sceneLookup, $defaultSceneId, $sceneStateFile);
 
 $activeScene = $activeSceneId !== null && isset($sceneLookup[$activeSceneId])
     ? $sceneLookup[$activeSceneId]

--- a/dnd/vtt/scene_state_repository.php
+++ b/dnd/vtt/scene_state_repository.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+const VTT_SCENE_STATE_FILE = __DIR__ . '/../data/vtt_active_scene.json';
+
+function getSceneStateFilePath(): string
+{
+    return VTT_SCENE_STATE_FILE;
+}
+
+function ensureSceneStateFile(?string $filePath = null, ?string $defaultSceneId = null): void
+{
+    $path = $filePath ?? getSceneStateFilePath();
+    $directory = dirname($path);
+    if (!is_dir($directory)) {
+        mkdir($directory, 0755, true);
+    }
+
+    if (!file_exists($path)) {
+        $initialId = $defaultSceneId !== null ? (string) $defaultSceneId : '';
+        $payload = json_encode(['active_scene_id' => $initialId], JSON_PRETTY_PRINT);
+        if ($payload === false) {
+            $payload = '{"active_scene_id": ""}';
+        }
+        file_put_contents($path, $payload, LOCK_EX);
+    }
+}
+
+function loadActiveSceneId(array $sceneLookup, ?string $defaultSceneId = null, ?string $filePath = null): ?string
+{
+    $path = $filePath ?? getSceneStateFilePath();
+    ensureSceneStateFile($path, $defaultSceneId);
+
+    $fp = fopen($path, 'c+');
+    if ($fp === false) {
+        return $defaultSceneId !== null && isset($sceneLookup[$defaultSceneId]) ? $defaultSceneId : null;
+    }
+
+    $storedId = null;
+    $explicitlyCleared = false;
+    if (flock($fp, LOCK_SH)) {
+        $content = stream_get_contents($fp) ?: '';
+        flock($fp, LOCK_UN);
+        $data = json_decode($content, true);
+        if (is_array($data) && array_key_exists('active_scene_id', $data)) {
+            $candidate = (string) $data['active_scene_id'];
+            if ($candidate === '') {
+                $explicitlyCleared = true;
+            } elseif (isset($sceneLookup[$candidate])) {
+                $storedId = $candidate;
+            }
+        }
+    }
+    fclose($fp);
+
+    if ($storedId !== null) {
+        return $storedId;
+    }
+
+    if ($explicitlyCleared) {
+        return null;
+    }
+
+    if ($defaultSceneId !== null && isset($sceneLookup[$defaultSceneId])) {
+        saveActiveSceneId($defaultSceneId, $path);
+        return $defaultSceneId;
+    }
+
+    saveActiveSceneId('', $path);
+    return null;
+}
+
+function saveActiveSceneId($sceneId, ?string $filePath = null): bool
+{
+    $path = $filePath ?? getSceneStateFilePath();
+    $directory = dirname($path);
+    if (!is_dir($directory)) {
+        mkdir($directory, 0755, true);
+    }
+
+    $fp = fopen($path, 'c+');
+    if ($fp === false) {
+        return false;
+    }
+
+    $value = '';
+    if (is_string($sceneId)) {
+        $value = $sceneId;
+    } elseif ($sceneId !== null) {
+        $value = (string) $sceneId;
+    }
+
+    $result = false;
+    if (flock($fp, LOCK_EX)) {
+        ftruncate($fp, 0);
+        rewind($fp);
+        $payload = json_encode(['active_scene_id' => $value], JSON_PRETTY_PRINT);
+        if ($payload === false) {
+            $payload = '{"active_scene_id": ""}';
+        }
+        $bytesWritten = fwrite($fp, $payload);
+        fflush($fp);
+        flock($fp, LOCK_UN);
+        $result = $bytesWritten !== false;
+    }
+
+    fclose($fp);
+    return $result;
+}


### PR DESCRIPTION
## Summary
- add a reusable scene state repository to manage the active scene JSON data
- update the VTT entrypoint and scene handler to load and persist the active scene through the repository helpers

## Testing
- php -l dnd/vtt/index.php
- php -l dnd/vtt/scenes_handler.php
- php -l dnd/vtt/scene_state_repository.php

------
https://chatgpt.com/codex/tasks/task_e_68e1e6ca5c948327a9c36aa16815a1f4