### PR TITLE
Ignore VTT scene state files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,9 +32,13 @@ pnpm-lock.yaml
 /dnd/data/characters_backup_*.json
 /dnd/data/characters_emergency_*.json
 /dnd/data/vtt_change_log.json
+/dnd/data/vtt_active_scene.json
+/dnd/data/vtt_scene_changes.json
+/dnd/data/vtt_scenes.json
 /dnd/data/vtt_scene_tokens.json
 /dnd/data/vtt_token_library.json
 /dnd/data/vtt_tokens.json
+/dnd/images/vtt/maps/
 
 # Schedule data
 /dnd/schedule/data/schedules.json


### PR DESCRIPTION
## Summary
- add the VTT scene state JSON files to the project .gitignore so local saves do not overwrite upstream changes
- ignore the VTT maps directory to keep user-generated images out of version control

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e1f043fc6083279d7c89e84cb3befd