### PR TITLE
Add scene token overlay and seed active scene tokens

### DIFF
--- a/dnd/vtt/index.php
+++ b/dnd/vtt/index.php
@@ -64,6 +64,7 @@ $activeSceneMap = [
     'image' => '',
     'gridScale' => 50,
 ];
+$activeSceneTokens = [];
 if (is_array($activeScene) && isset($activeScene['map']) && is_array($activeScene['map'])) {
     $activeSceneMap['image'] = isset($activeScene['map']['image']) ? (string) $activeScene['map']['image'] : '';
     $gridScale = isset($activeScene['map']['gridScale']) ? (int) $activeScene['map']['gridScale'] : 50;
@@ -74,6 +75,10 @@ if (is_array($activeScene) && isset($activeScene['map']) && is_array($activeScen
         $gridScale = 300;
     }
     $activeSceneMap['gridScale'] = $gridScale;
+}
+
+if (is_string($activeSceneId) && $activeSceneId !== '') {
+    $activeSceneTokens = loadSceneTokens($activeSceneId);
 }
 
 $tokenLibrary = loadTokenLibrary();
@@ -92,6 +97,7 @@ $vttConfig = [
     'tokenEndpoint' => 'token_handler.php',
     'tokenLibrary' => $tokenLibrary,
     'latestChangeId' => getLatestSceneChangeId(),
+    'activeSceneTokens' => $activeSceneTokens,
 ];
 ?>
 <!DOCTYPE html>
@@ -146,6 +152,7 @@ $vttConfig = [
                                 alt="Scene map"
                             >
                             <div id="scene-map-grid" class="scene-display__map-grid"></div>
+                            <div id="scene-token-layer" class="scene-display__token-layer" aria-live="polite"></div>
                         </div>
                     </div>
                     <div id="scene-grid-controls" class="scene-display__grid-controls">


### PR DESCRIPTION
## Summary
- load the saved tokens for the active scene and include them in the VTT bootstrap config
- add a dedicated token overlay layer on the scene map so dropped tokens render above the grid

## Testing
- php -l dnd/vtt/index.php

------
https://chatgpt.com/codex/tasks/task_e_68e1f1b856f0832795caf55ecdeb68ef