### PR TITLE
Guard loadSceneTokens helper

### DIFF
--- a/dnd/vtt/index.php
+++ b/dnd/vtt/index.php
@@ -78,7 +78,11 @@ if (is_array($activeScene) && isset($activeScene['map']) && is_array($activeScen
 }
 
 if (is_string($activeSceneId) && $activeSceneId !== '') {
-    $activeSceneTokens = loadSceneTokens($activeSceneId);
+    if (function_exists('loadSceneTokens')) {
+        $activeSceneTokens = loadSceneTokens($activeSceneId);
+    } else {
+        error_log('loadSceneTokens helper is missing; active scene tokens unavailable.');
+    }
 }
 
 $tokenLibrary = loadTokenLibrary();


### PR DESCRIPTION
## Summary
- guard the Virtual Tabletop entry point against missing loadSceneTokens helper
- log a warning and fall back to an empty token list when the helper is unavailable

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1f880a05c8327a0a2bc831265841a