### PR TITLE
Propagate token configuration to VTT settings panel

### DIFF
--- a/dnd/js/vtt.js
+++ b/dnd/js/vtt.js
@@ -24,6 +24,9 @@
             sceneEndpoint,
             initialSceneId,
             initialScene,
+            tokenEndpoint: config.tokenEndpoint,
+            tokenLibrary: config.tokenLibrary,
+            activeSceneTokens: config.activeSceneTokens,
             latestChangeId: typeof config.latestChangeId === 'number' ? config.latestChangeId : 0,
         });
     }


### PR DESCRIPTION
## Summary
- pass the server-provided token endpoint, library, and active scene tokens into the VTT settings panel initialization so they are available on load

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e1f884e0c88327a4104c67204f7d26