### PR TITLE
Ignore generated VTT scene data

### DIFF
--- a/dnd/data/.gitignore
+++ b/dnd/data/.gitignore
@@ -4,6 +4,15 @@ combat.json
 inventory.json
 version.json
 
+# VTT scene data files (auto-generated)
+vtt_active_scene.json
+vtt_change_log.json
+vtt_scene_changes.json
+vtt_scenes.json
+vtt_scene_tokens.json
+vtt_token_library.json
+vtt_tokens.json
+
 # Ignore all backup files
 characters_backup_*.json
 characters_temp.json

--- a/dnd/data/vtt_scenes.json
+++ b/dnd/data/vtt_scenes.json
@@ -1,4 +1,0 @@
-{
-    "folders": [],
-    "rootScenes": []
-}


### PR DESCRIPTION
## Summary
- add the VTT scene data files to dnd/data/.gitignore so the virtual tabletop stores remain local
- remove the tracked vtt_scenes.json so deployments no longer overwrite live scenes

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e1faac9bac8327bc8056966a9fb285