### PR TITLE
Sanitize scene tokens with non-finite coordinates

### DIFF
--- a/dnd/tests/token_repository_test.php
+++ b/dnd/tests/token_repository_test.php
@@ -1,0 +1,62 @@
+<?php
+require_once __DIR__ . '/../vtt/token_repository.php';
+
+$entries = [
+    [
+        'id' => 'token-1',
+        'imageData' => 'data:image/png;base64,AAA',
+        'libraryId' => 'lib-1',
+        'name' => 'Example Token',
+        'position' => [
+            'x' => NAN,
+            'y' => INF,
+        ],
+        'size' => [
+            'width' => NAN,
+            'height' => INF,
+        ],
+        'stamina' => 5,
+    ],
+];
+
+$result = normalizeSceneTokenEntries($entries);
+
+$allPassed = true;
+
+if (count($result) !== 1) {
+    fwrite(STDERR, "Expected one normalized token.\n");
+    $allPassed = false;
+} else {
+    $token = $result[0];
+
+    if ($token['position']['x'] !== 0.0) {
+        fwrite(STDERR, sprintf("Expected finite X position, got %s.\n", var_export($token['position']['x'], true)));
+        $allPassed = false;
+    }
+
+    if ($token['position']['y'] !== 0.0) {
+        fwrite(STDERR, sprintf("Expected finite Y position, got %s.\n", var_export($token['position']['y'], true)));
+        $allPassed = false;
+    }
+
+    if (!is_int($token['size']['width']) || $token['size']['width'] < 1) {
+        fwrite(STDERR, sprintf("Width was not normalized to a positive integer: %s.\n", var_export($token['size']['width'], true)));
+        $allPassed = false;
+    }
+
+    if (!is_int($token['size']['height']) || $token['size']['height'] < 1) {
+        fwrite(STDERR, sprintf("Height was not normalized to a positive integer: %s.\n", var_export($token['size']['height'], true)));
+        $allPassed = false;
+    }
+
+    if (json_encode($token) === false) {
+        fwrite(STDERR, "json_encode failed for the normalized token.\n");
+        $allPassed = false;
+    }
+}
+
+if (!$allPassed) {
+    exit(1);
+}
+
+echo "All token repository checks passed.\n";

--- a/dnd/vtt/token_repository.php
+++ b/dnd/vtt/token_repository.php
@@ -279,7 +279,13 @@ function normalizeSceneTokenEntries(array $entries): array
 
         $position = isset($entry['position']) && is_array($entry['position']) ? $entry['position'] : [];
         $x = isset($position['x']) ? (float) $position['x'] : 0.0;
+        if (!is_finite($x)) {
+            $x = 0.0;
+        }
         $y = isset($position['y']) ? (float) $position['y'] : 0.0;
+        if (!is_finite($y)) {
+            $y = 0.0;
+        }
 
         $staminaValue = isset($entry['stamina']) ? (int) round((float) $entry['stamina']) : 0;
         if ($staminaValue < 0) {
@@ -340,7 +346,12 @@ function loadAllSceneTokens(): array
  */
 function clampTokenDimension($value): int
 {
-    $numeric = is_numeric($value) ? (int) round((float) $value) : 1;
+    $numericValue = is_numeric($value) ? (float) $value : 1.0;
+    if (!is_finite($numericValue)) {
+        $numericValue = 1.0;
+    }
+
+    $numeric = (int) round($numericValue);
     if ($numeric < 1) {
         return 1;
     }


### PR DESCRIPTION
## Summary
- coerce scene token coordinates and dimensions to finite numbers during normalization
- add a regression test to ensure NaN inputs no longer break JSON encoding

## Testing
- php dnd/tests/token_repository_test.php

------
https://chatgpt.com/codex/tasks/task_e_68e20e0d83588327beb166f1138b5840