### PR TITLE
Trim token change payloads to avoid VTT 500s

### DIFF
--- a/dnd/tests/token_repository_test.php
+++ b/dnd/tests/token_repository_test.php
@@ -53,6 +53,68 @@ if (count($result) !== 1) {
         fwrite(STDERR, "json_encode failed for the normalized token.\n");
         $allPassed = false;
     }
+
+    $sceneSummary = summarizeSceneTokensForChangeLog([$token]);
+    if (count($sceneSummary) !== 1) {
+        fwrite(STDERR, "Scene token change summary should contain one entry.\n");
+        $allPassed = false;
+    } else {
+        $summaryToken = $sceneSummary[0];
+        if (isset($summaryToken['imageData'])) {
+            fwrite(STDERR, "Scene token change summary must not include raw image data.\n");
+            $allPassed = false;
+        }
+        if (empty($summaryToken['hasImage'])) {
+            fwrite(STDERR, "Scene token change summary lost the hasImage flag.\n");
+            $allPassed = false;
+        }
+        if (!isset($summaryToken['imageHash']) || !is_string($summaryToken['imageHash']) || strlen($summaryToken['imageHash']) < 8) {
+            fwrite(STDERR, "Scene token change summary is missing the image hash identifier.\n");
+            $allPassed = false;
+        }
+        if (json_encode($sceneSummary) === false) {
+            fwrite(STDERR, "json_encode failed for the scene token summary.\n");
+            $allPassed = false;
+        }
+    }
+}
+
+$libraryEntries = [
+    [
+        'id' => 'library-token-1',
+        'name' => 'Professor Onyx',
+        'folderId' => 'pcs',
+        'schoolId' => 'witherbloom',
+        'stamina' => 12,
+        'size' => ['width' => 2, 'height' => 2],
+        'imageData' => 'data:image/png;base64,' . str_repeat('A', 32),
+        'createdAt' => 123,
+        'updatedAt' => 456,
+    ],
+];
+
+$librarySummary = summarizeTokenLibraryForChangeLog($libraryEntries);
+if (count($librarySummary) !== 1) {
+    fwrite(STDERR, "Token library change summary should contain one entry.\n");
+    $allPassed = false;
+} else {
+    $summaryToken = $librarySummary[0];
+    if (isset($summaryToken['imageData'])) {
+        fwrite(STDERR, "Token library change summary must not include raw image data.\n");
+        $allPassed = false;
+    }
+    if (empty($summaryToken['hasImage'])) {
+        fwrite(STDERR, "Token library change summary lost the hasImage flag.\n");
+        $allPassed = false;
+    }
+    if (!isset($summaryToken['imageHash']) || !is_string($summaryToken['imageHash']) || strlen($summaryToken['imageHash']) < 8) {
+        fwrite(STDERR, "Token library change summary is missing the image hash identifier.\n");
+        $allPassed = false;
+    }
+    if (json_encode($librarySummary) === false) {
+        fwrite(STDERR, "json_encode failed for the token library summary.\n");
+        $allPassed = false;
+    }
 }
 
 if (!$allPassed) {

--- a/dnd/vtt/token_handler.php
+++ b/dnd/vtt/token_handler.php
@@ -101,6 +101,7 @@ function handleSaveLibraryRequest(array $requestData): void
     $changeId = recordSceneChange('token_library', null, [
         'action' => 'save_library',
         'token_count' => count($tokens),
+        'tokens' => summarizeTokenLibraryForChangeLog($tokens),
     ]);
 
     echo json_encode([
@@ -162,6 +163,7 @@ function handleSaveSceneTokensRequest(array $requestData): void
         'action' => 'save_scene_tokens',
         'sceneId' => $sceneId,
         'token_count' => count($tokens),
+        'tokens' => summarizeSceneTokensForChangeLog($tokens),
     ]);
 
     echo json_encode([

--- a/dnd/vtt/token_repository.php
+++ b/dnd/vtt/token_repository.php
@@ -362,6 +362,112 @@ function clampTokenDimension($value): int
 }
 
 /**
+ * Build a lightweight summary of token library entries for the change log.
+ */
+function summarizeTokenLibraryForChangeLog(array $tokens): array
+{
+    $summary = [];
+    foreach ($tokens as $token) {
+        if (!is_array($token)) {
+            continue;
+        }
+
+        $id = isset($token['id']) ? (string) $token['id'] : '';
+        if ($id === '') {
+            continue;
+        }
+
+        $name = isset($token['name']) ? (string) $token['name'] : '';
+        $folderId = isset($token['folderId']) ? (string) $token['folderId'] : '';
+        $schoolId = isset($token['schoolId']) ? (string) $token['schoolId'] : '';
+        $stamina = isset($token['stamina']) ? (int) $token['stamina'] : 0;
+        $size = isset($token['size']) && is_array($token['size']) ? $token['size'] : [];
+
+        $summary[] = [
+            'id' => $id,
+            'name' => $name,
+            'folderId' => $folderId,
+            'schoolId' => $schoolId,
+            'stamina' => $stamina,
+            'size' => [
+                'width' => clampTokenDimension($size['width'] ?? 1),
+                'height' => clampTokenDimension($size['height'] ?? 1),
+            ],
+            'hasImage' => isset($token['imageData']) && is_string($token['imageData']) && $token['imageData'] !== '',
+            'imageHash' => buildTokenImageHash($token['imageData'] ?? null),
+            'createdAt' => isset($token['createdAt']) ? (int) $token['createdAt'] : 0,
+            'updatedAt' => isset($token['updatedAt']) ? (int) $token['updatedAt'] : 0,
+        ];
+    }
+
+    return $summary;
+}
+
+/**
+ * Build a lightweight summary of scene token entries for the change log.
+ */
+function summarizeSceneTokensForChangeLog(array $tokens): array
+{
+    $summary = [];
+    foreach ($tokens as $token) {
+        if (!is_array($token)) {
+            continue;
+        }
+
+        $id = isset($token['id']) ? (string) $token['id'] : '';
+        if ($id === '') {
+            continue;
+        }
+
+        $libraryId = isset($token['libraryId']) ? (string) $token['libraryId'] : '';
+        $name = isset($token['name']) ? (string) $token['name'] : '';
+        $stamina = isset($token['stamina']) ? (int) $token['stamina'] : 0;
+        $size = isset($token['size']) && is_array($token['size']) ? $token['size'] : [];
+        $position = isset($token['position']) && is_array($token['position']) ? $token['position'] : [];
+
+        $x = isset($position['x']) && is_numeric($position['x']) ? (float) $position['x'] : 0.0;
+        if (!is_finite($x)) {
+            $x = 0.0;
+        }
+        $y = isset($position['y']) && is_numeric($position['y']) ? (float) $position['y'] : 0.0;
+        if (!is_finite($y)) {
+            $y = 0.0;
+        }
+
+        $summary[] = [
+            'id' => $id,
+            'libraryId' => $libraryId,
+            'name' => $name,
+            'stamina' => $stamina,
+            'size' => [
+                'width' => clampTokenDimension($size['width'] ?? 1),
+                'height' => clampTokenDimension($size['height'] ?? 1),
+            ],
+            'position' => [
+                'x' => $x,
+                'y' => $y,
+            ],
+            'hasImage' => isset($token['imageData']) && is_string($token['imageData']) && $token['imageData'] !== '',
+            'imageHash' => buildTokenImageHash($token['imageData'] ?? null),
+        ];
+    }
+
+    return $summary;
+}
+
+/**
+ * Produce a short hash that identifies token artwork without storing the full image data.
+ */
+function buildTokenImageHash($imageData): ?string
+{
+    if (!is_string($imageData) || $imageData === '') {
+        return null;
+    }
+
+    return substr(hash('sha1', $imageData), 0, 12);
+}
+
+/**
  * Generate a random identifier for token objects.
  */
 function generateTokenIdentifier(string $prefix = 'token'): string


### PR DESCRIPTION
## Summary
- strip raw token artwork from change log payloads to keep scene updates lightweight
- add helpers that generate hashed summaries for library and scene tokens
- extend repository tests to cover the new summaries and ensure json encoding never fails

## Testing
- php dnd/tests/token_repository_test.php

------
https://chatgpt.com/codex/tasks/task_e_68e20fe9f0ec832788c33a3385f6d56c