### PR TITLE
Adjust HTTP error handler singleton for PHP 7

### DIFF
--- a/dnd/includes/http_error_handler.php
+++ b/dnd/includes/http_error_handler.php
@@ -7,7 +7,10 @@ final class VttHttpErrorHandler
     private const FORMAT_JSON = 'json';
     private const FORMAT_HTML = 'html';
 
-    private static ?self $instance = null;
+    /**
+     * @var self|null
+     */
+    private static $instance = null;
 
     /** @var string */
     private $format;


### PR DESCRIPTION
## Summary
- replace the typed static singleton instance with an untyped property for PHP 7 compatibility
- document the intended type of the singleton instance via a docblock

## Testing
- php -l dnd/includes/http_error_handler.php

------
https://chatgpt.com/codex/tasks/task_e_68e2a9a32fdc8327b83104594f5c0f96