### PR TITLE
Ignore VTT token data files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,7 +34,10 @@ pnpm-lock.yaml
 /dnd/data/vtt_change_log.json
 /dnd/data/vtt_active_scene.json
 /dnd/data/vtt_scene_changes.json
+/dnd/data/vtt_scene_tokens.json
 /dnd/data/vtt_scenes.json
+/dnd/data/vtt_token_library.json
+/dnd/data/vtt_tokens.json
 /dnd/images/vtt/maps/
 
 # Schedule data


### PR DESCRIPTION
## Summary
- add the VTT token data JSON files to .gitignore so they are not overwritten by deployments

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2aee089d48327903b36ffc4b7d240