### PR TITLE
Add recovery flow for scene token persistence

### DIFF
--- a/dnd/tests/token_handler_recovery_test.php
+++ b/dnd/tests/token_handler_recovery_test.php
@@ -1,0 +1,101 @@
+<?php
+require_once __DIR__ . '/../vtt/token_repository.php';
+
+$sceneId = 'scene-test';
+$tokens = [
+    [
+        'id' => 'token-1',
+        'libraryId' => 'lib-1',
+        'name' => "Test \u{2603}",
+        'imageData' => 'data:image/png;base64,AAA',
+        'size' => ['width' => 1, 'height' => 1],
+        'position' => ['x' => 0, 'y' => 0],
+        'stamina' => 3,
+    ],
+];
+
+$saveAttempts = 0;
+$sanitizeInvoked = false;
+$resetInvoked = false;
+$logInvoked = false;
+
+$saveCallback = function (string $incomingSceneId, array $incomingTokens) use (&$saveAttempts) {
+    $saveAttempts++;
+    return false; // force failure to trigger recovery logic
+};
+
+$sanitizeCallback = function (array $incomingTokens) use (&$sanitizeInvoked) {
+    $sanitizeInvoked = true;
+    return array_slice($incomingTokens, 0, 1);
+};
+
+$resetCallback = function (string $incomingSceneId) use (&$resetInvoked) {
+    if ($incomingSceneId !== 'scene-test') {
+        fwrite(STDERR, "Reset invoked with unexpected scene identifier.\n");
+        return false;
+    }
+    $resetInvoked = true;
+    return true;
+};
+
+$logger = function (string $message, array $context = []) use (&$logInvoked) {
+    $logInvoked = true;
+    if (strpos($message, 'Failed to persist scene tokens for scene') === false) {
+        fwrite(STDERR, "Unexpected log message: {$message}\n");
+    }
+    if (!isset($context['original_count'], $context['sanitized_count'])) {
+        fwrite(STDERR, "Logger context missing expected keys.\n");
+    }
+};
+
+$result = persistSceneTokensWithRecovery(
+    $sceneId,
+    $tokens,
+    $saveCallback,
+    $sanitizeCallback,
+    $resetCallback,
+    $logger
+);
+
+$allPassed = true;
+
+if (!$sanitizeInvoked) {
+    fwrite(STDERR, "Sanitizer callback was not invoked.\n");
+    $allPassed = false;
+}
+
+if ($saveAttempts !== 2) {
+    fwrite(STDERR, sprintf("Expected two save attempts, observed %d.\n", $saveAttempts));
+    $allPassed = false;
+}
+
+if (!$resetInvoked) {
+    fwrite(STDERR, "Reset callback was not triggered after save failures.\n");
+    $allPassed = false;
+}
+
+if (!$logInvoked) {
+    fwrite(STDERR, "Logger callback was not invoked for fallback path.\n");
+    $allPassed = false;
+}
+
+if (!$result['success']) {
+    fwrite(STDERR, "Recovery result did not report success.\n");
+    $allPassed = false;
+}
+
+if (empty($result['removed_corrupt_tokens'])) {
+    fwrite(STDERR, "Recovery result did not flag removed corrupt tokens.\n");
+    $allPassed = false;
+}
+
+if ($result['tokens'] !== []) {
+    fwrite(STDERR, "Recovery result should reset tokens to an empty array.\n");
+    $allPassed = false;
+}
+
+if (!$allPassed) {
+    exit(1);
+}
+
+echo "All token handler recovery checks passed.\n";

--- a/dnd/vtt/token_repository.php
+++ b/dnd/vtt/token_repository.php
@@ -197,6 +197,54 @@ function saveSceneTokens(string $sceneId, array $tokens): bool
 }
 
 /**
+ * Remove a scene token entry from storage.
+ */
+function resetSceneTokens(string $sceneId): bool
+{
+    if ($sceneId === '') {
+        return false;
+    }
+
+    ensureSceneTokensFile();
+
+    $fp = fopen(VTT_SCENE_TOKENS_FILE, 'c+');
+    if ($fp === false) {
+        return false;
+    }
+
+    $result = false;
+    if (flock($fp, LOCK_EX)) {
+        $content = stream_get_contents($fp);
+        $data = ['scenes' => []];
+        if (is_string($content) && $content !== '') {
+            $decoded = json_decode($content, true);
+            if (is_array($decoded) && isset($decoded['scenes']) && is_array($decoded['scenes'])) {
+                $data['scenes'] = $decoded['scenes'];
+            }
+        }
+
+        if (isset($data['scenes'][$sceneId])) {
+            unset($data['scenes'][$sceneId]);
+        }
+
+        $payload = json_encode(['scenes' => $data['scenes']], JSON_PRETTY_PRINT);
+        if ($payload !== false) {
+            ftruncate($fp, 0);
+            rewind($fp);
+            $bytesWritten = fwrite($fp, $payload);
+            fflush($fp);
+            $result = $bytesWritten !== false;
+        }
+
+        flock($fp, LOCK_UN);
+    }
+
+    fclose($fp);
+
+    return $result;
+}
+
+/**
  * Return only the token entries intended for non-GM players.
  */
 function filterTokensForPlayers(array $tokens): array
@@ -336,6 +384,208 @@ function normalizeSceneTokenEntries(array $entries): array
     }
 
     return $normalized;
+}
+
+/**
+ * Sanitize scene token entries to remove values that cannot be persisted safely.
+ */
+function sanitizeSceneTokenEntriesForPersistence(array $entries): array
+{
+    $normalized = normalizeSceneTokenEntries($entries);
+    $sanitized = [];
+
+    foreach ($normalized as $entry) {
+        $sanitizedEntry = sanitizeSceneTokenEntryForPersistence($entry);
+        if ($sanitizedEntry !== null) {
+            $sanitized[] = $sanitizedEntry;
+        }
+    }
+
+    return $sanitized;
+}
+
+/**
+ * Attempt to clean a single scene token entry.
+ */
+function sanitizeSceneTokenEntryForPersistence(array $entry): ?array
+{
+    $entry['id'] = sanitizeUtf8TokenString($entry['id'] ?? '');
+    if ($entry['id'] === '') {
+        return null;
+    }
+
+    $entry['libraryId'] = sanitizeUtf8TokenString($entry['libraryId'] ?? '');
+    $entry['name'] = sanitizeUtf8TokenString($entry['name'] ?? '');
+    $entry['imageData'] = sanitizeTokenImageData($entry['imageData'] ?? '');
+
+    if ($entry['imageData'] === '') {
+        return null;
+    }
+
+    if (!isset($entry['size']) || !is_array($entry['size'])) {
+        $entry['size'] = ['width' => 1, 'height' => 1];
+    }
+
+    $entry['size']['width'] = clampTokenDimension($entry['size']['width'] ?? 1);
+    $entry['size']['height'] = clampTokenDimension($entry['size']['height'] ?? 1);
+
+    if (!isset($entry['position']) || !is_array($entry['position'])) {
+        $entry['position'] = ['x' => 0.0, 'y' => 0.0];
+    }
+
+    $entry['position']['x'] = isset($entry['position']['x']) && is_numeric($entry['position']['x']) && is_finite((float) $entry['position']['x'])
+        ? (float) $entry['position']['x']
+        : 0.0;
+    $entry['position']['y'] = isset($entry['position']['y']) && is_numeric($entry['position']['y']) && is_finite((float) $entry['position']['y'])
+        ? (float) $entry['position']['y']
+        : 0.0;
+
+    $entry['stamina'] = isset($entry['stamina']) ? max(0, (int) $entry['stamina']) : 0;
+
+    if (json_encode($entry) === false) {
+        return null;
+    }
+
+    return $entry;
+}
+
+/**
+ * Ensure token text fields are valid UTF-8 without control characters.
+ */
+function sanitizeUtf8TokenString($value): string
+{
+    if (!is_string($value) || $value === '') {
+        return '';
+    }
+
+    $trimmed = trim($value);
+    if ($trimmed === '') {
+        return '';
+    }
+
+    $converted = @mb_convert_encoding($trimmed, 'UTF-8', 'UTF-8');
+    if (!is_string($converted)) {
+        return '';
+    }
+
+    $filtered = preg_replace('/[^\P{C}\t\n\r]/u', '', $converted);
+    if (!is_string($filtered)) {
+        return '';
+    }
+
+    return $filtered;
+}
+
+/**
+ * Sanitize base64 token image data.
+ */
+function sanitizeTokenImageData($value): string
+{
+    if (!is_string($value) || $value === '') {
+        return '';
+    }
+
+    $trimmed = trim($value);
+    if ($trimmed === '') {
+        return '';
+    }
+
+    $converted = @mb_convert_encoding($trimmed, 'UTF-8', 'UTF-8');
+    if (!is_string($converted)) {
+        return '';
+    }
+
+    if (json_encode($converted) === false) {
+        $converted = preg_replace('/[^\P{C}\t\n\r]/u', '', $converted);
+        if (!is_string($converted) || $converted === '') {
+            return '';
+        }
+    }
+
+    return $converted;
+}
+
+/**
+ * Attempt to persist scene tokens, falling back to sanitizing or resetting entries when needed.
+ */
+function persistSceneTokensWithRecovery(
+    string $sceneId,
+    array $tokens,
+    ?callable $saveCallback = null,
+    ?callable $sanitizeCallback = null,
+    ?callable $resetCallback = null,
+    ?callable $logger = null
+): array {
+    $saveCallback = $saveCallback ?? 'saveSceneTokens';
+    $sanitizeCallback = $sanitizeCallback ?? 'sanitizeSceneTokenEntriesForPersistence';
+    $resetCallback = $resetCallback ?? 'resetSceneTokens';
+    $logger = $logger ?? 'logVttErrorMessage';
+
+    $initialTokens = $tokens;
+    $removedCorruptTokens = false;
+
+    if (call_user_func($saveCallback, $sceneId, $tokens)) {
+        return [
+            'success' => true,
+            'tokens' => $tokens,
+            'removed_corrupt_tokens' => false,
+        ];
+    }
+
+    $sanitizedTokens = call_user_func($sanitizeCallback, $initialTokens);
+    $removedCorruptTokens = count($sanitizedTokens) !== count($initialTokens);
+
+    if (call_user_func($saveCallback, $sceneId, $sanitizedTokens)) {
+        return [
+            'success' => true,
+            'tokens' => $sanitizedTokens,
+            'removed_corrupt_tokens' => $removedCorruptTokens,
+        ];
+    }
+
+    $resetResult = call_user_func($resetCallback, $sceneId);
+    $removedCorruptTokens = true;
+
+    call_user_func($logger, sprintf('Failed to persist scene tokens for scene "%s"; applying reset.', $sceneId), [
+        'original_count' => count($initialTokens),
+        'sanitized_count' => count($sanitizedTokens),
+    ]);
+
+    if ($resetResult) {
+        return [
+            'success' => true,
+            'tokens' => [],
+            'removed_corrupt_tokens' => true,
+        ];
+    }
+
+    return [
+        'success' => false,
+        'tokens' => [],
+        'removed_corrupt_tokens' => true,
+    ];
+}
+
+/**
+ * Append an entry to the VTT error log file.
+ */
+function logVttErrorMessage(string $message, array $context = []): void
+{
+    $logFile = __DIR__ . '/../logs/vtt_error.log';
+    $directory = dirname($logFile);
+    if (!is_dir($directory)) {
+        mkdir($directory, 0775, true);
+    }
+
+    if (!empty($context)) {
+        $encodedContext = json_encode($context, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+        if ($encodedContext !== false) {
+            $message = sprintf('%s %s', $message, $encodedContext);
+        }
+    }
+
+    $entry = sprintf('[%s] %s%s', date('c'), $message, PHP_EOL);
+    file_put_contents($logFile, $entry, FILE_APPEND);
 }
 
 /**


### PR DESCRIPTION
## Summary
- add recovery-aware save logic for scene tokens, including sanitizer, reset helper, and logging
- surface removed token information back to the client when corrupt data is cleaned
- cover the recovery branch with a dedicated test that mocks save failures

## Testing
- php dnd/tests/token_repository_test.php
- php dnd/tests/token_handler_recovery_test.php
- php dnd/tests/sanitize_image_url_test.php

------
https://chatgpt.com/codex/tasks/task_e_68e2d73a09488327a60a27989cca4466