### PR TITLE
Temporarily track VTT token data files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,10 +36,10 @@ pnpm-lock.yaml
 /dnd/data/vtt_change_log.json
 /dnd/data/vtt_active_scene.json
 /dnd/data/vtt_scene_changes.json
-/dnd/data/vtt_scene_tokens.json
-/dnd/data/vtt_scenes.json
-/dnd/data/vtt_token_library.json
-/dnd/data/vtt_tokens.json
+# Temporarily allow token data to be versioned; re-add '/dnd/data/vtt_scene_tokens.json' to .gitignore once token bug is resolved.
+# Temporarily allow token data to be versioned; re-add '/dnd/data/vtt_scenes.json' to .gitignore once token bug is resolved.
+# Temporarily allow token data to be versioned; re-add '/dnd/data/vtt_token_library.json' to .gitignore once token bug is resolved.
+# Temporarily allow token data to be versioned; re-add '/dnd/data/vtt_tokens.json' to .gitignore once token bug is resolved.
 /dnd/images/vtt/maps/
 
 # Schedule data


### PR DESCRIPTION
## Summary
- stop ignoring the VTT token-related data files so new commits can clear the problematic saved data
- add inline reminders about which file patterns to restore in .gitignore once the token issue is fixed

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2da429c6883278a040159ae3650a6