### PR TITLE
Allow vtt_scenes.json to be versioned

### DIFF
--- a/dnd/data/.gitignore
+++ b/dnd/data/.gitignore
@@ -8,7 +8,6 @@ version.json
 vtt_active_scene.json
 vtt_change_log.json
 vtt_scene_changes.json
-vtt_scenes.json
 vtt_scene_tokens.json
 vtt_tokens.json
 


### PR DESCRIPTION
## Summary
- remove vtt_scenes.json from the data gitignore so the file can be versioned and reset by updates

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2dfd26cd0832791767655250f25cb