### PR TITLE
Allow VTT active scene state file to be tracked

### DIFF
--- a/dnd/data/.gitignore
+++ b/dnd/data/.gitignore
@@ -5,7 +5,6 @@ inventory.json
 version.json
 
 # VTT scene data files (auto-generated)
-vtt_active_scene.json
 vtt_change_log.json
 vtt_scene_changes.json
 vtt_scene_tokens.json


### PR DESCRIPTION
## Summary
- stop ignoring `dnd/data/vtt_active_scene.json` so the active scene state file can be replaced on update and clear corrupted data

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2e154ac24832790148878c25ec192