### PR TITLE
Track VTT data assets for debugging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,21 +26,7 @@ pnpm-lock.yaml
 .env.local
 .env.*.local
 
-# Character and game data
-/dnd/data/characters.json
-/dnd/data/inventory.json
-/dnd/data/combat.json
-/dnd/data/pcs.json
-/dnd/data/characters_backup_*.json
-/dnd/data/characters_emergency_*.json
-/dnd/data/vtt_change_log.json
-# Temporarily allow active scene data to be versioned; re-add '/dnd/data/vtt_active_scene.json' to .gitignore once the VTT issue is resolved.
-# /dnd/data/vtt_scene_changes.json is intentionally versioned to help recover corrupted VTT scenes; re-add it here once the issue is resolved.
-# Temporarily allow token data to be versioned; re-add '/dnd/data/vtt_scene_tokens.json' to .gitignore once token bug is resolved.
-# Temporarily allow token data to be versioned; re-add '/dnd/data/vtt_scenes.json' to .gitignore once token bug is resolved.
-# Temporarily allow token data to be versioned; re-add '/dnd/data/vtt_token_library.json' to .gitignore once token bug is resolved.
-# Temporarily allow token data to be versioned; re-add '/dnd/data/vtt_tokens.json' to .gitignore once token bug is resolved.
-/dnd/images/vtt/maps/
+# Character and game data (tracking temporarily to diagnose VTT issues)
 
 # Schedule data
 /dnd/schedule/data/schedules.json

--- a/dnd/data/.gitignore
+++ b/dnd/data/.gitignore
@@ -1,15 +1,3 @@
-# Ignore actual data files (keep only .example files)
-characters.json
-combat.json
-inventory.json
-version.json
-
-# VTT scene data files (auto-generated)
-vtt_change_log.json
-vtt_scene_changes.json
-vtt_scene_tokens.json
-vtt_tokens.json
-
 # Ignore all backup files
 characters_backup_*.json
 characters_temp.json

--- a/dnd/images/vtt/maps/.gitignore
+++ b/dnd/images/vtt/maps/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore

--- a/dnd/images/vtt/maps/.gitkeep
+++ b/dnd/images/vtt/maps/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder to keep VTT map directory tracked


### PR DESCRIPTION
## Summary
- remove gitignore rules that excluded VTT JSON data so those files can be inspected and cleaned up
- allow dnd/data JSON and VTT map assets to be versioned while still ignoring backup/session files
- add a .gitkeep placeholder so the VTT map directory stays tracked in git

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e2e2f8a0ec8327bfa489ac6491e78a