### PR TITLE
Handle missing mbstring when validating token images

### DIFF
--- a/dnd/vtt/token_repository.php
+++ b/dnd/vtt/token_repository.php
@@ -267,7 +267,7 @@ function isValidImageDataUri(string $imageData): bool
         return false;
     }
 
-    if (!mb_check_encoding($imageData, 'UTF-8')) {
+    if (!isUtf8String($imageData)) {
         return false;
     }
 
@@ -286,6 +286,19 @@ function isValidImageDataUri(string $imageData): bool
     }
 
     return base64_decode($base64Payload, true) !== false;
+}
+
+function isUtf8String(string $value): bool
+{
+    if (function_exists('mb_check_encoding')) {
+        return mb_check_encoding($value, 'UTF-8');
+    }
+
+    if ($value === '') {
+        return true;
+    }
+
+    return preg_match('//u', $value) === 1;
 }
 
 /**


### PR DESCRIPTION
## Summary
- guard token image validation against environments where `mb_check_encoding` is unavailable
- add a UTF-8 helper that falls back to a regular-expression check when mbstring is missing

## Testing
- php -l dnd/vtt/token_repository.php

------
https://chatgpt.com/codex/tasks/task_e_68e2e60e903083278518e4465d7de26a