### PR TITLE
Restore VTT compatibility with PHP 7.0

### DIFF
--- a/dnd/vtt/scene_state_repository.php
+++ b/dnd/vtt/scene_state_repository.php
@@ -9,7 +9,12 @@ function getSceneStateFilePath(): string
     return VTT_SCENE_STATE_FILE;
 }
 
-function ensureSceneStateFile(?string $filePath = null, ?string $defaultSceneId = null): void
+/**
+ * @param string|null $filePath
+ * @param string|null $defaultSceneId
+ * @return void
+ */
+function ensureSceneStateFile($filePath = null, $defaultSceneId = null)
 {
     $path = $filePath ?? getSceneStateFilePath();
     $directory = dirname($path);
@@ -27,7 +32,13 @@ function ensureSceneStateFile(?string $filePath = null, ?string $defaultSceneId 
     }
 }
 
-function loadActiveSceneId(array $sceneLookup, ?string $defaultSceneId = null, ?string $filePath = null): ?string
+/**
+ * @param array $sceneLookup
+ * @param string|null $defaultSceneId
+ * @param string|null $filePath
+ * @return string|null
+ */
+function loadActiveSceneId(array $sceneLookup, $defaultSceneId = null, $filePath = null)
 {
     $path = $filePath ?? getSceneStateFilePath();
     ensureSceneStateFile($path, $defaultSceneId);
@@ -71,7 +82,12 @@ function loadActiveSceneId(array $sceneLookup, ?string $defaultSceneId = null, ?
     return null;
 }
 
-function saveActiveSceneId($sceneId, ?string $filePath = null): bool
+/**
+ * @param mixed $sceneId
+ * @param string|null $filePath
+ * @return bool
+ */
+function saveActiveSceneId($sceneId, $filePath = null): bool
 {
     $path = $filePath ?? getSceneStateFilePath();
     $directory = dirname($path);

--- a/dnd/vtt/scenes_repository.php
+++ b/dnd/vtt/scenes_repository.php
@@ -84,7 +84,10 @@ function saveScenesData(array $data): bool
     return $result;
 }
 
-function ensureScenesDataFile(): void
+/**
+ * @return void
+ */
+function ensureScenesDataFile()
 {
     $directory = dirname(VTT_SCENES_FILE);
     if (!is_dir($directory)) {
@@ -190,7 +193,13 @@ function createFolder(array $data, string $name): array
     return [$data, $folder];
 }
 
-function createScene(array $data, ?string $folderId = null, ?string $name = null): array
+/**
+ * @param array $data
+ * @param string|null $folderId
+ * @param string|null $name
+ * @return array
+ */
+function createScene(array $data, $folderId = null, $name = null): array
 {
     $trimmedName = $name !== null ? trim($name) : '';
     $scene = [
@@ -302,7 +311,12 @@ function renameScene(array $data, string $sceneId, string $name): array
     return [$data, $updatedScene];
 }
 
-function getSceneById(array $data, string $sceneId): ?array
+/**
+ * @param array $data
+ * @param string $sceneId
+ * @return array|null
+ */
+function getSceneById(array $data, string $sceneId)
 {
     foreach ($data['rootScenes'] ?? [] as $scene) {
         if (isset($scene['id']) && $scene['id'] === $sceneId) {
@@ -323,7 +337,14 @@ function getSceneById(array $data, string $sceneId): ?array
     return null;
 }
 
-function updateSceneMap(array $data, string $sceneId, ?string $imagePath, ?int $gridScale): array
+/**
+ * @param array $data
+ * @param string $sceneId
+ * @param string|null $imagePath
+ * @param int|null $gridScale
+ * @return array
+ */
+function updateSceneMap(array $data, string $sceneId, $imagePath, $gridScale): array
 {
     $updatedScene = null;
 
@@ -358,7 +379,13 @@ function updateSceneMap(array $data, string $sceneId, ?string $imagePath, ?int $
     return [$data, $updatedScene];
 }
 
-function applySceneMapChanges(array $scene, ?string $imagePath, ?int $gridScale): array
+/**
+ * @param array $scene
+ * @param string|null $imagePath
+ * @param int|null $gridScale
+ * @return array
+ */
+function applySceneMapChanges(array $scene, $imagePath, $gridScale): array
 {
     if (!isset($scene['map']) || !is_array($scene['map'])) {
         $scene['map'] = [];
@@ -381,7 +408,11 @@ function applySceneMapChanges(array $scene, ?string $imagePath, ?int $gridScale)
     return $scene;
 }
 
-function getFirstSceneId(array $data): ?string
+/**
+ * @param array $data
+ * @return string|null
+ */
+function getFirstSceneId(array $data)
 {
     if (!empty($data['rootScenes'])) {
         $first = $data['rootScenes'][0];
@@ -402,7 +433,10 @@ function getFirstSceneId(array $data): ?string
     return null;
 }
 
-function ensureSceneChangesFile(): void
+/**
+ * @return void
+ */
+function ensureSceneChangesFile()
 {
     $directory = dirname(VTT_SCENE_CHANGES_FILE);
     if (!is_dir($directory)) {
@@ -489,7 +523,13 @@ function saveSceneChangeState(array $state): bool
     return $result;
 }
 
-function recordSceneChange(string $entityType, ?string $entityId, array $payload = []): ?int
+/**
+ * @param string $entityType
+ * @param string|null $entityId
+ * @param array $payload
+ * @return int|null
+ */
+function recordSceneChange(string $entityType, $entityId, array $payload = [])
 {
     ensureSceneChangesFile();
 
@@ -591,7 +631,10 @@ function getLatestSceneChangeId(): int
     return isset($state['latest_change_id']) ? (int) $state['latest_change_id'] : 0;
 }
 
-function ensureMapUploadDirectory(): void
+/**
+ * @return void
+ */
+function ensureMapUploadDirectory()
 {
     if (!is_dir(VTT_MAP_UPLOAD_DIR)) {
         mkdir(VTT_MAP_UPLOAD_DIR, 0755, true);

--- a/dnd/vtt/token_handler.php
+++ b/dnd/vtt/token_handler.php
@@ -72,7 +72,7 @@ switch ($action) {
         exit;
 }
 
-function handleLibraryRequest(bool $isGm): void
+function handleLibraryRequest(bool $isGm)
 {
     $tokens = loadTokenLibrary();
     if (!$isGm) {
@@ -87,7 +87,7 @@ function handleLibraryRequest(bool $isGm): void
     exit;
 }
 
-function handleSaveLibraryRequest(array $requestData): void
+function handleSaveLibraryRequest(array $requestData)
 {
     $entries = [];
     if (isset($requestData['tokens']) && is_array($requestData['tokens'])) {
@@ -115,7 +115,7 @@ function handleSaveLibraryRequest(array $requestData): void
     exit;
 }
 
-function handleSceneTokensRequest(array $requestData): void
+function handleSceneTokensRequest(array $requestData)
 {
     $sceneId = '';
     if (isset($_GET['scene_id'])) {
@@ -141,7 +141,7 @@ function handleSceneTokensRequest(array $requestData): void
     exit;
 }
 
-function handleSaveSceneTokensRequest(array $requestData): void
+function handleSaveSceneTokensRequest(array $requestData)
 {
     $sceneId = isset($requestData['sceneId']) ? trim((string) $requestData['sceneId']) : '';
     if ($sceneId === '') {

--- a/dnd/vtt/token_repository.php
+++ b/dnd/vtt/token_repository.php
@@ -7,8 +7,10 @@ const VTT_SCENE_TOKENS_FILE = __DIR__ . '/../data/vtt_scene_tokens.json';
 
 /**
  * Ensure the token library storage file exists on disk.
+ *
+ * @return void
  */
-function ensureTokenLibraryFile(): void
+function ensureTokenLibraryFile()
 {
     $directory = dirname(VTT_TOKEN_LIBRARY_FILE);
     if (!is_dir($directory)) {
@@ -39,8 +41,10 @@ function ensureTokenLibraryFile(): void
 
 /**
  * Ensure the scene token storage file exists on disk.
+ *
+ * @return void
  */
-function ensureSceneTokensFile(): void
+function ensureSceneTokensFile()
 {
     $directory = dirname(VTT_SCENE_TOKENS_FILE);
     if (!is_dir($directory)) {
@@ -460,8 +464,11 @@ function sanitizeSceneTokenEntriesForPersistence(array $entries): array
 
 /**
  * Attempt to clean a single scene token entry.
+ *
+ * @param array $entry
+ * @return array|null
  */
-function sanitizeSceneTokenEntryForPersistence(array $entry): ?array
+function sanitizeSceneTokenEntryForPersistence(array $entry)
 {
     $entry['id'] = sanitizeUtf8TokenString($entry['id'] ?? '');
     if ($entry['id'] === '') {
@@ -565,10 +572,10 @@ function sanitizeTokenImageData($value): string
 function persistSceneTokensWithRecovery(
     string $sceneId,
     array $tokens,
-    ?callable $saveCallback = null,
-    ?callable $sanitizeCallback = null,
-    ?callable $resetCallback = null,
-    ?callable $logger = null
+    $saveCallback = null,
+    $sanitizeCallback = null,
+    $resetCallback = null,
+    $logger = null
 ): array {
     $saveCallback = $saveCallback ?? 'saveSceneTokens';
     $sanitizeCallback = $sanitizeCallback ?? 'sanitizeSceneTokenEntriesForPersistence';
@@ -622,8 +629,12 @@ function persistSceneTokensWithRecovery(
 
 /**
  * Append an entry to the VTT error log file.
+ *
+ * @param string $message
+ * @param array $context
+ * @return void
  */
-function logVttErrorMessage(string $message, array $context = []): void
+function logVttErrorMessage(string $message, array $context = [])
 {
     $logFile = __DIR__ . '/../logs/vtt_error.log';
     $directory = dirname($logFile);
@@ -787,8 +798,11 @@ function summarizeSceneTokensForChangeLog(array $tokens): array
 
 /**
  * Produce a short hash that identifies token artwork without storing the full image data.
+ *
+ * @param mixed $imageData
+ * @return string|null
  */
-function buildTokenImageHash($imageData): ?string
+function buildTokenImageHash($imageData)
 {
     if (!is_string($imageData) || $imageData === '') {
         return null;


### PR DESCRIPTION
## Summary
- remove PHP 7.1+ nullable and void type hints from the VTT repositories and handlers so they parse on PHP 7.0
- replace strict type hints with docblocks that document the expected argument and return shapes

## Testing
- php -l dnd/vtt/scene_state_repository.php
- php -l dnd/vtt/scenes_repository.php
- php -l dnd/vtt/token_handler.php
- php -l dnd/vtt/token_repository.php

------
https://chatgpt.com/codex/tasks/task_e_68e2e88283588327b79eef60bbe7acc8