### PR TITLE
Implement sliding sidebars for VTT chat and settings

### DIFF
--- a/dnd/vtt/assets/css/layout.css
+++ b/dnd/vtt/assets/css/layout.css
@@ -1,50 +1,24 @@
 .vtt-app {
-  display: grid;
-  grid-template-columns: 320px minmax(0, 1fr) 360px;
-  gap: 1.5rem;
+  position: relative;
   min-height: 100vh;
-  padding: 2rem;
-}
-
-.vtt-app__sidebar {
-  background: var(--vtt-panel-bg);
-  border: 1px solid var(--vtt-panel-border);
-  border-radius: var(--vtt-radius);
-  backdrop-filter: blur(10px);
-  box-shadow: 0 18px 45px rgba(15, 23, 42, 0.45);
+  padding: 2.5rem 3.5rem;
+  display: flex;
+  align-items: stretch;
+  justify-content: center;
 }
 
 .vtt-app__main {
+  width: 100%;
   background: rgba(15, 23, 42, 0.6);
   border-radius: var(--vtt-radius);
   border: 1px solid var(--vtt-panel-border);
   position: relative;
   overflow: hidden;
-}
-
-@media (max-width: 1280px) {
-  .vtt-app {
-    grid-template-columns: 280px minmax(0, 1fr);
-    grid-template-areas:
-      "settings settings"
-      "board board"
-      "chat chat";
-  }
-
-  .vtt-app__sidebar--settings,
-  .vtt-app__sidebar--chat {
-    grid-area: auto;
-  }
+  box-shadow: 0 25px 60px rgba(15, 23, 42, 0.45);
 }
 
 @media (max-width: 960px) {
   .vtt-app {
-    grid-template-columns: minmax(0, 1fr);
-    grid-auto-rows: auto;
-  }
-
-  .vtt-app__sidebar,
-  .vtt-app__main {
-    width: 100%;
+    padding: 1.5rem;
   }
 }

--- a/dnd/vtt/assets/css/settings.css
+++ b/dnd/vtt/assets/css/settings.css
@@ -149,3 +149,115 @@
   display: flex;
   gap: 0.5rem;
 }
+
+:root {
+  --vtt-settings-panel-width: 360px;
+  --vtt-settings-panel-offset: 20px;
+}
+
+.vtt-settings-panel {
+  position: fixed;
+  top: var(--vtt-settings-panel-offset);
+  left: 0;
+  bottom: var(--vtt-settings-panel-offset);
+  width: min(var(--vtt-settings-panel-width), calc(100vw - (var(--vtt-settings-panel-offset) * 2)));
+  background: rgba(15, 23, 42, 0.92);
+  border-radius: 0 16px 16px 0;
+  border-right: 1px solid rgba(148, 163, 184, 0.3);
+  box-shadow: 0 18px 45px rgba(15, 23, 42, 0.55);
+  transform: translateX(calc(-100% - var(--vtt-settings-panel-offset)));
+  transition: transform 0.35s ease;
+  display: flex;
+  flex-direction: column;
+  color: var(--vtt-text-primary);
+  z-index: 1500;
+}
+
+.vtt-settings-panel--open {
+  transform: translateX(0);
+  pointer-events: auto;
+}
+
+.vtt-settings-panel--closed {
+  pointer-events: none;
+}
+
+.vtt-settings-panel__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 1.25rem;
+  border-bottom: 1px solid rgba(99, 102, 241, 0.35);
+  background: linear-gradient(135deg, rgba(15, 23, 42, 0.95) 0%, rgba(30, 41, 59, 0.98) 100%);
+}
+
+.vtt-settings-panel__title {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+}
+
+.vtt-settings-panel__close {
+  background: transparent;
+  border: none;
+  color: inherit;
+  font-size: 1.5rem;
+  cursor: pointer;
+  line-height: 1;
+  padding: 0 0.25rem;
+}
+
+.vtt-settings-panel__body {
+  flex: 1;
+  overflow: hidden auto;
+  padding: 1.25rem 1.5rem 1.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.vtt-settings-toggle {
+  position: fixed;
+  top: 50%;
+  left: 0;
+  background: #1f2937;
+  color: #fff;
+  border: none;
+  border-radius: 0 12px 12px 0;
+  padding: 18px 12px;
+  font-weight: 600;
+  cursor: pointer;
+  box-shadow: 10px 0 25px rgba(15, 23, 42, 0.25);
+  z-index: 1490;
+  transition: background 0.2s ease, transform 0.3s ease;
+  transform: translate3d(0, -50%, 0);
+  writing-mode: vertical-rl;
+  text-orientation: mixed;
+  letter-spacing: 0.12em;
+}
+
+.vtt-settings-toggle:not([aria-expanded="true"]):hover {
+  background: #111827;
+  transform: translate3d(6px, -50%, 0);
+}
+
+.vtt-settings-toggle[aria-expanded="true"] {
+  background: #6366f1;
+  transform: translate3d(calc(var(--vtt-settings-panel-width) + var(--vtt-settings-panel-offset)), -50%, 0);
+}
+
+.vtt-settings-toggle[aria-expanded="true"]:hover {
+  transform: translate3d(calc(var(--vtt-settings-panel-width) + var(--vtt-settings-panel-offset) + 6px), -50%, 0);
+}
+
+@media (max-width: 768px) {
+  :root {
+    --vtt-settings-panel-width: calc(100vw - 24px);
+    --vtt-settings-panel-offset: 12px;
+  }
+
+  .vtt-settings-panel {
+    border-radius: 0 14px 14px 0;
+  }
+}

--- a/dnd/vtt/assets/js/ui/chat-panel.js
+++ b/dnd/vtt/assets/js/ui/chat-panel.js
@@ -1,17 +1,46 @@
 import { initializeChatBridge } from '../services/chat-service.js';
 
 export function mountChatPanel(routes) {
-  const panel = document.querySelector('[data-module="vtt-chat"]');
+  const panel = document.getElementById('chat-panel');
   if (!panel) return;
 
-  const toggle = panel.querySelector('[data-action="toggle-chat"]');
+  const toggle = document.getElementById('chat-panel-toggle');
+  const closeButton = panel.querySelector('[data-action="close-chat"]');
+
+  let isOpen = false;
+
+  const setOpen = (open) => {
+    if (isOpen === open) return;
+    isOpen = open;
+
+    panel.classList.toggle('chat-panel--open', open);
+    panel.classList.toggle('chat-panel--closed', !open);
+    panel.setAttribute('aria-hidden', open ? 'false' : 'true');
+
+    if (toggle) {
+      toggle.setAttribute('aria-expanded', String(open));
+    }
+  };
+
+  const togglePanel = () => {
+    setOpen(!isOpen);
+  };
+
   if (toggle) {
-    toggle.addEventListener('click', () => {
-      const expanded = toggle.getAttribute('aria-expanded') === 'true';
-      toggle.setAttribute('aria-expanded', String(!expanded));
-      panel.classList.toggle('is-collapsed');
-    });
+    toggle.addEventListener('click', togglePanel);
   }
+
+  if (closeButton) {
+    closeButton.addEventListener('click', () => setOpen(false));
+  }
+
+  document.addEventListener('keydown', (event) => {
+    if (event.key === 'Escape' && isOpen) {
+      setOpen(false);
+    }
+  });
+
+  setOpen(false);
 
   initializeChatBridge({ chatEndpoint: routes.chat, panel });
 }

--- a/dnd/vtt/assets/js/ui/settings-panel.js
+++ b/dnd/vtt/assets/js/ui/settings-panel.js
@@ -2,17 +2,42 @@ import { renderSceneList } from './scene-manager.js';
 import { renderTokenLibrary } from './token-library.js';
 
 export function mountSettingsPanel(routes, store) {
-  const panel = document.querySelector('[data-module="vtt-settings"]');
+  const panel = document.getElementById('vtt-settings-panel');
   if (!panel) return;
 
-  const toggle = panel.querySelector('[data-action="toggle-settings"]');
+  const toggle = document.getElementById('vtt-settings-toggle');
+  const closeButton = panel.querySelector('[data-action="close-settings"]');
+
+  let isOpen = false;
+
+  const setOpen = (open) => {
+    if (isOpen === open) return;
+    isOpen = open;
+
+    panel.classList.toggle('vtt-settings-panel--open', open);
+    panel.classList.toggle('vtt-settings-panel--closed', !open);
+    panel.setAttribute('aria-hidden', open ? 'false' : 'true');
+
+    if (toggle) {
+      toggle.setAttribute('aria-expanded', String(open));
+    }
+  };
+
   if (toggle) {
-    toggle.addEventListener('click', () => {
-      const expanded = toggle.getAttribute('aria-expanded') === 'true';
-      toggle.setAttribute('aria-expanded', String(!expanded));
-      panel.classList.toggle('is-collapsed');
-    });
+    toggle.addEventListener('click', () => setOpen(!isOpen));
   }
+
+  if (closeButton) {
+    closeButton.addEventListener('click', () => setOpen(false));
+  }
+
+  document.addEventListener('keydown', (event) => {
+    if (event.key === 'Escape' && isOpen) {
+      setOpen(false);
+    }
+  });
+
+  setOpen(false);
 
   panel.addEventListener('click', (event) => {
     const tab = event.target.closest('[data-settings-tab]');

--- a/dnd/vtt/components/ChatPanel.php
+++ b/dnd/vtt/components/ChatPanel.php
@@ -5,24 +5,51 @@ function renderVttChatPanel(): string
 {
     ob_start();
     ?>
-    <aside class="vtt-panel vtt-panel--chat" data-module="vtt-chat">
-        <header class="vtt-panel__header">
-            <h2 class="vtt-panel__title">VTT Chat</h2>
-            <button type="button" class="vtt-panel__toggle" data-action="toggle-chat" aria-expanded="false">
-                <span class="visually-hidden">Toggle VTT chat</span>
-            </button>
-        </header>
-        <div class="vtt-panel__body">
-            <div id="vtt-chat-log" class="chat-log" aria-live="polite"></div>
-            <form id="vtt-chat-form" class="chat-form" autocomplete="off">
-                <label class="visually-hidden" for="vtt-chat-input">Message</label>
-                <textarea id="vtt-chat-input" name="message" rows="3" placeholder="Send a message..." required></textarea>
-                <div class="chat-form__actions">
-                    <button type="submit" class="btn btn--primary">Send</button>
-                </div>
-            </form>
+    <aside
+        id="chat-panel"
+        class="chat-panel chat-panel--closed"
+        aria-hidden="true"
+        data-module="vtt-chat"
+    >
+        <div class="chat-panel__header">
+            <h3 class="chat-panel__title">VTT Chat</h3>
+            <div class="chat-panel__actions">
+                <button
+                    type="button"
+                    id="chat-panel-close"
+                    class="chat-panel__close"
+                    aria-label="Close chat"
+                    data-action="close-chat"
+                >&times;</button>
+            </div>
         </div>
+        <div id="chat-message-list" class="chat-panel__history" role="log" aria-live="polite"></div>
+        <div id="chat-whisper-targets" class="chat-panel__whispers" role="group" aria-label="Whisper targets"></div>
+        <form id="chat-input-form" class="chat-panel__input" autocomplete="off">
+            <textarea
+                id="chat-input"
+                class="chat-panel__textarea"
+                rows="2"
+                placeholder="Type a message..."
+            ></textarea>
+            <button type="submit" id="chat-send-btn" class="chat-panel__send">Send</button>
+        </form>
     </aside>
+    <button
+        id="chat-panel-toggle"
+        class="chat-panel-toggle"
+        type="button"
+        aria-expanded="false"
+        aria-controls="chat-panel"
+        data-action="toggle-chat"
+    >
+        Open Chat
+    </button>
+    <div id="chat-drop-target" class="chat-drop-target" hidden aria-hidden="true">
+        Drop images or image links to share
+    </div>
+    <div id="chat-whisper-popouts" class="chat-whisper-popouts" aria-live="polite" aria-atomic="false"></div>
+    <div id="chat-whisper-alerts" class="chat-whisper-alerts" aria-live="assertive" aria-atomic="true"></div>
     <?php
     return trim((string) ob_get_clean());
 }

--- a/dnd/vtt/components/SettingsPanel.php
+++ b/dnd/vtt/components/SettingsPanel.php
@@ -5,14 +5,22 @@ function renderVttSettingsPanel(string $tokenLibraryMarkup = ''): string
 {
     ob_start();
     ?>
-    <aside class="vtt-panel vtt-panel--settings" data-module="vtt-settings">
-        <header class="vtt-panel__header">
-            <h2 class="vtt-panel__title">Settings</h2>
-            <button type="button" class="vtt-panel__toggle" data-action="toggle-settings" aria-expanded="false">
-                <span class="visually-hidden">Toggle settings</span>
-            </button>
+    <aside
+        id="vtt-settings-panel"
+        class="vtt-settings-panel vtt-settings-panel--closed"
+        data-module="vtt-settings"
+        aria-hidden="true"
+    >
+        <header class="vtt-settings-panel__header">
+            <h2 class="vtt-settings-panel__title">Settings</h2>
+            <button
+                type="button"
+                class="vtt-settings-panel__close"
+                data-action="close-settings"
+                aria-label="Close settings"
+            >&times;</button>
         </header>
-        <div class="vtt-panel__body">
+        <div class="vtt-settings-panel__body">
             <nav class="settings-tabs" aria-label="Settings">
                 <button class="settings-tab is-active" data-settings-tab="scenes" type="button">Scenes</button>
                 <button class="settings-tab" data-settings-tab="tokens" type="button">Tokens</button>
@@ -44,6 +52,16 @@ function renderVttSettingsPanel(string $tokenLibraryMarkup = ''): string
             </section>
         </div>
     </aside>
+    <button
+        id="vtt-settings-toggle"
+        class="vtt-settings-toggle"
+        type="button"
+        aria-controls="vtt-settings-panel"
+        aria-expanded="false"
+        data-action="toggle-settings"
+    >
+        Settings
+    </button>
     <?php
     return trim((string) ob_get_clean());
 }

--- a/dnd/vtt/templates/layout.php
+++ b/dnd/vtt/templates/layout.php
@@ -21,15 +21,11 @@ $assetVersion = (int) ($config['assetsVersion'] ?? time());
 </head>
 <body class="vtt-body">
     <div id="vtt-app" class="vtt-app" data-routes='<?= json_encode($routes, JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP) ?>'>
-        <div class="vtt-app__sidebar vtt-app__sidebar--settings">
-            <?= $sections['settingsPanel'] ?? '' ?>
-        </div>
+        <?= $sections['settingsPanel'] ?? '' ?>
         <main class="vtt-app__main" id="vtt-main" tabindex="-1">
             <?= $sections['sceneBoard'] ?? '' ?>
         </main>
-        <div class="vtt-app__sidebar vtt-app__sidebar--chat">
-            <?= $sections['chatPanel'] ?? '' ?>
-        </div>
+        <?= $sections['chatPanel'] ?? '' ?>
     </div>
     <script>
         window.vttConfig = <?= json_encode($config, JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP) ?>;


### PR DESCRIPTION
## Summary
- replace the VTT chat markup with the dashboard-style slide-out panel and toggle button
- add a mirrored slide-out settings panel on the left and adjust the layout to center the board
- update CSS and panel scripts so both sidebars open and close from buttons with proper aria states

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e492e10ccc83279514d1ccd323c249