### PR TITLE
Fix VTT side panel toggle alignment

### DIFF
--- a/dnd/vtt/assets/css/chat.css
+++ b/dnd/vtt/assets/css/chat.css
@@ -55,3 +55,38 @@
   display: flex;
   justify-content: flex-end;
 }
+
+/*
+ * The chat panel markup reuses the legacy dashboard structure so we inherit
+ * its toggle styles from ../css/style.css. When the panel is undocked in the
+ * VTT workspace, the legacy CSS assumes a fixed width which causes the toggle
+ * tab to drift away from the panel on narrow viewports. By computing a shared
+ * effective width we keep the toggle aligned regardless of the available
+ * screen space.
+ */
+body.vtt-body {
+  --vtt-chat-panel-effective-width: min(
+    var(--chat-panel-width, 360px),
+    calc(100vw - (var(--chat-panel-offset, 20px) * 2))
+  );
+}
+
+body.vtt-body .chat-panel {
+  width: var(--vtt-chat-panel-effective-width);
+}
+
+body.vtt-body .chat-panel-toggle[aria-expanded="true"] {
+  transform: translate3d(
+    calc(-1 * (var(--vtt-chat-panel-effective-width) + var(--chat-panel-offset, 20px))),
+    -50%,
+    0
+  );
+}
+
+body.vtt-body .chat-panel-toggle[aria-expanded="true"]:hover {
+  transform: translate3d(
+    calc(-1 * (var(--vtt-chat-panel-effective-width) + var(--chat-panel-offset, 20px) + 6px)),
+    -50%,
+    0
+  );
+}

--- a/dnd/vtt/assets/css/settings.css
+++ b/dnd/vtt/assets/css/settings.css
@@ -155,12 +155,19 @@
   --vtt-settings-panel-offset: 20px;
 }
 
+body.vtt-body {
+  --vtt-settings-panel-effective-width: min(
+    var(--vtt-settings-panel-width, 360px),
+    calc(100vw - (var(--vtt-settings-panel-offset, 20px) * 2))
+  );
+}
+
 .vtt-settings-panel {
   position: fixed;
   top: var(--vtt-settings-panel-offset);
   left: 0;
   bottom: var(--vtt-settings-panel-offset);
-  width: min(var(--vtt-settings-panel-width), calc(100vw - (var(--vtt-settings-panel-offset) * 2)));
+  width: var(--vtt-settings-panel-effective-width);
   background: rgba(15, 23, 42, 0.92);
   border-radius: 0 16px 16px 0;
   border-right: 1px solid rgba(148, 163, 184, 0.3);
@@ -244,17 +251,32 @@
 
 .vtt-settings-toggle[aria-expanded="true"] {
   background: #6366f1;
-  transform: translate3d(calc(var(--vtt-settings-panel-width) + var(--vtt-settings-panel-offset)), -50%, 0);
+  transform: translate3d(
+    calc(var(--vtt-settings-panel-effective-width) + var(--vtt-settings-panel-offset, 20px)),
+    -50%,
+    0
+  );
 }
 
 .vtt-settings-toggle[aria-expanded="true"]:hover {
-  transform: translate3d(calc(var(--vtt-settings-panel-width) + var(--vtt-settings-panel-offset) + 6px), -50%, 0);
+  transform: translate3d(
+    calc(var(--vtt-settings-panel-effective-width) + var(--vtt-settings-panel-offset, 20px) + 6px),
+    -50%,
+    0
+  );
 }
 
 @media (max-width: 768px) {
   :root {
     --vtt-settings-panel-width: calc(100vw - 24px);
     --vtt-settings-panel-offset: 12px;
+  }
+
+  body.vtt-body {
+    --vtt-settings-panel-effective-width: min(
+      var(--vtt-settings-panel-width, calc(100vw - 24px)),
+      calc(100vw - (var(--vtt-settings-panel-offset, 12px) * 2))
+    );
   }
 
   .vtt-settings-panel {


### PR DESCRIPTION
## Summary
- compute a shared responsive width for the chat panel so its toggle stays attached when undocked
- apply the same responsive width logic to the settings panel so the side tab aligns on narrow viewports

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e4962c37288327928d2ea73a59faef