### PR TITLE
Add scene map upload and navigation controls

### DIFF
--- a/dnd/vtt/api/uploads.php
+++ b/dnd/vtt/api/uploads.php
@@ -1,10 +1,182 @@
 <?php
 declare(strict_types=1);
 
+require_once __DIR__ . '/../bootstrap.php';
+
 header('Content-Type: application/json');
-http_response_code(501);
+
+$method = $_SERVER['REQUEST_METHOD'] ?? 'GET';
+if (strtoupper($method) !== 'POST') {
+    http_response_code(405);
+    echo json_encode([
+        'success' => false,
+        'error' => 'Only POST requests are supported for uploads.',
+    ]);
+    return;
+}
+
+if (!isset($_FILES['map'])) {
+    http_response_code(400);
+    echo json_encode([
+        'success' => false,
+        'error' => 'No map image was provided.',
+    ]);
+    return;
+}
+
+$file = $_FILES['map'];
+
+if (!is_array($file) || ($file['error'] ?? UPLOAD_ERR_NO_FILE) === UPLOAD_ERR_NO_FILE) {
+    http_response_code(400);
+    echo json_encode([
+        'success' => false,
+        'error' => 'The map upload is missing or invalid.',
+    ]);
+    return;
+}
+
+$uploadError = $file['error'] ?? UPLOAD_ERR_OK;
+if ($uploadError !== UPLOAD_ERR_OK) {
+    http_response_code(400);
+    echo json_encode([
+        'success' => false,
+        'error' => uploadErrorMessage($uploadError),
+    ]);
+    return;
+}
+
+$tmpPath = $file['tmp_name'] ?? '';
+if ($tmpPath === '' || !is_uploaded_file($tmpPath)) {
+    http_response_code(400);
+    echo json_encode([
+        'success' => false,
+        'error' => 'Uploaded file could not be processed.',
+    ]);
+    return;
+}
+
+$maxBytes = 40 * 1024 * 1024; // 40 MB ceiling for very large maps.
+$size = (int) ($file['size'] ?? 0);
+if ($size <= 0 || $size > $maxBytes) {
+    http_response_code(413);
+    echo json_encode([
+        'success' => false,
+        'error' => 'Map images must be smaller than 40 MB.',
+    ]);
+    return;
+}
+
+$imageInfo = @getimagesize($tmpPath);
+if ($imageInfo === false) {
+    http_response_code(415);
+    echo json_encode([
+        'success' => false,
+        'error' => 'Only valid image files can be used as scene maps.',
+    ]);
+    return;
+}
+
+[$width, $height, $imageType] = $imageInfo;
+if ($width > 12000 || $height > 12000) {
+    http_response_code(413);
+    echo json_encode([
+        'success' => false,
+        'error' => 'Map dimensions exceed the supported 12,000 x 12,000 pixel limit.',
+    ]);
+    return;
+}
+
+$extension = imageTypeToExtension($imageType);
+if ($extension === null) {
+    http_response_code(415);
+    echo json_encode([
+        'success' => false,
+        'error' => 'Unsupported image format for scene maps.',
+    ]);
+    return;
+}
+
+$destinationDir = __DIR__ . '/../storage/uploads';
+if (!is_dir($destinationDir) && !mkdir($destinationDir, 0775, true) && !is_dir($destinationDir)) {
+    http_response_code(500);
+    echo json_encode([
+        'success' => false,
+        'error' => 'Unable to prepare storage for map uploads.',
+    ]);
+    return;
+}
+
+try {
+    $basename = bin2hex(random_bytes(12));
+} catch (Throwable $exception) {
+    http_response_code(500);
+    echo json_encode([
+        'success' => false,
+        'error' => 'Failed to generate a safe filename for the map.',
+    ]);
+    return;
+}
+
+$filename = sprintf('%s_%dx%d.%s', $basename, $width, $height, $extension);
+$destinationPath = $destinationDir . '/' . $filename;
+
+if (!move_uploaded_file($tmpPath, $destinationPath)) {
+    http_response_code(500);
+    echo json_encode([
+        'success' => false,
+        'error' => 'Unable to save the uploaded map to disk.',
+    ]);
+    return;
+}
+
+$publicUrl = '/dnd/vtt/storage/uploads/' . $filename;
+
+$boardState = loadVttJson('board-state.json');
+if (!is_array($boardState) || array_values($boardState) === $boardState) {
+    $boardState = [];
+}
+$boardState['mapUrl'] = $publicUrl;
+if (!saveVttJson('board-state.json', $boardState)) {
+    // Do not fail the upload if the board state cannot be persisted.
+    error_log('[VTT] Unable to persist board-state.json after map upload.');
+}
 
 echo json_encode([
-    'success' => false,
-    'error' => 'Upload handling will be implemented in a future iteration.',
+    'success' => true,
+    'data' => [
+        'url' => $publicUrl,
+        'width' => $width,
+        'height' => $height,
+    ],
 ]);
+
+/**
+ * Maps GD image type constants to usable extensions.
+ */
+function imageTypeToExtension(int $type): ?string
+{
+    switch ($type) {
+        case IMAGETYPE_GIF:
+            return 'gif';
+        case IMAGETYPE_JPEG:
+            return 'jpg';
+        case IMAGETYPE_PNG:
+            return 'png';
+        case IMAGETYPE_WEBP:
+            return 'webp';
+        default:
+            return null;
+    }
+}
+
+function uploadErrorMessage(int $code): string
+{
+    return match ($code) {
+        UPLOAD_ERR_INI_SIZE, UPLOAD_ERR_FORM_SIZE => 'The uploaded map exceeds the server size limit.',
+        UPLOAD_ERR_PARTIAL => 'The map upload was only partially completed.',
+        UPLOAD_ERR_NO_TMP_DIR => 'Missing a temporary folder on the server.',
+        UPLOAD_ERR_CANT_WRITE => 'Failed to write the map image to disk.',
+        UPLOAD_ERR_EXTENSION => 'A server extension stopped the upload.',
+        default => 'The map upload failed due to an unexpected error.',
+    };
+}

--- a/dnd/vtt/assets/css/base.css
+++ b/dnd/vtt/assets/css/base.css
@@ -71,6 +71,13 @@ body.vtt-body {
   background: #4f46e5;
 }
 
+.btn[disabled],
+.btn:disabled,
+.btn.is-loading {
+  opacity: 0.65;
+  cursor: not-allowed;
+}
+
 .empty-state {
   color: var(--vtt-text-muted);
   text-align: center;

--- a/dnd/vtt/assets/css/board.css
+++ b/dnd/vtt/assets/css/board.css
@@ -26,6 +26,7 @@
 .vtt-board__controls {
   display: flex;
   gap: 0.75rem;
+  flex-wrap: wrap;
 }
 
 .vtt-board__canvas-wrapper {
@@ -42,12 +43,27 @@
   background: rgba(15, 23, 42, 0.4);
 }
 
+.vtt-board__canvas::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: radial-gradient(circle at center, rgba(15, 23, 42, 0) 0%, rgba(15, 23, 42, 0.45) 100%);
+  opacity: 0.3;
+  z-index: 0;
+}
+
 .vtt-board__empty {
   position: absolute;
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
   color: var(--vtt-text-muted);
+  z-index: 2;
+}
+
+.vtt-board__empty[hidden] {
+  display: none;
 }
 
 .vtt-board__grid {
@@ -59,10 +75,50 @@
   pointer-events: none;
   opacity: 0;
   transition: opacity var(--vtt-transition);
+  z-index: 3;
 }
 
 .vtt-board__grid.is-visible {
   opacity: 1;
+}
+
+.vtt-board__map-surface {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  cursor: grab;
+  touch-action: none;
+  user-select: none;
+}
+
+.vtt-board__map-surface.is-panning {
+  cursor: grabbing;
+}
+
+.vtt-board__map-backdrop {
+  position: absolute;
+  top: 0;
+  left: 0;
+  padding: var(--vtt-map-padding, 18rem);
+  transform-origin: top left;
+  will-change: transform;
+  border-radius: calc(var(--vtt-radius) * 1.5);
+  box-shadow: 0 45px 95px rgba(15, 23, 42, 0.5);
+  background: rgba(15, 23, 42, 0.55);
+}
+
+.vtt-board__map-backdrop[hidden] {
+  display: none;
+}
+
+.vtt-board__map-image {
+  display: block;
+  max-width: none;
+  height: auto;
+  width: auto;
+  border-radius: calc(var(--vtt-radius) * 1.25);
+  box-shadow: 0 25px 55px rgba(15, 23, 42, 0.65);
+  pointer-events: none;
 }
 
 .vtt-board__ruler {

--- a/dnd/vtt/assets/js/bootstrap.js
+++ b/dnd/vtt/assets/js/bootstrap.js
@@ -23,7 +23,7 @@ async function bootstrap() {
 
   mountSettingsPanel(routes, { getState, subscribe });
   mountChatPanel(routes);
-  mountBoardInteractions({ getState, subscribe, updateState });
+  mountBoardInteractions({ getState, subscribe, updateState }, routes);
   mountDragRuler();
 
   await hydrateFromServer(routes);

--- a/dnd/vtt/assets/js/state/store.js
+++ b/dnd/vtt/assets/js/state/store.js
@@ -3,14 +3,19 @@ const listeners = new Set();
 const state = {
   scenes: [],
   tokens: [],
-  boardState: { activeSceneId: null, placements: {} },
+  boardState: { activeSceneId: null, placements: {}, mapUrl: null },
   grid: { size: 64, locked: false, visible: true },
 };
 
 export function initializeState(snapshot = {}) {
   state.scenes = snapshot.scenes ?? [];
   state.tokens = snapshot.tokens ?? [];
-  state.boardState = snapshot.boardState ?? state.boardState;
+  if (snapshot.boardState && typeof snapshot.boardState === 'object') {
+    state.boardState = {
+      ...state.boardState,
+      ...snapshot.boardState,
+    };
+  }
   notify();
 }
 

--- a/dnd/vtt/assets/js/ui/board-interactions.js
+++ b/dnd/vtt/assets/js/ui/board-interactions.js
@@ -1,7 +1,35 @@
-export function mountBoardInteractions(store) {
+export function mountBoardInteractions(store, routes = {}) {
   const board = document.getElementById('vtt-board-canvas');
   const grid = document.getElementById('vtt-grid-overlay');
-  if (!board) return;
+  const mapSurface = document.getElementById('vtt-map-surface');
+  const mapBackdrop = document.getElementById('vtt-map-backdrop');
+  const mapImage = document.getElementById('vtt-map-image');
+  const emptyState = board?.querySelector('.vtt-board__empty');
+  const status = document.getElementById('active-scene-status');
+  const uploadButton = document.querySelector('[data-action="upload-map"]');
+  const uploadInput = document.getElementById('vtt-map-upload-input');
+  if (!board || !mapSurface || !mapBackdrop || !mapImage) return;
+
+  const defaultStatusText = status?.textContent ?? '';
+
+  if (uploadButton && !routes.uploads) {
+    uploadButton.disabled = true;
+    uploadButton.title = 'Map uploads are not available right now.';
+  }
+
+  const viewState = {
+    scale: 1,
+    minScale: 0.1,
+    maxScale: 5,
+    translation: { x: 0, y: 0 },
+    isPanning: false,
+    pointerId: null,
+    lastPointer: { x: 0, y: 0 },
+    mapLoaded: false,
+    activeMapUrl: null,
+  };
+
+  const boardApi = store ?? {};
 
   board.addEventListener('keydown', (event) => {
     const movement = movementFromKey(event.key);
@@ -11,11 +39,260 @@ export function mountBoardInteractions(store) {
     console.info('[VTT] Token movement pending implementation', movement);
   });
 
+  board.addEventListener('contextmenu', (event) => {
+    event.preventDefault();
+  });
+
+  if (uploadButton && uploadInput && routes.uploads) {
+    uploadButton.addEventListener('click', () => {
+      uploadInput.click();
+    });
+
+    uploadInput.addEventListener('change', async () => {
+      const file = uploadInput.files?.[0];
+      uploadInput.value = '';
+      if (!file) return;
+
+      try {
+        setUploadingState(true);
+        const url = await uploadMap(file, routes.uploads);
+        if (!url) {
+          throw new Error('Upload endpoint returned no URL.');
+        }
+
+        boardApi.updateState?.((draft) => {
+          if (!draft.boardState || typeof draft.boardState !== 'object') {
+            draft.boardState = {};
+          }
+          draft.boardState.mapUrl = url;
+        });
+
+        if (status) {
+          status.textContent = 'Map uploaded successfully. Right-click to pan and scroll to zoom.';
+        }
+      } catch (error) {
+        console.error('[VTT] Failed to upload map', error);
+        if (status) {
+          status.textContent = `Unable to upload map: ${error.message ?? 'Unknown error'}`;
+        }
+      } finally {
+        setUploadingState(false);
+      }
+    });
+  }
+
   const toggleGridButton = document.querySelector('[data-action="toggle-grid"]');
   if (toggleGridButton && grid) {
     toggleGridButton.addEventListener('click', () => {
       grid.classList.toggle('is-visible');
     });
+  }
+
+  mapSurface.addEventListener('contextmenu', (event) => {
+    event.preventDefault();
+  });
+
+  mapSurface.addEventListener(
+    'wheel',
+    (event) => {
+      if (!viewState.mapLoaded) return;
+      event.preventDefault();
+      const pointer = getPointerPosition(event, board);
+      const previousScale = viewState.scale;
+      const zoomIntensity = 0.0018;
+      const scaleFactor = Math.exp(-event.deltaY * zoomIntensity);
+      const nextScale = clamp(previousScale * scaleFactor, viewState.minScale, viewState.maxScale);
+      if (nextScale === previousScale) return;
+
+      const zoomRatio = nextScale / previousScale;
+      viewState.translation.x = pointer.x - (pointer.x - viewState.translation.x) * zoomRatio;
+      viewState.translation.y = pointer.y - (pointer.y - viewState.translation.y) * zoomRatio;
+      viewState.scale = nextScale;
+      applyTransform();
+    },
+    { passive: false }
+  );
+
+  mapSurface.addEventListener('pointerdown', (event) => {
+    if (event.button !== 2 || !viewState.mapLoaded) {
+      return;
+    }
+
+    event.preventDefault();
+    viewState.isPanning = true;
+    viewState.pointerId = event.pointerId;
+    viewState.lastPointer = { x: event.clientX, y: event.clientY };
+    mapSurface.classList.add('is-panning');
+    try {
+      mapSurface.setPointerCapture(event.pointerId);
+    } catch (error) {
+      console.warn('[VTT] Unable to set pointer capture', error);
+    }
+  });
+
+  mapSurface.addEventListener('pointermove', (event) => {
+    if (!viewState.isPanning || event.pointerId !== viewState.pointerId) {
+      return;
+    }
+
+    const deltaX = event.clientX - viewState.lastPointer.x;
+    const deltaY = event.clientY - viewState.lastPointer.y;
+    viewState.translation.x += deltaX;
+    viewState.translation.y += deltaY;
+    viewState.lastPointer = { x: event.clientX, y: event.clientY };
+    applyTransform();
+  });
+
+  const endPan = (event) => {
+    if (viewState.pointerId !== null && event.pointerId !== viewState.pointerId) {
+      return;
+    }
+
+    viewState.isPanning = false;
+    viewState.pointerId = null;
+    mapSurface.classList.remove('is-panning');
+    try {
+      mapSurface.releasePointerCapture?.(event.pointerId);
+    } catch (error) {
+      // Ignore capture release errors
+    }
+  };
+
+  mapSurface.addEventListener('pointerup', endPan);
+  mapSurface.addEventListener('pointercancel', endPan);
+  mapSurface.addEventListener('pointerleave', endPan);
+
+  if (typeof boardApi.subscribe === 'function') {
+    boardApi.subscribe((state) => {
+      const nextUrl = state.boardState?.mapUrl ?? null;
+      if (nextUrl !== viewState.activeMapUrl) {
+        loadMap(nextUrl);
+      }
+    });
+  }
+
+  loadMap(boardApi.getState?.().boardState?.mapUrl ?? null);
+
+  function loadMap(url) {
+    viewState.activeMapUrl = url || null;
+    viewState.mapLoaded = false;
+    mapImage.hidden = true;
+    mapBackdrop.hidden = !url;
+    resetView();
+
+    if (!url) {
+      emptyState?.removeAttribute('hidden');
+      if (status) {
+        status.textContent = defaultStatusText;
+      }
+      return;
+    }
+
+    emptyState?.setAttribute('hidden', 'hidden');
+    mapImage.onload = () => {
+      viewState.mapLoaded = true;
+      calibrateToBoard();
+      mapImage.hidden = false;
+      mapBackdrop.hidden = false;
+      if (status) {
+        status.textContent = 'Right-click and drag to pan. Use the mouse wheel to zoom.';
+      }
+    };
+    mapImage.onerror = () => {
+      viewState.mapLoaded = false;
+      mapImage.hidden = true;
+      mapBackdrop.hidden = true;
+      emptyState?.removeAttribute('hidden');
+      if (status) {
+        status.textContent = 'Unable to display the uploaded map.';
+      }
+    };
+    mapImage.src = url;
+  }
+
+  function calibrateToBoard() {
+    const boardRect = board.getBoundingClientRect();
+    const styles = getComputedStyle(mapBackdrop);
+    const paddingX = parseFloat(styles.paddingLeft || '0') + parseFloat(styles.paddingRight || '0');
+    const paddingY = parseFloat(styles.paddingTop || '0') + parseFloat(styles.paddingBottom || '0');
+    const mapWidth = mapImage.naturalWidth + paddingX;
+    const mapHeight = mapImage.naturalHeight + paddingY;
+
+    const scaleX = boardRect.width / mapWidth;
+    const scaleY = boardRect.height / mapHeight;
+    const initialScale = Number.isFinite(Math.min(scaleX, scaleY))
+      ? Math.min(1, Math.min(scaleX, scaleY))
+      : 1;
+
+    viewState.scale = clamp(initialScale, 0.02, 1);
+    viewState.minScale = Math.min(viewState.scale, 0.05);
+    viewState.maxScale = Math.max(5, viewState.scale * 6);
+
+    viewState.translation.x = (boardRect.width - mapWidth * viewState.scale) / 2;
+    viewState.translation.y = (boardRect.height - mapHeight * viewState.scale) / 2;
+    applyTransform();
+  }
+
+  function applyTransform() {
+    mapBackdrop.style.transform = `translate3d(${viewState.translation.x}px, ${viewState.translation.y}px, 0) scale(${viewState.scale})`;
+  }
+
+  function resetView() {
+    viewState.scale = 1;
+    viewState.translation = { x: 0, y: 0 };
+    applyTransform();
+  }
+
+  function setUploadingState(isUploading) {
+    if (!uploadButton) return;
+    uploadButton.disabled = isUploading;
+    uploadButton.classList.toggle('is-loading', isUploading);
+    if (isUploading && status) {
+      status.textContent = 'Uploading map…';
+    }
+  }
+
+  function getPointerPosition(event, element) {
+    const rect = element.getBoundingClientRect();
+    return {
+      x: event.clientX - rect.left,
+      y: event.clientY - rect.top,
+    };
+  }
+
+  function clamp(value, min, max) {
+    return Math.min(Math.max(value, min), max);
+  }
+
+  async function uploadMap(file, endpoint) {
+    const formData = new FormData();
+    formData.append('map', file, file.name);
+
+    const response = await fetch(endpoint, {
+      method: 'POST',
+      body: formData,
+    });
+
+    if (!response.ok) {
+      const message = await safeReadError(response);
+      throw new Error(message || `Upload failed with status ${response.status}`);
+    }
+
+    const payload = await response.json();
+    if (!payload.success) {
+      throw new Error(payload.error || 'Upload failed');
+    }
+
+    return payload.data?.url ?? null;
+  }
+
+  async function safeReadError(response) {
+    try {
+      const payload = await response.json();
+      return payload.error ?? '';
+    } catch (error) {
+      return '';
+    }
   }
 }
 

--- a/dnd/vtt/components/SceneBoard.php
+++ b/dnd/vtt/components/SceneBoard.php
@@ -12,6 +12,13 @@ function renderVttSceneBoard(): string
                 <p id="active-scene-status" class="vtt-board__status">Select or create a scene to begin.</p>
             </div>
             <div class="vtt-board__controls">
+                <input
+                    id="vtt-map-upload-input"
+                    class="visually-hidden"
+                    type="file"
+                    accept="image/*"
+                />
+                <button class="btn btn--primary" type="button" data-action="upload-map">Upload Map</button>
                 <button class="btn" type="button" data-action="toggle-grid">Toggle Grid</button>
                 <button class="btn" type="button" data-action="lock-grid">Lock Grid</button>
                 <button class="btn" type="button" data-action="measure-distance">Measure</button>
@@ -20,6 +27,11 @@ function renderVttSceneBoard(): string
         <div class="vtt-board__canvas-wrapper">
             <div id="vtt-grid-overlay" class="vtt-board__grid" aria-hidden="true"></div>
             <div id="vtt-board-canvas" class="vtt-board__canvas" tabindex="0" role="application">
+                <div id="vtt-map-surface" class="vtt-board__map-surface" aria-live="polite">
+                    <div id="vtt-map-backdrop" class="vtt-board__map-backdrop">
+                        <img id="vtt-map-image" class="vtt-board__map-image" alt="Scene map" hidden />
+                    </div>
+                </div>
                 <p class="vtt-board__empty">Drag a scene map here or create a scene from the settings panel.</p>
             </div>
             <div id="vtt-distance-ruler" class="vtt-board__ruler" hidden>

--- a/dnd/vtt/storage/board-state.json
+++ b/dnd/vtt/storage/board-state.json
@@ -1,4 +1,5 @@
 {
   "activeSceneId": null,
-  "placements": {}
+  "placements": {},
+  "mapUrl": null
 }

--- a/dnd/vtt/storage/uploads/.gitignore
+++ b/dnd/vtt/storage/uploads/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
## Summary
- add an upload control and map surface scaffold to the VTT board
- implement a PHP upload endpoint that accepts large scene images and saves the latest map URL in board state
- enable front-end map rendering with right-click panning, scroll zooming, and generous map padding styles

## Testing
- php -l dnd/vtt/api/uploads.php

------
https://chatgpt.com/codex/tasks/task_e_68e499a913ec8327a8c23759a8b74457