### PR TITLE
Relocate VTT map controls to the settings panel

### DIFF
--- a/dnd/vtt/assets/css/settings.css
+++ b/dnd/vtt/assets/css/settings.css
@@ -49,6 +49,33 @@
   padding: 1rem;
 }
 
+.scene-controls {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+  padding: 0.75rem;
+  border: 1px dashed rgba(148, 163, 184, 0.35);
+  border-radius: var(--vtt-radius);
+  background: rgba(15, 23, 42, 0.5);
+}
+
+.scene-controls__buttons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.scene-controls__hint {
+  margin: 0;
+  color: var(--vtt-text-muted);
+  font-size: 0.85rem;
+}
+
+.scene-manager {
+  min-height: 140px;
+}
+
 .vtt-token-library {
   display: flex;
   flex-direction: column;

--- a/dnd/vtt/components/SceneBoard.php
+++ b/dnd/vtt/components/SceneBoard.php
@@ -12,15 +12,6 @@ function renderVttSceneBoard(): string
                 <p id="active-scene-status" class="vtt-board__status">Select or create a scene to begin.</p>
             </div>
             <div class="vtt-board__controls">
-                <input
-                    id="vtt-map-upload-input"
-                    class="visually-hidden"
-                    type="file"
-                    accept="image/*"
-                />
-                <button class="btn btn--primary" type="button" data-action="upload-map">Upload Map</button>
-                <button class="btn" type="button" data-action="toggle-grid">Toggle Grid</button>
-                <button class="btn" type="button" data-action="lock-grid">Lock Grid</button>
                 <button class="btn" type="button" data-action="measure-distance">Measure</button>
             </div>
         </header>

--- a/dnd/vtt/components/SettingsPanel.php
+++ b/dnd/vtt/components/SettingsPanel.php
@@ -31,7 +31,23 @@ function renderVttSettingsPanel(string $tokenLibraryMarkup = ''): string
                     <h3>Scene Manager</h3>
                     <button class="btn btn--primary" type="button" data-action="create-scene">New Scene</button>
                 </header>
-                <div class="settings-view__content" id="scene-manager"></div>
+                <div class="settings-view__content">
+                    <section class="scene-controls" aria-label="Scene map and grid controls">
+                        <input
+                            id="vtt-map-upload-input"
+                            class="visually-hidden"
+                            type="file"
+                            accept="image/*"
+                        />
+                        <div class="scene-controls__buttons">
+                            <button class="btn btn--primary" type="button" data-action="upload-map">Upload Map</button>
+                            <button class="btn" type="button" data-action="toggle-grid">Toggle Grid</button>
+                            <button class="btn" type="button" data-action="lock-grid">Lock Grid</button>
+                        </div>
+                        <p class="scene-controls__hint">Upload a background map and adjust the shared grid without leaving settings.</p>
+                    </section>
+                    <div class="scene-manager" id="scene-manager"></div>
+                </div>
             </section>
             <section class="settings-view settings-view--tokens" data-settings-view="tokens" hidden>
                 <header class="settings-view__header">


### PR DESCRIPTION
## Summary
- move the map upload input and grid controls into the scenes tab of the settings panel
- streamline the board header by keeping only the measurement control visible on the canvas
- add styling for the new scene control section within the settings view

## Testing
- Manual UI verification in the in-repo PHP dev server

------
https://chatgpt.com/codex/tasks/task_e_68e49cfd48e483279a712826d07ff18b