### PR TITLE
Improve VTT grid rendering at varied zoom levels

### DIFF
--- a/dnd/vtt/assets/css/board.css
+++ b/dnd/vtt/assets/css/board.css
@@ -88,6 +88,7 @@
   will-change: transform;
   pointer-events: none;
   z-index: 1;
+  --vtt-map-scale: 1;
 }
 
 .vtt-board__map-transform[hidden] {
@@ -124,13 +125,24 @@
   right: var(--vtt-grid-offset-right, 0px);
   bottom: var(--vtt-grid-offset-bottom, 0px);
   left: var(--vtt-grid-offset-left, 0px);
-  background-image: linear-gradient(to right, rgba(148, 163, 184, 0.2) 1px, transparent 1px),
-    linear-gradient(to bottom, rgba(148, 163, 184, 0.2) 1px, transparent 1px);
+  --vtt-grid-line-color: rgba(226, 232, 240, 0.45);
+  --vtt-grid-line-width: 1px;
+  background-image: linear-gradient(
+      to right,
+      var(--vtt-grid-line-color) var(--vtt-grid-line-width),
+      transparent var(--vtt-grid-line-width)
+    ),
+    linear-gradient(
+      to bottom,
+      var(--vtt-grid-line-color) var(--vtt-grid-line-width),
+      transparent var(--vtt-grid-line-width)
+    );
   background-size: var(--vtt-grid-size, 64px) var(--vtt-grid-size, 64px);
   pointer-events: none;
   opacity: 0;
   transition: opacity var(--vtt-transition);
   z-index: 2;
+  mix-blend-mode: screen;
 }
 
 .vtt-board__grid.is-visible {

--- a/dnd/vtt/assets/js/ui/board-interactions.js
+++ b/dnd/vtt/assets/js/ui/board-interactions.js
@@ -283,6 +283,11 @@ export function mountBoardInteractions(store, routes = {}) {
   function applyTransform() {
     if (!mapTransform) return;
     mapTransform.style.transform = `translate3d(${viewState.translation.x}px, ${viewState.translation.y}px, 0) scale(${viewState.scale})`;
+    mapTransform.style.setProperty('--vtt-map-scale', String(viewState.scale));
+    if (grid) {
+      const lineWidth = Math.max(1, 1 / viewState.scale);
+      grid.style.setProperty('--vtt-grid-line-width', `${lineWidth}px`);
+    }
   }
 
   function resetView() {


### PR DESCRIPTION
## Summary
- adjust board grid styling to use configurable line color and width for better contrast on top of maps
- update board interactions to scale grid stroke width inversely with zoom to avoid artifacts when zooming out

## Testing
- php -S 0.0.0.0:8000 (manual verification in browser)


------
https://chatgpt.com/codex/tasks/task_e_68e4a5f0e7a48327825bb4feb63b185d