### PR TITLE
Add scene thumbnails to settings panel

### DIFF
--- a/dnd/vtt/assets/css/settings.css
+++ b/dnd/vtt/assets/css/settings.css
@@ -246,6 +246,8 @@
 }
 
 .scene-item {
+  display: flex;
+  gap: 0.75rem;
   border: 1px solid rgba(148, 163, 184, 0.2);
   border-radius: var(--vtt-radius);
   padding: 0.75rem;
@@ -257,11 +259,17 @@
   box-shadow: 0 0 0 1px rgba(99, 102, 241, 0.45);
 }
 
+.scene-item__content {
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
+  gap: 0.75rem;
+}
+
 .scene-item__header {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 0.75rem;
 }
 
 .scene-item__header h4 {
@@ -278,6 +286,41 @@
 .scene-item__footer {
   display: flex;
   gap: 0.5rem;
+  margin-top: auto;
+}
+
+.scene-item__preview {
+  position: relative;
+  flex: 0 0 96px;
+  width: 96px;
+  aspect-ratio: 4 / 3;
+  border-radius: calc(var(--vtt-radius) - 2px);
+  overflow: hidden;
+  background: rgba(30, 41, 59, 0.6);
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.15);
+}
+
+.scene-item__preview img {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.scene-item__preview--empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  color: var(--vtt-text-muted);
+  background: linear-gradient(145deg, rgba(79, 70, 229, 0.18), rgba(14, 116, 144, 0.18));
+}
+
+.scene-item__preview-text {
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
 }
 
 .scene-group {

--- a/dnd/vtt/assets/js/ui/scene-manager.js
+++ b/dnd/vtt/assets/js/ui/scene-manager.js
@@ -269,14 +269,17 @@ function renderSceneItem(scene, activeSceneId) {
   const name = escapeHtml(scene.name || 'Untitled Scene');
   return `
     <article class="scene-item${isActive ? ' is-active' : ''}" data-scene-id="${scene.id}">
-      <header class="scene-item__header">
-        <h4>${name}</h4>
-        <span class="scene-item__status">${isActive ? 'Active' : ''}</span>
-      </header>
-      <footer class="scene-item__footer">
-        <button type="button" class="btn" data-action="activate-scene" data-scene-id="${scene.id}">Activate</button>
-        <button type="button" class="btn btn--danger" data-action="delete-scene" data-scene-id="${scene.id}">Delete</button>
-      </footer>
+      ${renderScenePreview(scene, scene.name)}
+      <div class="scene-item__content">
+        <header class="scene-item__header">
+          <h4>${name}</h4>
+          <span class="scene-item__status">${isActive ? 'Active' : ''}</span>
+        </header>
+        <footer class="scene-item__footer">
+          <button type="button" class="btn" data-action="activate-scene" data-scene-id="${scene.id}">Activate</button>
+          <button type="button" class="btn btn--danger" data-action="delete-scene" data-scene-id="${scene.id}">Delete</button>
+        </footer>
+      </div>
     </article>
   `;
 }
@@ -288,6 +291,25 @@ function escapeHtml(value = '') {
     .replace(/>/g, '&gt;')
     .replace(/"/g, '&quot;')
     .replace(/'/g, '&#039;');
+}
+
+function renderScenePreview(scene, fallbackName) {
+  const url = typeof scene.mapUrl === 'string' ? scene.mapUrl.trim() : '';
+  if (!url) {
+    return `
+      <div class="scene-item__preview scene-item__preview--empty">
+        <span class="scene-item__preview-text">No Map</span>
+      </div>
+    `;
+  }
+
+  const safeName = typeof fallbackName === 'string' ? fallbackName.trim() : '';
+  const label = safeName ? `Preview of ${safeName}` : 'Scene preview';
+  return `
+    <div class="scene-item__preview">
+      <img src="${escapeHtml(url)}" alt="${escapeHtml(label)}" loading="lazy" />
+    </div>
+  `;
 }
 
 function showFeedback(element, message, type = 'info') {


### PR DESCRIPTION
## Summary
- render scene cards with thumbnail previews in the settings panel
- extend scene manager styling for image tiles and empty placeholders

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e58e4640c88327a4a630178051d95b