### PR TITLE
Refine VTT settings layout styling

### DIFF
--- a/dnd/vtt/assets/css/settings.css
+++ b/dnd/vtt/assets/css/settings.css
@@ -42,22 +42,27 @@
 }
 
 .settings-view__content {
-  background: rgba(15, 23, 42, 0.35);
-  border-radius: var(--vtt-radius);
-  border: 1px solid rgba(148, 163, 184, 0.2);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  background: none;
+  border: none;
+  border-radius: 0;
   min-height: 160px;
-  padding: 1rem;
+  padding: 0;
+}
+
+.settings-view__content > :first-child {
+  border-top: none;
+  padding-top: 0;
 }
 
 .scene-controls {
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
-  margin-bottom: 1rem;
-  padding: 0.75rem;
-  border: 1px dashed rgba(148, 163, 184, 0.35);
-  border-radius: var(--vtt-radius);
-  background: rgba(15, 23, 42, 0.5);
+  padding-top: 1.25rem;
+  border-top: 1px solid rgba(148, 163, 184, 0.35);
 }
 
 .scene-controls__buttons {
@@ -105,11 +110,8 @@
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
-  margin-bottom: 1rem;
-  padding: 0.75rem;
-  border: 1px solid rgba(148, 163, 184, 0.2);
-  border-radius: var(--vtt-radius);
-  background: rgba(15, 23, 42, 0.45);
+  padding-top: 1.25rem;
+  border-top: 1px solid rgba(148, 163, 184, 0.35);
 }
 
 .scene-creator.is-pending {
@@ -177,6 +179,8 @@
 
 .scene-manager {
   min-height: 140px;
+  padding-top: 1.5rem;
+  border-top: 1px solid rgba(148, 163, 184, 0.35);
 }
 
 .vtt-token-library {
@@ -242,21 +246,20 @@
 .scene-list {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 1.25rem;
 }
 
 .scene-item {
   display: flex;
   gap: 0.75rem;
-  border: 1px solid rgba(148, 163, 184, 0.2);
   border-radius: var(--vtt-radius);
-  padding: 0.75rem;
-  background: rgba(15, 23, 42, 0.45);
+  padding: 0.75rem 1rem;
+  background: rgba(15, 23, 42, 0.35);
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.18);
 }
 
 .scene-item.is-active {
-  border-color: rgba(99, 102, 241, 0.5);
-  box-shadow: 0 0 0 1px rgba(99, 102, 241, 0.45);
+  box-shadow: inset 0 0 0 1px rgba(99, 102, 241, 0.5);
 }
 
 .scene-item__content {
@@ -264,6 +267,7 @@
   flex-direction: column;
   flex: 1 1 auto;
   gap: 0.75rem;
+  min-width: 0;
 }
 
 .scene-item__header {
@@ -285,6 +289,7 @@
 
 .scene-item__footer {
   display: flex;
+  flex-wrap: wrap;
   gap: 0.5rem;
   margin-top: auto;
 }
@@ -324,17 +329,15 @@
 }
 
 .scene-group {
-  border: 1px solid rgba(148, 163, 184, 0.2);
-  border-radius: var(--vtt-radius);
-  background: rgba(15, 23, 42, 0.35);
+  padding-top: 1rem;
+  border-top: 1px solid rgba(148, 163, 184, 0.25);
 }
 
 .scene-group__header {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 0.65rem 0.75rem;
-  border-bottom: 1px solid rgba(148, 163, 184, 0.15);
+  margin-bottom: 0.75rem;
 }
 
 .scene-group__header h4 {
@@ -348,8 +351,12 @@
 .scene-group__body {
   display: flex;
   flex-direction: column;
-  gap: 0.65rem;
-  padding: 0.75rem;
+  gap: 0.75rem;
+}
+
+.scene-list > .scene-group:first-child {
+  border-top: none;
+  padding-top: 0;
 }
 
 :root {


### PR DESCRIPTION
## Summary
- replace the stacked cards in the VTT settings scene manager with lighter horizontal separators
- allow scene preview cards to wrap their footer buttons and prevent image previews from pushing controls out of view

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5922ea6688327adf04f266575f7a5