### PR TITLE
Add interactive token maker preview to settings panel

### DIFF
--- a/dnd/vtt/assets/css/settings.css
+++ b/dnd/vtt/assets/css/settings.css
@@ -189,6 +189,110 @@
   gap: 1rem;
 }
 
+.token-maker {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+  padding: 1.25rem;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: var(--vtt-radius);
+  background: rgba(15, 23, 42, 0.45);
+}
+
+.token-maker__preview {
+  position: relative;
+  width: 220px;
+  aspect-ratio: 1 / 1;
+  border-radius: 50%;
+  overflow: hidden;
+  border: 2px solid rgba(99, 102, 241, 0.35);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.05);
+  background: radial-gradient(circle at 50% 50%, rgba(99, 102, 241, 0.18), rgba(30, 41, 59, 0.85));
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  user-select: none;
+  cursor: grab;
+}
+
+.token-maker__preview:active {
+  cursor: grabbing;
+}
+
+.token-maker__preview-hint {
+  max-width: 80%;
+  text-align: center;
+  font-size: 0.85rem;
+  color: var(--vtt-text-muted);
+  line-height: 1.4;
+}
+
+.token-maker--has-image .token-maker__preview-hint {
+  display: none;
+}
+
+.token-maker__preview-image {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  display: block;
+  max-width: none;
+  pointer-events: none;
+  user-select: none;
+  transform-origin: center;
+  --token-maker-offset-x: 0px;
+  --token-maker-offset-y: 0px;
+  --token-maker-scale: 1;
+  transform: translate(-50%, -50%) translate(var(--token-maker-offset-x), var(--token-maker-offset-y))
+    scale(var(--token-maker-scale));
+  will-change: transform;
+}
+
+.token-maker__controls {
+  flex: 1 1 220px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  justify-content: flex-start;
+}
+
+.token-maker__dropzone {
+  padding: 1.25rem 1rem;
+  border: 1px dashed rgba(148, 163, 184, 0.4);
+  border-radius: var(--vtt-radius);
+  background: rgba(15, 23, 42, 0.6);
+  text-align: center;
+  transition: border-color var(--vtt-transition), background var(--vtt-transition);
+}
+
+.token-maker__dropzone.is-active {
+  border-color: rgba(99, 102, 241, 0.65);
+  background: rgba(99, 102, 241, 0.18);
+}
+
+.token-maker__dropzone-title {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--vtt-text-primary);
+}
+
+.token-maker__dropzone-hint {
+  margin: 0.5rem 0 0;
+  font-size: 0.85rem;
+  color: var(--vtt-text-muted);
+}
+
+.token-maker__controls .btn {
+  align-self: flex-start;
+}
+
+.token-maker__controls-hint {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--vtt-text-muted);
+}
+
 .token-template-list {
   list-style: none;
   margin: 0;

--- a/dnd/vtt/assets/js/ui/token-library.js
+++ b/dnd/vtt/assets/js/ui/token-library.js
@@ -1,9 +1,13 @@
+import { initializeTokenMaker } from './token-maker.js';
+
 export function renderTokenLibrary(routes, store) {
   const moduleRoot = document.querySelector('[data-module="vtt-token-library"]');
   if (!moduleRoot) return;
 
   const listContainer = moduleRoot.querySelector('#token-template-list');
   if (!listContainer) return;
+
+  initializeTokenMaker(moduleRoot);
 
   const render = (state) => {
     const { tokens } = state;

--- a/dnd/vtt/assets/js/ui/token-maker.js
+++ b/dnd/vtt/assets/js/ui/token-maker.js
@@ -1,0 +1,219 @@
+const MAX_ZOOM_MULTIPLIER = 10;
+
+export function initializeTokenMaker(moduleRoot) {
+  const makerRoot = moduleRoot?.querySelector('[data-module="vtt-token-maker"]');
+  if (!makerRoot) return;
+
+  const preview = makerRoot.querySelector('[data-token-preview]');
+  const placeholder = makerRoot.querySelector('[data-token-placeholder]');
+  const image = makerRoot.querySelector('[data-token-image]');
+  const dropzone = makerRoot.querySelector('[data-token-dropzone]');
+  const fileInput = makerRoot.querySelector('[data-token-input]');
+  const browseButton = makerRoot.querySelector('[data-action="browse-token-image"]');
+
+  if (!preview || !image || !fileInput) {
+    return;
+  }
+
+  const state = {
+    scale: 1,
+    minScale: 1,
+    offsetX: 0,
+    offsetY: 0,
+    hasImage: false,
+  };
+
+  let objectUrl = null;
+  let isPanning = false;
+  let lastPoint = { x: 0, y: 0 };
+  let dragDepth = 0;
+
+  const applyTransform = () => {
+    image.style.setProperty('--token-maker-scale', String(state.scale));
+    image.style.setProperty('--token-maker-offset-x', `${state.offsetX}px`);
+    image.style.setProperty('--token-maker-offset-y', `${state.offsetY}px`);
+  };
+
+  const setHasImage = (hasImage) => {
+    state.hasImage = hasImage;
+    makerRoot.classList.toggle('token-maker--has-image', hasImage);
+    if (hasImage) {
+      image.hidden = false;
+      placeholder?.setAttribute('aria-hidden', 'true');
+    } else {
+      image.hidden = true;
+      placeholder?.setAttribute('aria-hidden', 'false');
+    }
+  };
+
+  const resetPosition = (scale) => {
+    state.scale = scale;
+    state.minScale = scale;
+    state.offsetX = 0;
+    state.offsetY = 0;
+    applyTransform();
+  };
+
+  const cleanupObjectUrl = (url) => {
+    if (url && url.startsWith('blob:')) {
+      URL.revokeObjectURL(url);
+    }
+  };
+
+  const loadFile = (file) => {
+    if (!file || !file.type?.startsWith('image/')) {
+      return;
+    }
+
+    const nextUrl = URL.createObjectURL(file);
+    const handleLoad = () => {
+      const bounds = preview.getBoundingClientRect();
+      const naturalWidth = image.naturalWidth || 1;
+      const naturalHeight = image.naturalHeight || 1;
+      const coverScale = Math.max(
+        bounds.width / naturalWidth,
+        bounds.height / naturalHeight,
+      );
+
+      resetPosition(Number.isFinite(coverScale) && coverScale > 0 ? coverScale : 1);
+      setHasImage(true);
+
+      if (objectUrl && objectUrl !== nextUrl) {
+        cleanupObjectUrl(objectUrl);
+      }
+
+      objectUrl = nextUrl;
+    };
+
+    image.addEventListener('load', handleLoad, { once: true });
+    image.addEventListener(
+      'error',
+      () => {
+        if (objectUrl && objectUrl !== nextUrl) {
+          cleanupObjectUrl(objectUrl);
+        }
+        cleanupObjectUrl(nextUrl);
+        setHasImage(false);
+      },
+      { once: true },
+    );
+    image.src = nextUrl;
+  };
+
+  const handleWheel = (event) => {
+    if (!state.hasImage) return;
+
+    event.preventDefault();
+
+    const zoomMultiplier = Math.exp(-event.deltaY / 300);
+    const maxScale = state.minScale * MAX_ZOOM_MULTIPLIER;
+    const nextScale = clamp(state.scale * zoomMultiplier, state.minScale, maxScale);
+
+    if (Math.abs(nextScale - state.scale) < 0.001) {
+      return;
+    }
+
+    state.scale = nextScale;
+    applyTransform();
+  };
+
+  const handlePointerMove = (event) => {
+    if (!isPanning || !state.hasImage) return;
+
+    event.preventDefault();
+
+    if ((event.buttons & 2) === 0) {
+      isPanning = false;
+      return;
+    }
+
+    const dx = event.clientX - lastPoint.x;
+    const dy = event.clientY - lastPoint.y;
+    lastPoint = { x: event.clientX, y: event.clientY };
+
+    state.offsetX += dx / state.scale;
+    state.offsetY += dy / state.scale;
+    applyTransform();
+  };
+
+  const handlePointerUp = () => {
+    isPanning = false;
+  };
+
+  preview.addEventListener('wheel', handleWheel, { passive: false });
+  preview.addEventListener('contextmenu', (event) => event.preventDefault());
+
+  preview.addEventListener('mousedown', (event) => {
+    if (event.button !== 2 || !state.hasImage) return;
+
+    isPanning = true;
+    lastPoint = { x: event.clientX, y: event.clientY };
+    event.preventDefault();
+  });
+
+  window.addEventListener('mousemove', handlePointerMove);
+  window.addEventListener('mouseup', handlePointerUp);
+  preview.addEventListener('mouseleave', handlePointerUp);
+
+  const dropTargets = [dropzone, preview].filter(Boolean);
+
+  dropTargets.forEach((target) => {
+    target.addEventListener('dragenter', (event) => {
+      event.preventDefault();
+      dragDepth += 1;
+      dropzone?.classList.add('is-active');
+    });
+
+    target.addEventListener('dragover', (event) => {
+      event.preventDefault();
+    });
+
+    target.addEventListener('dragleave', (event) => {
+      if (event.currentTarget !== target) return;
+      const related = event.relatedTarget;
+      if (related && target.contains(related)) {
+        return;
+      }
+      dragDepth = Math.max(0, dragDepth - 1);
+      if (dragDepth === 0) {
+        dropzone?.classList.remove('is-active');
+      }
+    });
+
+    target.addEventListener('drop', (event) => {
+      event.preventDefault();
+      dragDepth = 0;
+      dropzone?.classList.remove('is-active');
+
+      const file = event.dataTransfer?.files?.[0];
+      loadFile(file);
+    });
+  });
+
+  if (fileInput) {
+    fileInput.addEventListener('change', () => {
+      const file = fileInput.files?.[0];
+      loadFile(file);
+      fileInput.value = '';
+    });
+  }
+
+  if (browseButton) {
+    browseButton.addEventListener('click', () => {
+      fileInput.click();
+    });
+  }
+
+  window.addEventListener('beforeunload', () => {
+    cleanupObjectUrl(objectUrl);
+  });
+
+  applyTransform();
+  setHasImage(false);
+}
+
+function clamp(value, min, max) {
+  return Math.min(Math.max(value, min), max);
+}
+
+export default initializeTokenMaker;

--- a/dnd/vtt/components/TokenLibrary.php
+++ b/dnd/vtt/components/TokenLibrary.php
@@ -15,6 +15,34 @@ function renderVttTokenLibrary(): string
             </div>
         </header>
         <div class="vtt-token-library__content">
+            <section class="token-maker" data-module="vtt-token-maker" aria-label="Token image builder">
+                <div class="token-maker__preview" data-token-preview>
+                    <span class="token-maker__preview-hint" data-token-placeholder>Drop an image or browse to begin.</span>
+                    <img
+                        class="token-maker__preview-image"
+                        data-token-image
+                        alt=""
+                        hidden
+                    />
+                </div>
+                <div class="token-maker__controls">
+                    <div class="token-maker__dropzone" data-token-dropzone>
+                        <p class="token-maker__dropzone-title">Drag &amp; Drop</p>
+                        <p class="token-maker__dropzone-hint">PNG or JPG up to 10MB</p>
+                    </div>
+                    <input
+                        id="token-image-input"
+                        class="visually-hidden"
+                        type="file"
+                        accept="image/*"
+                        data-token-input
+                    />
+                    <button class="btn" type="button" data-action="browse-token-image">Browse Images</button>
+                    <p class="token-maker__controls-hint">
+                        Scroll to zoom. Right-click and drag inside the circle to reposition.
+                    </p>
+                </div>
+            </section>
             <ul id="token-template-list" class="token-template-list" aria-live="polite">
                 <li class="token-template-list__empty">No tokens saved yet.</li>
             </ul>


### PR DESCRIPTION
## Summary
- add a token maker section with preview circle, drop zone, and browse controls in the settings panel
- implement a token maker JavaScript module that supports drag-and-drop image loading, zooming, and right-click panning
- style the new token maker UI to match the VTT design system

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e595e7281883278292f3f1834fae26