### PR TITLE
Enable editing tokens and collapsible folders

### DIFF
--- a/dnd/vtt/assets/css/settings.css
+++ b/dnd/vtt/assets/css/settings.css
@@ -184,6 +184,7 @@
 }
 
 .vtt-token-library {
+  position: relative;
   display: flex;
   flex-direction: column;
   gap: 1rem;
@@ -370,13 +371,43 @@
 }
 
 .token-group__header {
+  margin-bottom: 0.35rem;
+}
+
+.token-group__toggle {
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  margin-bottom: 0.5rem;
+  gap: 0.5rem;
+  width: 100%;
+  padding: 0.35rem 0;
+  border: none;
+  background: transparent;
+  color: var(--vtt-text-primary);
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.token-group__toggle:focus-visible {
+  outline: 2px solid rgba(99, 102, 241, 0.6);
+  outline-offset: 2px;
+}
+
+.token-group__chevron {
+  width: 0.75rem;
+  height: 0.75rem;
+  border-right: 2px solid rgba(148, 163, 184, 0.65);
+  border-bottom: 2px solid rgba(148, 163, 184, 0.65);
+  transform: rotate(45deg);
+  transition: transform var(--vtt-transition), border-color var(--vtt-transition);
+}
+
+.token-group__toggle:hover .token-group__chevron {
+  border-color: rgba(129, 140, 248, 0.85);
 }
 
 .token-group__title {
+  flex: 1 1 auto;
   margin: 0;
   font-size: 0.95rem;
   font-weight: 600;
@@ -384,6 +415,7 @@
 }
 
 .token-group__count {
+  margin-left: auto;
   font-size: 0.8rem;
   color: var(--vtt-text-muted);
 }
@@ -396,6 +428,14 @@
   gap: 0.75rem;
 }
 
+.token-group.is-collapsed .token-group__chevron {
+  transform: rotate(-45deg);
+}
+
+.token-group.is-collapsed .token-group__list {
+  display: none;
+}
+
 .token-item {
   display: flex;
   gap: 0.75rem;
@@ -405,6 +445,16 @@
   border-radius: var(--vtt-radius);
   background: rgba(15, 23, 42, 0.45);
   cursor: grab;
+  transition: border-color var(--vtt-transition), box-shadow var(--vtt-transition);
+}
+
+.token-item.is-context-active {
+  border-color: rgba(99, 102, 241, 0.6);
+  box-shadow: 0 0 0 1px rgba(99, 102, 241, 0.4);
+}
+
+.token-item.is-context-active .token-item__thumb {
+  box-shadow: 0 0 0 2px rgba(99, 102, 241, 0.35);
 }
 
 .token-item__thumb {
@@ -429,9 +479,108 @@
 }
 
 .token-item__meta p {
-  margin: 0.25rem 0 0;
+  margin: 0;
+}
+
+.token-item__subtext {
+  margin-top: 0.35rem;
   color: var(--vtt-text-muted);
   font-size: 0.85rem;
+}
+
+.token-item__details {
+  margin-top: 0.3rem;
+  color: var(--vtt-text-muted);
+  font-size: 0.8rem;
+}
+
+.token-item__subtext + .token-item__details {
+  margin-top: 0.25rem;
+}
+
+.token-context-menu {
+  position: fixed;
+  z-index: 1200;
+  min-width: 220px;
+  max-width: 280px;
+  padding: 1rem;
+  border-radius: var(--vtt-radius);
+  background: rgba(15, 23, 42, 0.98);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  box-shadow: 0 18px 45px rgba(15, 23, 42, 0.65);
+  backdrop-filter: blur(10px);
+}
+
+.token-context-menu__form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.token-context-menu__header {
+  margin: 0;
+}
+
+.token-context-menu__title {
+  margin: 0;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--vtt-text-primary);
+}
+
+.token-context-menu__field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.token-context-menu__field label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--vtt-text-muted);
+}
+
+.token-context-menu__field input {
+  width: 100%;
+  padding: 0.45rem 0.6rem;
+  border-radius: var(--vtt-radius);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(15, 23, 42, 0.65);
+  color: var(--vtt-text-primary);
+  transition: border-color var(--vtt-transition), box-shadow var(--vtt-transition);
+}
+
+.token-context-menu__field input:focus-visible {
+  outline: 2px solid rgba(99, 102, 241, 0.6);
+  outline-offset: 2px;
+  border-color: transparent;
+  box-shadow: 0 0 0 1px rgba(99, 102, 241, 0.4);
+}
+
+.token-context-menu__hint {
+  margin: 0;
+  font-size: 0.75rem;
+  color: var(--vtt-text-muted);
+}
+
+.token-context-menu__actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.token-context-menu__feedback {
+  margin: 0;
+  font-size: 0.8rem;
+  color: var(--vtt-text-muted);
+}
+
+.token-context-menu__feedback[data-variant='error'] {
+  color: #fca5a5;
+}
+
+.token-context-menu__feedback[data-variant='success'] {
+  color: #86efac;
 }
 
 .scene-list {

--- a/dnd/vtt/assets/js/services/token-service.js
+++ b/dnd/vtt/assets/js/services/token-service.js
@@ -39,3 +39,18 @@ export async function createTokenFolder(endpoint, name) {
 
   return data.data;
 }
+
+export async function updateToken(endpoint, payload) {
+  const response = await fetch(endpoint, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ action: 'update-token', ...payload }),
+  });
+
+  const data = await response.json().catch(() => ({}));
+  if (!response.ok || !data.success) {
+    throw new Error(data.error || 'Unable to update token');
+  }
+
+  return data.data;
+}


### PR DESCRIPTION
## Summary
- add backend support for updating token size and HP metadata with validation
- expose updateToken service and rich UI for editing tokens via a custom context menu
- make token folders collapsible and refresh styling for active tokens and the edit menu

## Testing
- php -l dnd/vtt/api/tokens.php

------
https://chatgpt.com/codex/tasks/task_e_68e5a28f99108327bf2cfd8f2bedd7d8