### PR TITLE
Streamline token folder controls and size selection

### DIFF
--- a/dnd/vtt/assets/js/ui/token-library.js
+++ b/dnd/vtt/assets/js/ui/token-library.js
@@ -64,6 +64,12 @@ export function renderTokenLibrary(routes, store) {
       contextMenu.form.reset();
     }
 
+    if (contextMenu.sizeInput) {
+      Array.from(
+        contextMenu.sizeInput.querySelectorAll('option[data-dynamic-size-option="true"]')
+      ).forEach((option) => option.remove());
+    }
+
     setContextMenuPending(contextMenu, false);
     showFeedback(contextMenu.feedback, '', 'info');
   }
@@ -128,7 +134,22 @@ export function renderTokenLibrary(routes, store) {
     contextTokenId = token.id;
 
     if (contextMenu.sizeInput) {
-      contextMenu.sizeInput.value = typeof token.size === 'string' ? token.size : '';
+      const sizeValue = typeof token.size === 'string' ? token.size : '';
+      if (sizeValue) {
+        const hasOption = Array.from(contextMenu.sizeInput.options || []).some(
+          (option) => option.value === sizeValue
+        );
+        if (!hasOption) {
+          const dynamicOption = document.createElement('option');
+          dynamicOption.value = sizeValue;
+          dynamicOption.textContent = sizeValue;
+          dynamicOption.dataset.dynamicSizeOption = 'true';
+          contextMenu.sizeInput.appendChild(dynamicOption);
+        }
+        contextMenu.sizeInput.value = sizeValue;
+      } else {
+        contextMenu.sizeInput.value = '';
+      }
     }
 
     if (contextMenu.hpInput) {
@@ -628,6 +649,11 @@ function createTokenContextMenu(root) {
   element.hidden = true;
   element.dataset.open = 'false';
   element.tabIndex = -1;
+  const sizeOptions = Array.from({ length: 10 }, (_, index) => {
+    const size = `${index + 1}x${index + 1}`;
+    return `<option value="${size}">${size}</option>`;
+  }).join('');
+
   element.innerHTML = `
     <form class="token-context-menu__form" data-token-context-form>
       <header class="token-context-menu__header">
@@ -635,13 +661,13 @@ function createTokenContextMenu(root) {
       </header>
       <div class="token-context-menu__field">
         <label for="token-context-size">Size</label>
-        <input
+        <select
           id="token-context-size"
-          type="text"
-          placeholder="e.g. 1x1"
-          autocomplete="off"
           data-token-context-size
-        />
+        >
+          <option value="">No size override</option>
+          ${sizeOptions}
+        </select>
       </div>
       <div class="token-context-menu__field">
         <label for="token-context-hp">HP</label>

--- a/dnd/vtt/components/SettingsPanel.php
+++ b/dnd/vtt/components/SettingsPanel.php
@@ -100,7 +100,6 @@ function renderVttSettingsPanel(string $tokenLibraryMarkup = ''): string
             <section class="settings-view settings-view--tokens" data-settings-view="tokens" hidden>
                 <header class="settings-view__header">
                     <h3>Token Maker</h3>
-                    <button class="btn" type="button" data-action="create-token-folder">New Folder</button>
                 </header>
                 <div class="settings-view__content" id="token-library">
                     <?= $tokenLibraryMarkup ?>

--- a/dnd/vtt/components/TokenLibrary.php
+++ b/dnd/vtt/components/TokenLibrary.php
@@ -11,7 +11,6 @@ function renderVttTokenLibrary(): string
             <div class="vtt-token-library__actions">
                 <label class="visually-hidden" for="token-search">Search tokens</label>
                 <input id="token-search" type="search" placeholder="Search tokens" />
-                <button class="btn" type="button" data-action="create-token-folder">New Folder</button>
             </div>
         </header>
         <div class="vtt-token-library__content">


### PR DESCRIPTION
## Summary
- remove duplicate New Folder buttons so the token maker uses a single entry point
- switch the token size editor to a dropdown of supported dimensions and handle legacy values gracefully

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e5aa30e43483279c985a73829a006b