### PR TITLE
Add drag-and-drop token placement on VTT board

### DIFF
--- a/dnd/vtt/assets/css/board.css
+++ b/dnd/vtt/assets/css/board.css
@@ -149,6 +149,49 @@
   opacity: 1;
 }
 
+.vtt-board__tokens {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 3;
+}
+
+.vtt-board__tokens[hidden] {
+  display: none;
+}
+
+.vtt-token {
+  position: absolute;
+  border-radius: 50%;
+  overflow: hidden;
+  border: 2px solid rgba(15, 23, 42, 0.9);
+  box-shadow: 0 10px 24px rgba(15, 23, 42, 0.55);
+  background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.3), rgba(15, 23, 42, 0.85));
+  pointer-events: none;
+  transform: translate3d(0, 0, 0);
+}
+
+.vtt-token__image {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.vtt-token--placeholder {
+  background: rgba(71, 85, 105, 0.55);
+}
+
+.vtt-board__map-surface.is-token-drop-active::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border: 2px dashed rgba(165, 180, 252, 0.75);
+  border-radius: calc(var(--vtt-radius) * 1.25);
+  pointer-events: none;
+  mix-blend-mode: screen;
+}
+
 .vtt-board__ruler {
   position: absolute;
   bottom: 1rem;

--- a/dnd/vtt/components/SceneBoard.php
+++ b/dnd/vtt/components/SceneBoard.php
@@ -23,6 +23,12 @@ function renderVttSceneBoard(): string
                             <img id="vtt-map-image" class="vtt-board__map-image" alt="Scene map" hidden />
                         </div>
                         <div id="vtt-grid-overlay" class="vtt-board__grid" aria-hidden="true"></div>
+                        <div
+                            id="vtt-token-layer"
+                            class="vtt-board__tokens"
+                            aria-live="off"
+                            hidden
+                        ></div>
                     </div>
                 </div>
                 <p class="vtt-board__empty">Drag a scene map here or create a scene from the settings panel.</p>


### PR DESCRIPTION
## Summary
- add a dedicated token layer to the board markup and styling
- expose token templates as draggable payloads from the library UI
- handle token drag/drop on the board, snapping placements to the current grid and rendering instances from state
- normalize persisted board placements in the client store for robustness

## Testing
- php -S 0.0.0.0:8000 -t dnd/vtt

------
https://chatgpt.com/codex/tasks/task_e_68e5acaad51c832794e18ad0ac2fbcb4