### PR TITLE
Default tokens to 1x1 and add selection glow

### DIFF
--- a/dnd/vtt/assets/css/board.css
+++ b/dnd/vtt/assets/css/board.css
@@ -171,6 +171,14 @@
   transform: translate3d(0, 0, 0);
 }
 
+.vtt-token.is-selected {
+  border-color: rgba(129, 140, 248, 0.95);
+  box-shadow:
+    0 0 0 2px rgba(99, 102, 241, 0.85),
+    0 0 0 8px rgba(165, 180, 252, 0.55),
+    0 14px 30px rgba(15, 23, 42, 0.55);
+}
+
 .vtt-token__image {
   width: 100%;
   height: 100%;

--- a/dnd/vtt/assets/js/ui/token-library.js
+++ b/dnd/vtt/assets/js/ui/token-library.js
@@ -134,7 +134,8 @@ export function renderTokenLibrary(routes, store) {
     contextTokenId = token.id;
 
     if (contextMenu.sizeInput) {
-      const sizeValue = typeof token.size === 'string' ? token.size : '';
+      const rawSize = typeof token.size === 'string' ? token.size : '';
+      const sizeValue = rawSize.trim();
       if (sizeValue) {
         const hasOption = Array.from(contextMenu.sizeInput.options || []).some(
           (option) => option.value === sizeValue
@@ -148,7 +149,7 @@ export function renderTokenLibrary(routes, store) {
         }
         contextMenu.sizeInput.value = sizeValue;
       } else {
-        contextMenu.sizeInput.value = '';
+        contextMenu.sizeInput.value = '1x1';
       }
     }
 
@@ -498,10 +499,10 @@ function buildTokenDragData(element, tokenIndex) {
     return null;
   }
 
-  const sizeValue =
-    typeof record?.size === 'string' && record.size
-      ? record.size
-      : element.getAttribute('data-token-size') || '';
+  const recordSize = typeof record?.size === 'string' ? record.size.trim() : '';
+  const elementSize = element.getAttribute('data-token-size');
+  const fallbackSize = typeof elementSize === 'string' ? elementSize.trim() : '';
+  const sizeValue = recordSize || fallbackSize || '1x1';
 
   return {
     id: tokenId,
@@ -724,7 +725,8 @@ function createTokenContextMenu(root) {
   element.tabIndex = -1;
   const sizeOptions = Array.from({ length: 10 }, (_, index) => {
     const size = `${index + 1}x${index + 1}`;
-    return `<option value="${size}">${size}</option>`;
+    const selected = index === 0 ? ' selected' : '';
+    return `<option value="${size}"${selected}>${size}</option>`;
   }).join('');
 
   element.innerHTML = `
@@ -738,8 +740,8 @@ function createTokenContextMenu(root) {
           id="token-context-size"
           data-token-context-size
         >
-          <option value="">No size override</option>
           ${sizeOptions}
+          <option value="">No size override</option>
         </select>
       </div>
       <div class="token-context-menu__field">


### PR DESCRIPTION
## Summary
- default new token placements to 1x1 size unless an override is chosen and move the override option after 10x10 in the context menu
- allow left-click selection of placed tokens and highlight the active token with a glowing ring

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e5b1af9a948327907af1b74242a8c0