### PR TITLE
Add interactive measurement ruler for VTT board

### DIFF
--- a/dnd/vtt/assets/css/base.css
+++ b/dnd/vtt/assets/css/base.css
@@ -57,6 +57,12 @@ body.vtt-body {
   background: rgba(99, 102, 241, 0.25);
 }
 
+.btn.is-active {
+  background: rgba(99, 102, 241, 0.35);
+  border-color: rgba(99, 102, 241, 0.65);
+  color: #fff;
+}
+
 .btn:active {
   transform: scale(0.98);
 }

--- a/dnd/vtt/assets/css/board.css
+++ b/dnd/vtt/assets/css/board.css
@@ -219,3 +219,36 @@
   border: 1px solid var(--vtt-panel-border);
   color: #fff;
 }
+
+.vtt-measure-overlay {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  overflow: visible;
+  z-index: 4;
+}
+
+.vtt-measure-overlay__path {
+  stroke: rgba(96, 165, 250, 0.85);
+  stroke-width: 3;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  fill: none;
+}
+
+.vtt-measure-overlay__node {
+  fill: rgba(59, 130, 246, 0.95);
+  stroke: rgba(15, 23, 42, 0.9);
+  stroke-width: 3;
+}
+
+.vtt-measure-overlay__label {
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  font-weight: 600;
+  font-size: 14px;
+  fill: #fff;
+  stroke: rgba(15, 23, 42, 0.85);
+  stroke-width: 4;
+  paint-order: stroke fill;
+  letter-spacing: 0.02em;
+}

--- a/dnd/vtt/assets/js/ui/drag-ruler.js
+++ b/dnd/vtt/assets/js/ui/drag-ruler.js
@@ -1,20 +1,467 @@
+const SVG_NS = 'http://www.w3.org/2000/svg';
+
 export function mountDragRuler() {
   const ruler = document.getElementById('vtt-distance-ruler');
-  if (!ruler) return;
+  const rulerValue = ruler?.querySelector('.vtt-board__ruler-value');
+  const measureButton = document.querySelector('[data-action="measure-distance"]');
+  const mapSurface = document.getElementById('vtt-map-surface');
+  const mapTransform = document.getElementById('vtt-map-transform');
+  const grid = document.getElementById('vtt-grid-overlay');
+
+  if (!ruler || !rulerValue || !measureButton || !mapSurface || !mapTransform || !grid) {
+    return;
+  }
+
+  const overlay = createOverlay(mapTransform);
+  const state = {
+    active: false,
+    measuring: false,
+    pointerId: null,
+    points: [],
+    hoverPoint: null,
+    overlay,
+    ruler,
+    rulerValue,
+    measureButton,
+    mapSurface,
+    mapTransform,
+    grid,
+    overlaySize: { width: 0, height: 0 },
+  };
+
+  state.measureButton.setAttribute('aria-pressed', 'false');
+
+  const resizeObserver =
+    typeof ResizeObserver === 'function'
+      ? new ResizeObserver(() => syncOverlaySize(state))
+      : null;
+  resizeObserver?.observe(mapTransform);
+
+  if (typeof MutationObserver === 'function') {
+    const visibilityObserver = new MutationObserver(() => {
+      if (mapTransform.hasAttribute('hidden')) {
+        clearMeasurement(state);
+      }
+    });
+    visibilityObserver.observe(mapTransform, { attributes: true, attributeFilter: ['hidden'] });
+  }
+
+  measureButton.addEventListener('click', () => {
+    toggleMeasureMode(state, !state.active);
+  });
+
+  mapSurface.addEventListener(
+    'pointerdown',
+    (event) => {
+      if (!state.active || event.button !== 0) {
+        return;
+      }
+
+      const snapPoint = getSnappedPoint(state, event);
+      if (!snapPoint) {
+        return;
+      }
+
+      event.preventDefault();
+      event.stopPropagation();
+
+      beginMeasurement(state, event.pointerId, snapPoint);
+      try {
+        mapSurface.setPointerCapture(event.pointerId);
+      } catch (error) {
+        // Ignore pointer capture errors – measurement will still function without it.
+      }
+    },
+    true
+  );
+
+  mapSurface.addEventListener('pointermove', (event) => {
+    if (!state.measuring || event.pointerId !== state.pointerId) {
+      return;
+    }
+
+    const snapPoint = getSnappedPoint(state, event);
+    if (!snapPoint) {
+      return;
+    }
+
+    event.preventDefault();
+    event.stopPropagation();
+    updateHoverPoint(state, snapPoint);
+  });
+
+  mapSurface.addEventListener('pointerup', (event) => {
+    if (!state.measuring || event.pointerId !== state.pointerId) {
+      return;
+    }
+
+    event.preventDefault();
+    event.stopPropagation();
+    const snapPoint = getSnappedPoint(state, event);
+    if (snapPoint) {
+      commitHoverPoint(state, snapPoint);
+    }
+    endMeasurement(state);
+    mapSurface.releasePointerCapture?.(event.pointerId);
+  });
+
+  mapSurface.addEventListener('pointercancel', (event) => {
+    if (state.measuring && event.pointerId === state.pointerId) {
+      event.stopPropagation();
+      endMeasurement(state);
+      mapSurface.releasePointerCapture?.(event.pointerId);
+    }
+  });
 
   document.addEventListener('keydown', (event) => {
-    if (event.key === 'r') {
-      toggleRuler(ruler, true);
+    if (event.key === 'Escape' && state.active) {
+      clearMeasurement(state);
+      return;
+    }
+
+    if (event.key === 'Shift' && !event.repeat) {
+      handleShiftKey(state);
     }
   });
 
-  document.addEventListener('keyup', (event) => {
-    if (event.key === 'r') {
-      toggleRuler(ruler, false);
+  document.addEventListener('visibilitychange', () => {
+    if (document.hidden) {
+      clearMeasurement(state);
     }
   });
+
+  syncOverlaySize(state);
 }
 
-function toggleRuler(ruler, visible) {
-  ruler.toggleAttribute('hidden', !visible);
+function toggleMeasureMode(state, nextActive) {
+  if (state.active === nextActive) {
+    return;
+  }
+
+  state.active = nextActive;
+  state.measureButton?.classList.toggle('is-active', state.active);
+  if (state.measureButton) {
+    state.measureButton.setAttribute('aria-pressed', state.active ? 'true' : 'false');
+  }
+
+  if (!state.active) {
+    clearMeasurement(state);
+  }
+}
+
+function beginMeasurement(state, pointerId, startPoint) {
+  state.measuring = true;
+  state.pointerId = pointerId;
+  state.points = [startPoint];
+  state.hoverPoint = startPoint;
+  updateOverlay(state);
+}
+
+function updateHoverPoint(state, hoverPoint) {
+  state.hoverPoint = hoverPoint;
+  updateOverlay(state);
+}
+
+function commitHoverPoint(state, snapPoint) {
+  if (!state.points.length) {
+    state.points = [snapPoint];
+  } else {
+    const lastPoint = state.points[state.points.length - 1];
+    if (lastPoint.column !== snapPoint.column || lastPoint.row !== snapPoint.row) {
+      state.points.push(snapPoint);
+    }
+  }
+  state.hoverPoint = snapPoint;
+  updateOverlay(state);
+}
+
+function endMeasurement(state) {
+  state.measuring = false;
+  state.pointerId = null;
+  state.hoverPoint = null;
+  updateOverlay(state);
+}
+
+function clearMeasurement(state) {
+  if (state.pointerId !== null) {
+    state.mapSurface.releasePointerCapture?.(state.pointerId);
+  }
+  state.measuring = false;
+  state.pointerId = null;
+  state.points = [];
+  state.hoverPoint = null;
+  updateOverlay(state);
+}
+
+function handleShiftKey(state) {
+  if (!state.measuring) {
+    return;
+  }
+
+  const snapshot = state.hoverPoint ?? state.points[state.points.length - 1];
+  if (!snapshot) {
+    return;
+  }
+
+  const duplicate = state.points.find(
+    (point) => point.column === snapshot.column && point.row === snapshot.row
+  );
+  if (!duplicate) {
+    state.points.push({ ...snapshot });
+    updateOverlay(state);
+  }
+}
+
+function getSnappedPoint(state, event) {
+  const mapCoords = getMapCoordinates(state.mapTransform, event);
+  if (!mapCoords) {
+    return null;
+  }
+
+  const gridMetrics = getGridMetrics(state.grid, state.mapTransform);
+  if (!gridMetrics) {
+    return null;
+  }
+
+  syncOverlaySize(state);
+
+  const { size, offsets, columns, rows } = gridMetrics;
+  if (size <= 0 || columns <= 0 || rows <= 0) {
+    return null;
+  }
+
+  const relativeX = mapCoords.x - offsets.left;
+  const relativeY = mapCoords.y - offsets.top;
+
+  const clampedColumn = clamp(Math.floor(relativeX / size), 0, columns - 1);
+  const clampedRow = clamp(Math.floor(relativeY / size), 0, rows - 1);
+
+  const centerX = offsets.left + (clampedColumn + 0.5) * size;
+  const centerY = offsets.top + (clampedRow + 0.5) * size;
+
+  return {
+    mapX: centerX,
+    mapY: centerY,
+    column: clampedColumn,
+    row: clampedRow,
+  };
+}
+
+function getMapCoordinates(mapTransform, event) {
+  const rect = mapTransform.getBoundingClientRect();
+  const baseWidth = mapTransform.offsetWidth;
+  const baseHeight = mapTransform.offsetHeight;
+  if (!baseWidth || !baseHeight) {
+    return null;
+  }
+
+  const scaleX = rect.width / baseWidth;
+  const scaleY = rect.height / baseHeight;
+  if (!Number.isFinite(scaleX) || !Number.isFinite(scaleY) || scaleX === 0 || scaleY === 0) {
+    return null;
+  }
+
+  return {
+    x: (event.clientX - rect.left) / scaleX,
+    y: (event.clientY - rect.top) / scaleY,
+  };
+}
+
+function getGridMetrics(grid, mapTransform) {
+  const style = getComputedStyle(grid);
+  const rawSize = parseFloat(style.getPropertyValue('--vtt-grid-size') || '0');
+  const size = Number.isFinite(rawSize) && rawSize > 0 ? rawSize : 64;
+
+  const offsets = {
+    top: parseFloat(style.getPropertyValue('--vtt-grid-offset-top') || '0'),
+    right: parseFloat(style.getPropertyValue('--vtt-grid-offset-right') || '0'),
+    bottom: parseFloat(style.getPropertyValue('--vtt-grid-offset-bottom') || '0'),
+    left: parseFloat(style.getPropertyValue('--vtt-grid-offset-left') || '0'),
+  };
+
+  const effectiveWidth = Math.max(
+    0,
+    mapTransform.offsetWidth - offsets.left - offsets.right
+  );
+  const effectiveHeight = Math.max(
+    0,
+    mapTransform.offsetHeight - offsets.top - offsets.bottom
+  );
+
+  const columns = size > 0 ? Math.floor(effectiveWidth / size) : 0;
+  const rows = size > 0 ? Math.floor(effectiveHeight / size) : 0;
+
+  return {
+    size,
+    offsets,
+    columns: Math.max(columns, 0),
+    rows: Math.max(rows, 0),
+  };
+}
+
+function updateOverlay(state) {
+  const points = getRenderablePoints(state);
+  const segments = getSegments(points);
+  const totalSquares = segments.reduce((sum, segment) => sum + segment.squares, 0);
+
+  if (!segments.length) {
+    state.overlay.svg.setAttribute('hidden', 'hidden');
+    state.overlay.path.setAttribute('points', '');
+    state.overlay.nodes.innerHTML = '';
+    state.overlay.labels.innerHTML = '';
+    state.ruler.setAttribute('hidden', 'hidden');
+    state.rulerValue.textContent = '0 squares';
+    return;
+  }
+
+  state.overlay.svg.removeAttribute('hidden');
+  state.overlay.path.setAttribute(
+    'points',
+    points.map((point) => `${point.mapX},${point.mapY}`).join(' ')
+  );
+
+  syncNodeMarkers(state.overlay.nodes, points);
+  syncSegmentLabels(state.overlay.labels, segments);
+
+  state.ruler.removeAttribute('hidden');
+  state.rulerValue.textContent =
+    totalSquares === 1 ? '1 square' : `${totalSquares} squares`;
+}
+
+function getRenderablePoints(state) {
+  if (!state.points.length) {
+    return [];
+  }
+
+  if (state.measuring && state.hoverPoint) {
+    const lastPoint = state.points[state.points.length - 1];
+    if (
+      !lastPoint ||
+      lastPoint.column !== state.hoverPoint.column ||
+      lastPoint.row !== state.hoverPoint.row
+    ) {
+      return [...state.points, state.hoverPoint];
+    }
+  }
+
+  return state.points.slice();
+}
+
+function getSegments(points) {
+  if (points.length < 2) {
+    return [];
+  }
+
+  const segments = [];
+  for (let index = 1; index < points.length; index += 1) {
+    const start = points[index - 1];
+    const end = points[index];
+    const squares = Math.max(
+      Math.abs(end.column - start.column),
+      Math.abs(end.row - start.row)
+    );
+    segments.push({ start, end, squares });
+  }
+  return segments;
+}
+
+function syncNodeMarkers(group, points) {
+  const existing = Array.from(group.children);
+  const desired = points.length;
+
+  if (existing.length > desired) {
+    existing.slice(desired).forEach((node) => node.remove());
+  }
+
+  const nodes = Array.from(group.children);
+  for (let index = 0; index < points.length; index += 1) {
+    const point = points[index];
+    let circle = nodes[index];
+    if (!circle) {
+      circle = document.createElementNS(SVG_NS, 'circle');
+      circle.classList.add('vtt-measure-overlay__node');
+      circle.setAttribute('r', '6');
+      circle.setAttribute('vector-effect', 'non-scaling-stroke');
+      group.appendChild(circle);
+      nodes.push(circle);
+    }
+    circle.setAttribute('cx', point.mapX);
+    circle.setAttribute('cy', point.mapY);
+  }
+}
+
+function syncSegmentLabels(group, segments) {
+  const existing = Array.from(group.children);
+  if (existing.length > segments.length) {
+    existing.slice(segments.length).forEach((node) => node.remove());
+  }
+
+  const nodes = Array.from(group.children);
+  for (let index = 0; index < segments.length; index += 1) {
+    const segment = segments[index];
+    let text = nodes[index];
+    if (!text) {
+      text = document.createElementNS(SVG_NS, 'text');
+      text.classList.add('vtt-measure-overlay__label');
+      text.setAttribute('text-anchor', 'middle');
+      text.setAttribute('dominant-baseline', 'middle');
+      group.appendChild(text);
+      nodes.push(text);
+    }
+
+    const midpoint = {
+      x: (segment.start.mapX + segment.end.mapX) / 2,
+      y: (segment.start.mapY + segment.end.mapY) / 2,
+    };
+
+    text.textContent = segment.squares === 1 ? '1 square' : `${segment.squares} squares`;
+    text.setAttribute('x', midpoint.x);
+    text.setAttribute('y', midpoint.y);
+  }
+}
+
+function createOverlay(container) {
+  const svg = document.createElementNS(SVG_NS, 'svg');
+  svg.classList.add('vtt-measure-overlay');
+  svg.setAttribute('aria-hidden', 'true');
+  svg.setAttribute('preserveAspectRatio', 'none');
+  svg.setAttribute('hidden', 'hidden');
+  svg.style.pointerEvents = 'none';
+
+  const path = document.createElementNS(SVG_NS, 'polyline');
+  path.classList.add('vtt-measure-overlay__path');
+  path.setAttribute('fill', 'none');
+  path.setAttribute('vector-effect', 'non-scaling-stroke');
+  svg.appendChild(path);
+
+  const nodes = document.createElementNS(SVG_NS, 'g');
+  nodes.classList.add('vtt-measure-overlay__nodes');
+  svg.appendChild(nodes);
+
+  const labels = document.createElementNS(SVG_NS, 'g');
+  labels.classList.add('vtt-measure-overlay__labels');
+  svg.appendChild(labels);
+
+  container.appendChild(svg);
+
+  return { svg, path, nodes, labels };
+}
+
+function syncOverlaySize(state) {
+  const width = state.mapTransform.offsetWidth || 0;
+  const height = state.mapTransform.offsetHeight || 0;
+  if (state.overlaySize.width === width && state.overlaySize.height === height) {
+    return;
+  }
+
+  const safeWidth = Math.max(width, 1);
+  const safeHeight = Math.max(height, 1);
+  state.overlay.svg.setAttribute('viewBox', `0 0 ${safeWidth} ${safeHeight}`);
+  state.overlay.svg.setAttribute('width', String(safeWidth));
+  state.overlay.svg.setAttribute('height', String(safeHeight));
+  state.overlaySize = { width, height };
+}
+
+function clamp(value, min, max) {
+  return Math.min(Math.max(value, min), max);
 }

--- a/dnd/vtt/components/SceneBoard.php
+++ b/dnd/vtt/components/SceneBoard.php
@@ -12,7 +12,7 @@ function renderVttSceneBoard(): string
                 <p id="active-scene-status" class="vtt-board__status">Select or create a scene to begin.</p>
             </div>
             <div class="vtt-board__controls">
-                <button class="btn" type="button" data-action="measure-distance">Measure</button>
+                <button class="btn" type="button" data-action="measure-distance" aria-pressed="false">Measure</button>
             </div>
         </header>
         <div class="vtt-board__canvas-wrapper">
@@ -34,7 +34,7 @@ function renderVttSceneBoard(): string
                 <p class="vtt-board__empty">Drag a scene map here or create a scene from the settings panel.</p>
             </div>
             <div id="vtt-distance-ruler" class="vtt-board__ruler" hidden>
-                <span class="vtt-board__ruler-value">0 ft</span>
+                <span class="vtt-board__ruler-value">0 squares</span>
             </div>
         </div>
     </section>


### PR DESCRIPTION
## Summary
- implement a toggleable measuring mode with a SVG overlay that tracks distance in grid squares
- support multi-segment paths with shift key waypoints and inline segment labels while keeping the total in the ruler badge
- update styling for the measure button and measurement visuals for clarity

## Testing
- Manual verification with the VTT board in the browser

------
https://chatgpt.com/codex/tasks/task_e_68e5e82157f083278a64e6af91aa2807