### PR TITLE
Show total measurement at cursor and during token drag

### DIFF
--- a/dnd/vtt/assets/css/board.css
+++ b/dnd/vtt/assets/css/board.css
@@ -252,3 +252,9 @@
   paint-order: stroke fill;
   letter-spacing: 0.02em;
 }
+
+.vtt-measure-overlay__total {
+  font-size: 16px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+}


### PR DESCRIPTION
## Summary
- display the total square count at the measuring cursor for ruler interactions
- expose drag ruler helpers so token drags can start, update, and finish measurements
- trigger token drag measurements from the token center and style the overlay total label

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e5ecac9ddc8327a38f0ef51d43a79c