### PR TITLE
Fix drag ruler shift nodes while dragging tokens

### DIFF
--- a/dnd/vtt/assets/js/ui/drag-ruler.js
+++ b/dnd/vtt/assets/js/ui/drag-ruler.js
@@ -208,7 +208,10 @@ function clearMeasurement(state) {
 }
 
 function handleShiftKey(state) {
-  if (!state.measuring || state.mode !== 'pointer') {
+  if (
+    !state.measuring ||
+    (state.mode !== 'pointer' && state.mode !== 'external')
+  ) {
     return;
   }
 


### PR DESCRIPTION
## Summary
- allow the drag ruler shift key handler to run for external (token-driven) measurements so adding nodes works during token drags

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5f235db5883278dd4eb21c43d1a00