### PR TITLE
Add token settings overlays for board tokens

### DIFF
--- a/dnd/vtt/assets/css/board.css
+++ b/dnd/vtt/assets/css/board.css
@@ -152,7 +152,7 @@
 .vtt-board__tokens {
   position: absolute;
   inset: 0;
-  pointer-events: none;
+  pointer-events: auto;
   z-index: 3;
 }
 
@@ -163,11 +163,10 @@
 .vtt-token {
   position: absolute;
   border-radius: 50%;
-  overflow: hidden;
   border: 2px solid rgba(15, 23, 42, 0.9);
   box-shadow: 0 10px 24px rgba(15, 23, 42, 0.55);
   background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.3), rgba(15, 23, 42, 0.85));
-  pointer-events: none;
+  pointer-events: auto;
   transform: translate3d(0, 0, 0);
   transition: transform 180ms ease, width 180ms ease, height 180ms ease;
   will-change: transform;
@@ -193,10 +192,195 @@
   height: 100%;
   object-fit: cover;
   display: block;
+  border-radius: 50%;
 }
 
 .vtt-token--placeholder {
   background: rgba(71, 85, 105, 0.55);
+}
+
+.vtt-token__hp-bar {
+  position: absolute;
+  top: -1.6rem;
+  left: 50%;
+  transform: translateX(-50%);
+  background: rgba(244, 63, 94, 0.92);
+  color: #fff;
+  padding: 0.2rem 0.6rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  box-shadow: 0 6px 14px rgba(15, 23, 42, 0.5);
+  pointer-events: none;
+  white-space: nowrap;
+  transition: opacity var(--vtt-transition), transform var(--vtt-transition);
+}
+
+.vtt-token__hp-bar[data-empty='true'] {
+  opacity: 0.8;
+}
+
+.vtt-token__hp-value {
+  display: inline-block;
+  min-width: 1.75rem;
+  text-align: center;
+}
+
+.vtt-token__trigger-indicator {
+  position: absolute;
+  bottom: 0.35rem;
+  right: 0.35rem;
+  width: 0.85rem;
+  height: 0.85rem;
+  border-radius: 50%;
+  border: 2px solid rgba(15, 23, 42, 0.75);
+  background: var(--vtt-success);
+  box-shadow: 0 4px 10px rgba(15, 23, 42, 0.55);
+  cursor: pointer;
+  pointer-events: auto;
+  transition: transform var(--vtt-transition), background var(--vtt-transition), box-shadow var(--vtt-transition);
+}
+
+.vtt-token__trigger-indicator.is-spent {
+  background: var(--vtt-danger);
+}
+
+.vtt-token__trigger-indicator:hover {
+  transform: scale(1.1);
+  box-shadow: 0 6px 14px rgba(15, 23, 42, 0.65);
+}
+
+.vtt-token__trigger-indicator:active {
+  transform: scale(0.95);
+}
+
+.vtt-token__trigger-indicator:focus-visible {
+  outline: 2px solid rgba(250, 204, 21, 0.85);
+  outline-offset: 2px;
+}
+
+.vtt-token-settings {
+  position: fixed;
+  z-index: 40;
+  min-width: 240px;
+  max-width: 280px;
+  padding: 1rem 1.1rem;
+  background: rgba(15, 23, 42, 0.92);
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  border-radius: calc(var(--vtt-radius) * 1.1);
+  box-shadow: 0 20px 55px rgba(15, 23, 42, 0.6);
+  color: var(--vtt-text-primary);
+  backdrop-filter: blur(12px);
+}
+
+.vtt-token-settings[hidden] {
+  display: none;
+}
+
+.vtt-token-settings__form {
+  display: flex;
+  flex-direction: column;
+  gap: 1.1rem;
+}
+
+.vtt-token-settings__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-bottom: 0.25rem;
+}
+
+.vtt-token-settings__title {
+  margin: 0;
+  font-size: 1.05rem;
+}
+
+.vtt-token-settings__close {
+  appearance: none;
+  border: none;
+  background: transparent;
+  color: var(--vtt-text-muted);
+  font-size: 1.25rem;
+  line-height: 1;
+  border-radius: 999px;
+  padding: 0.15rem 0.35rem;
+  cursor: pointer;
+  transition: color var(--vtt-transition), background var(--vtt-transition);
+}
+
+.vtt-token-settings__close:hover {
+  color: #fff;
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.vtt-token-settings__close:focus-visible {
+  outline: 2px solid var(--vtt-accent);
+  outline-offset: 2px;
+}
+
+.vtt-token-settings__section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
+}
+
+.vtt-token-settings__toggle {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 600;
+}
+
+.vtt-token-settings__toggle input {
+  width: 1rem;
+  height: 1rem;
+  accent-color: var(--vtt-accent);
+}
+
+.vtt-token-settings__field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  transition: opacity var(--vtt-transition);
+}
+
+.vtt-token-settings__field.is-disabled {
+  opacity: 0.55;
+}
+
+.vtt-token-settings__field-label {
+  font-size: 0.85rem;
+  color: var(--vtt-text-muted);
+}
+
+.vtt-token-settings__field input {
+  background: rgba(15, 23, 42, 0.55);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  border-radius: calc(var(--vtt-radius) / 1.5);
+  padding: 0.45rem 0.6rem;
+  color: var(--vtt-text-primary);
+  font-size: 0.9rem;
+  transition: border-color var(--vtt-transition), box-shadow var(--vtt-transition);
+}
+
+.vtt-token-settings__field input:focus {
+  outline: none;
+  border-color: var(--vtt-accent);
+  box-shadow: 0 0 0 2px rgba(99, 102, 241, 0.35);
+}
+
+.vtt-token-settings__field input:disabled {
+  opacity: 0.75;
+  cursor: not-allowed;
+}
+
+.vtt-token-settings__hint {
+  margin: 0;
+  font-size: 0.8rem;
+  color: var(--vtt-text-muted);
+  line-height: 1.35;
 }
 
 .vtt-board__map-surface.is-token-drop-active::after {

--- a/dnd/vtt/assets/js/state/store.js
+++ b/dnd/vtt/assets/js/state/store.js
@@ -114,6 +114,17 @@ function normalizePlacementEntry(entry) {
   const width = Math.max(1, toNonNegativeInt(entry.width ?? entry.columns ?? entry.w ?? 1));
   const height = Math.max(1, toNonNegativeInt(entry.height ?? entry.rows ?? entry.h ?? 1));
   const size = typeof entry.size === 'string' && entry.size ? entry.size : `${width}x${height}`;
+  const hp = normalizeHitPointsValue(
+    entry.hp ?? entry.hitPoints ?? entry?.overlays?.hitPoints?.value ?? entry?.stats?.hp ?? null
+  );
+  const showHp = Boolean(
+    entry.showHp ?? entry.showHitPoints ?? entry?.overlays?.hitPoints?.visible ?? false
+  );
+  const showTriggeredAction = Boolean(
+    entry.showTriggeredAction ?? entry?.overlays?.triggeredAction?.visible ?? false
+  );
+  const triggeredActionReady =
+    entry.triggeredActionReady ?? entry?.overlays?.triggeredAction?.ready ?? true;
 
   return {
     id,
@@ -125,6 +136,10 @@ function normalizePlacementEntry(entry) {
     width,
     height,
     size,
+    hp,
+    showHp,
+    showTriggeredAction,
+    triggeredActionReady: triggeredActionReady !== false,
   };
 }
 
@@ -139,4 +154,25 @@ function toNonNegativeInt(value, fallback = 0) {
   }
 
   return Math.max(0, Math.trunc(fallback));
+}
+
+function normalizeHitPointsValue(value) {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return String(Math.trunc(value));
+  }
+
+  if (typeof value === 'string') {
+    return value.trim();
+  }
+
+  if (value && typeof value === 'object') {
+    if (typeof value.value === 'number' && Number.isFinite(value.value)) {
+      return String(Math.trunc(value.value));
+    }
+    if (typeof value.value === 'string') {
+      return value.value.trim();
+    }
+  }
+
+  return '';
 }

--- a/dnd/vtt/assets/js/ui/token-library.js
+++ b/dnd/vtt/assets/js/ui/token-library.js
@@ -503,12 +503,23 @@ function buildTokenDragData(element, tokenIndex) {
   const elementSize = element.getAttribute('data-token-size');
   const fallbackSize = typeof elementSize === 'string' ? elementSize.trim() : '';
   const sizeValue = recordSize || fallbackSize || '1x1';
+  const recordHp = record?.hp;
+  const elementHp = element.getAttribute('data-token-hp');
+  let hpValue = '';
+  if (typeof recordHp === 'number' && Number.isFinite(recordHp)) {
+    hpValue = String(Math.trunc(recordHp));
+  } else if (typeof recordHp === 'string' && recordHp.trim()) {
+    hpValue = recordHp.trim();
+  } else if (typeof elementHp === 'string' && elementHp.trim()) {
+    hpValue = elementHp.trim();
+  }
 
   return {
     id: tokenId,
     name,
     imageUrl,
     size: sizeValue,
+    hp: hpValue,
     source: 'token-library',
   };
 }


### PR DESCRIPTION
## Summary
- add a right-click token settings menu to toggle hit points and triggered action indicators, persisting the new placement fields
- render hit point bars and triggered action status dots on tokens with interactive indicator toggling
- extend token drag data and styles to support the new overlays

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68e5f573b8188327839f2c1eae4ae6c8