### PR TITLE
vtt-sync: phase 1-1 start Pusher before the poller

### DIFF
--- a/dnd/vtt/assets/js/services/pusher-service.js
+++ b/dnd/vtt/assets/js/services/pusher-service.js
@@ -83,6 +83,35 @@ export function initializePusher({
     pusherInstance.connection.bind('error', handleError);
     pusherInstance.connection.bind('state_change', handleStateChange);
 
+    // "Ready" promise: resolves the first time Pusher reports 'connected',
+    // or after a short timeout so callers waiting on it don't block the UI
+    // indefinitely when Pusher can't connect. Callers can use this to
+    // sequence initialization (e.g. starting the poller only after the
+    // connection state is known).
+    let readyResolver;
+    let readyTimeout;
+    const readyPromise = new Promise((resolve) => {
+      readyResolver = resolve;
+    });
+
+    pusherInstance.connection.bind('connected', () => {
+      if (readyResolver) {
+        readyResolver({ connected: true });
+        readyResolver = null;
+        if (readyTimeout) {
+          clearTimeout(readyTimeout);
+          readyTimeout = null;
+        }
+      }
+    });
+
+    readyTimeout = setTimeout(() => {
+      if (readyResolver) {
+        readyResolver({ connected: false, reason: 'timeout' });
+        readyResolver = null;
+      }
+    }, 2500);
+
     // Subscribe to channel
     pusherChannel = pusherInstance.subscribe(channel);
 
@@ -111,6 +140,7 @@ export function initializePusher({
           lastAppliedVersion = version;
         }
       },
+      ready: readyPromise,
     };
   } catch (error) {
     console.error('[VTT Pusher] Initialization failed:', error);
@@ -308,6 +338,7 @@ function createNullInterface() {
     isConnected: () => false,
     getLastAppliedVersion: () => 0,
     setLastAppliedVersion: () => {},
+    ready: Promise.resolve({ connected: false, reason: 'unavailable' }),
   };
 }
 

--- a/dnd/vtt/assets/js/ui/board-interactions.js
+++ b/dnd/vtt/assets/js/ui/board-interactions.js
@@ -2731,6 +2731,12 @@ export function mountBoardInteractions(store, routes = {}) {
   /**
    * Initialize Pusher for real-time state synchronization.
    * This provides instant updates instead of relying on polling.
+   *
+   * Returns a promise that resolves once Pusher has either connected or
+   * timed out, so the caller can sequence downstream init (notably the
+   * board state poller) against a known connection state instead of
+   * locking in "Pusher-is-down fallback mode" while Pusher is still
+   * handshaking.
    */
   function initializePusherSync() {
     // Get Pusher config from window (set by layout.php or via vttConfig from bootstrap)
@@ -2739,7 +2745,7 @@ export function mountBoardInteractions(store, routes = {}) {
       : null;
     if (!pusherConfig || !pusherConfig.key || !pusherConfig.cluster) {
       console.log('[VTT] Pusher not configured, using polling only');
-      return;
+      return Promise.resolve({ connected: false, reason: 'unconfigured' });
     }
 
     // Initialize the board state version from current state
@@ -2760,6 +2766,8 @@ export function mountBoardInteractions(store, routes = {}) {
     });
 
     console.log('[VTT] Pusher sync initialized');
+
+    return pusherInterface?.ready ?? Promise.resolve({ connected: false });
   }
 
   /**
@@ -3869,9 +3877,16 @@ export function mountBoardInteractions(store, routes = {}) {
   };
 
   applyStateToBoard(boardApi.getState?.() ?? {});
-  startBoardStatePoller();
-  startCombatStateRefreshLoop();
-  initializePusherSync();
+
+  // Start Pusher first, then start the poller only after Pusher has either
+  // connected or timed out. This prevents the poller from locking its
+  // interval at "1 second fallback mode" while Pusher is still handshaking.
+  const pusherReady = initializePusherSync();
+  Promise.resolve(pusherReady).then(() => {
+    startBoardStatePoller();
+    startCombatStateRefreshLoop();
+  });
+
   startListeningForSheetSync();
 
   function focusBoard() {


### PR DESCRIPTION
## Summary

Phase 1-1 of the VTT sync refactor plan in `docs/vtt-sync-refactor/`. Fixes the biggest source of user-visible lag in the VTT: the board state poller used to start before Pusher was initialized, so its first call to `isPusherConnected()` always returned `false` and the poll interval locked at 1 second for the whole session — every player hammered the server once per second forever.

- `pusher-service.js`: `initializePusher()` now exposes a `ready` promise that resolves with `{connected: true}` on Pusher's first `connected` event, or `{connected: false, reason: 'timeout'}` after 2.5s. `createNullInterface()` returns an already-resolved promise so the fallback path doesn't hang.
- `board-interactions.js`: `initializePusherSync()` returns that ready promise. The init block now calls `initializePusherSync()` first, and `startBoardStatePoller()` / `startCombatStateRefreshLoop()` run inside `Promise.resolve(pusherReady).then(...)`, so the poller reads the real `isPusherConnected()` state when it picks its interval. `startListeningForSheetSync()` stays outside the `.then` — it's unrelated to Pusher.

See `docs/vtt-sync-refactor/phase-1-1-init-order.md` for the full fix spec.

## Test plan

- [x] `board-state-poller.test.mjs` — 14/14 pass locally after the change
- [x] `pusher-service.js` and `board-interactions.js` both parse and import cleanly
- [ ] Manual: hard-refresh the VTT and confirm in DevTools that the first `state.php` GET arrives after Pusher connects (not within the first 1s of load)
- [ ] Manual: move a token as GM and confirm it shows up in a second tab within ~1s, arriving as a Pusher push rather than a poll
- [ ] Manual: Network tab WS filter shows one stable WebSocket to `ws-us3.pusher.com` (not repeatedly opening/closing, which would mean the 2.5s timeout is too short)

> Note: the rest of the JS test suite has 7 pre-existing failures that are unrelated to this change (missing `jsdom` dev dep / refactor churn the plan doc warns about). They were not introduced by this commit.