### PR TITLE
vtt-sync: phase 1-2 make the poller react to Pusher state changes

### DIFF
--- a/dnd/vtt/assets/js/ui/__tests__/board-state-poller.test.mjs
+++ b/dnd/vtt/assets/js/ui/__tests__/board-state-poller.test.mjs
@@ -786,3 +786,259 @@ test('mergeBoardStateSnapshot preserves fogOfWar for scenes not in incoming', as
     'scene-2 fogOfWar revealedCells should be preserved'
   );
 });
+
+// ---------------------------------------------------------------------------
+// Phase 1-2: dynamic poller interval reconfiguration
+// ---------------------------------------------------------------------------
+//
+// These tests cover the reconfigure() method that handlePusherConnectionChange
+// uses to switch the poller between fallback mode (Pusher down, 1s interval)
+// and safety-net mode (Pusher up, 30s interval). See
+// docs/vtt-sync-refactor/phase-1-2-dynamic-poller.md.
+
+function createIntervalSpyWindow() {
+  // Minimal window stub that records every setInterval / clearInterval call
+  // so the tests can assert on how often (and with what interval) the poller
+  // reschedules itself.
+  let nextId = 1;
+  const setCalls = [];
+  const clearCalls = [];
+  const windowRef = {
+    setInterval(fn, ms) {
+      const id = nextId++;
+      setCalls.push({ id, ms, fn });
+      return id;
+    },
+    clearInterval(id) {
+      clearCalls.push(id);
+    },
+  };
+  return { windowRef, setCalls, clearCalls };
+}
+
+function createReconfigurePoller({
+  createBoardStatePoller,
+  isPusherConnectedFn,
+  windowRef,
+  fetchFn,
+} = {}) {
+  const boardStateContainer = {
+    boardState: { placements: {} },
+    user: { name: 'GM User', isGM: true },
+  };
+
+  const boardApi = {
+    getState: () => boardStateContainer,
+    updateState: (mutator) => mutator(boardStateContainer),
+  };
+
+  return createBoardStatePoller({
+    stateEndpoint: '/state',
+    boardApi,
+    fetchFn,
+    windowRef,
+    documentRef: { visibilityState: 'visible' },
+    hashBoardStateSnapshotFn: (snapshot) => JSON.stringify(snapshot),
+    safeJsonStringifyFn: (value) => JSON.stringify(value),
+    mergeBoardStateSnapshotFn: (existing, incoming) => incoming ?? existing,
+    getCurrentUserIdFn: () => 'gm user',
+    normalizeProfileIdFn: (value) =>
+      typeof value === 'string' ? value.trim().toLowerCase() : null,
+    getPendingSaveInfo: () => ({ pending: false }),
+    getLastPersistedHashFn: () => null,
+    getLastPersistedSignatureFn: () => null,
+    isPusherConnectedFn,
+  });
+}
+
+test('board state poller starts in fallback mode (1s) when Pusher is down', async () => {
+  const { createBoardStatePoller } = await modulePromise;
+  const { windowRef, setCalls } = createIntervalSpyWindow();
+
+  const fetchCalls = [];
+  const fetchFn = async () => {
+    fetchCalls.push(Date.now());
+    return { ok: true, json: async () => ({ data: { boardState: {} } }) };
+  };
+
+  const poller = createReconfigurePoller({
+    createBoardStatePoller,
+    isPusherConnectedFn: () => false,
+    windowRef,
+    fetchFn,
+  });
+
+  const handle = poller.start();
+  // Yield to let the immediate poll resolve so test output is deterministic.
+  await Promise.resolve();
+
+  assert.equal(setCalls.length, 1, 'setInterval called once on start()');
+  assert.equal(setCalls[0].ms, 1000, 'fallback mode uses 1s interval');
+  assert.equal(typeof handle.reconfigure, 'function', 'handle exposes reconfigure()');
+});
+
+test('board state poller starts in safety-net mode (30s) when Pusher is up', async () => {
+  const { createBoardStatePoller } = await modulePromise;
+  const { windowRef, setCalls } = createIntervalSpyWindow();
+
+  const poller = createReconfigurePoller({
+    createBoardStatePoller,
+    isPusherConnectedFn: () => true,
+    windowRef,
+    fetchFn: async () => ({ ok: true, json: async () => ({ data: { boardState: {} } }) }),
+  });
+
+  poller.start();
+  await Promise.resolve();
+
+  assert.equal(setCalls.length, 1, 'setInterval called once on start()');
+  assert.equal(setCalls[0].ms, 30000, 'safety-net mode uses 30s interval');
+});
+
+test('reconfigure({ pusherConnected: true }) switches poller to 30s safety-net mode', async () => {
+  const { createBoardStatePoller } = await modulePromise;
+  const { windowRef, setCalls, clearCalls } = createIntervalSpyWindow();
+
+  const poller = createReconfigurePoller({
+    createBoardStatePoller,
+    isPusherConnectedFn: () => false,
+    windowRef,
+    fetchFn: async () => ({ ok: true, json: async () => ({ data: { boardState: {} } }) }),
+  });
+
+  const handle = poller.start();
+  await Promise.resolve();
+
+  // Starting in fallback mode: one setInterval call at 1000ms.
+  assert.equal(setCalls.length, 1);
+  assert.equal(setCalls[0].ms, 1000);
+  assert.equal(clearCalls.length, 0);
+
+  handle.reconfigure({ pusherConnected: true });
+  await Promise.resolve();
+
+  // Reconfigure must clear the old interval and create a new 30s one.
+  assert.equal(clearCalls.length, 1, 'clearInterval called when mode changes');
+  assert.equal(clearCalls[0], setCalls[0].id, 'old interval id was cleared');
+  assert.equal(setCalls.length, 2, 'setInterval called again for new interval');
+  assert.equal(setCalls[1].ms, 30000, 'new interval is 30s');
+});
+
+test('reconfigure({ pusherConnected: false }) returns to 1s fallback and fires immediate poll', async () => {
+  const { createBoardStatePoller } = await modulePromise;
+  const { windowRef, setCalls, clearCalls } = createIntervalSpyWindow();
+
+  let fetchCount = 0;
+  const fetchFn = async () => {
+    fetchCount += 1;
+    return { ok: true, json: async () => ({ data: { boardState: { tick: fetchCount } } }) };
+  };
+
+  const poller = createReconfigurePoller({
+    createBoardStatePoller,
+    isPusherConnectedFn: () => true, // start in safety-net mode
+    windowRef,
+    fetchFn,
+  });
+
+  const handle = poller.start();
+  // Drain microtasks until the initial poll from start() has fully settled
+  // (both the fetch await and the response.json() await) so that
+  // reconfigure() does not race the in-flight poll via isPolling guard.
+  await new Promise((resolve) => setImmediate(resolve));
+  await new Promise((resolve) => setImmediate(resolve));
+  const fetchCountAfterStart = fetchCount;
+  assert.equal(setCalls.length, 1);
+  assert.equal(setCalls[0].ms, 30000);
+
+  handle.reconfigure({ pusherConnected: false });
+  // Let the immediate-fallback poll resolve.
+  await new Promise((resolve) => setImmediate(resolve));
+  await new Promise((resolve) => setImmediate(resolve));
+
+  assert.equal(clearCalls.length, 1, 'old safety-net interval cleared');
+  assert.equal(setCalls.length, 2, 'new interval scheduled');
+  assert.equal(setCalls[1].ms, 1000, 'fallback interval is 1s');
+  assert.ok(
+    fetchCount > fetchCountAfterStart,
+    'entering fallback mode should fire one immediate poll',
+  );
+});
+
+test('reconfigure({ pusherConnected: true }) does NOT fire an immediate poll', async () => {
+  const { createBoardStatePoller } = await modulePromise;
+  const { windowRef } = createIntervalSpyWindow();
+
+  let fetchCount = 0;
+  const fetchFn = async () => {
+    fetchCount += 1;
+    return { ok: true, json: async () => ({ data: { boardState: {} } }) };
+  };
+
+  const poller = createReconfigurePoller({
+    createBoardStatePoller,
+    isPusherConnectedFn: () => false, // start in fallback mode
+    windowRef,
+    fetchFn,
+  });
+
+  const handle = poller.start();
+  await Promise.resolve();
+  await Promise.resolve();
+  const fetchCountAfterStart = fetchCount;
+
+  handle.reconfigure({ pusherConnected: true });
+  // Yield plenty of microtasks so any stray poll would have time to fire.
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+
+  assert.equal(
+    fetchCount,
+    fetchCountAfterStart,
+    'entering safety-net mode should not fire an extra poll (Pusher will deliver state)',
+  );
+});
+
+test('reconfigure is a no-op when the mode has not changed', async () => {
+  const { createBoardStatePoller } = await modulePromise;
+  const { windowRef, setCalls, clearCalls } = createIntervalSpyWindow();
+
+  const poller = createReconfigurePoller({
+    createBoardStatePoller,
+    isPusherConnectedFn: () => false,
+    windowRef,
+    fetchFn: async () => ({ ok: true, json: async () => ({ data: { boardState: {} } }) }),
+  });
+
+  const handle = poller.start();
+  await Promise.resolve();
+
+  handle.reconfigure({ pusherConnected: false });
+  handle.reconfigure({ pusherConnected: false });
+
+  assert.equal(clearCalls.length, 0, 'clearInterval should not be called on a no-op reconfigure');
+  assert.equal(setCalls.length, 1, 'setInterval should not be called again on a no-op reconfigure');
+});
+
+test('start() returns a no-op reconfigure when no setInterval is available', async () => {
+  const { createBoardStatePoller } = await modulePromise;
+
+  const poller = createBoardStatePoller({
+    stateEndpoint: '/state',
+    boardApi: { getState: () => ({}), updateState: () => {} },
+    fetchFn: async () => ({ ok: true, json: async () => ({ data: { boardState: {} } }) }),
+    // windowRef without setInterval → the poller should degrade gracefully
+    windowRef: {},
+    documentRef: { visibilityState: 'visible' },
+    isPusherConnectedFn: () => false,
+  });
+
+  const handle = poller.start();
+  assert.equal(typeof handle.stop, 'function');
+  assert.equal(typeof handle.reconfigure, 'function');
+  // Calling reconfigure on the no-op handle must not throw.
+  handle.reconfigure({ pusherConnected: true });
+  handle.reconfigure({ pusherConnected: false });
+  handle.stop();
+});

--- a/dnd/vtt/assets/js/ui/board-interactions.js
+++ b/dnd/vtt/assets/js/ui/board-interactions.js
@@ -1670,10 +1670,6 @@ export function mountBoardInteractions(store, routes = {}) {
   // handlePusherConnectionChange() can call reconfigure() when Pusher
   // connects or drops mid-session.
   let boardStatePollerHandle = null;
-  // Reduced polling interval when Pusher is connected (fallback only)
-  const PUSHER_FALLBACK_POLL_INTERVAL_MS = 10000;
-  // Normal polling interval when Pusher is not available
-  const NORMAL_POLL_INTERVAL_MS = 1000;
   let suppressCombatStateSync = false;
   let pendingCombatStateSync = false;
   let combatStateVersion = 0;

--- a/dnd/vtt/assets/js/ui/board-interactions.js
+++ b/dnd/vtt/assets/js/ui/board-interactions.js
@@ -46,6 +46,13 @@ const DEFAULT_SCENE_ID = '_default';
 // that would trigger subscribers are blocked to prevent infinite recursion.
 let isApplyingState = false;
 
+// Board state poller intervals. See phase-1-2-dynamic-poller.md.
+// Fallback mode: Pusher is down, poll aggressively as an active fallback.
+// Safety-net mode: Pusher is up, poll rarely just in case a Pusher event
+// was dropped during a reconnect.
+const POLL_FALLBACK_INTERVAL_MS = 1000;
+const POLL_SAFETY_NET_INTERVAL_MS = 30000;
+
 function getStaminaSyncChannel() {
   if (typeof BroadcastChannel !== 'function') {
     return null;
@@ -103,6 +110,7 @@ export function createBoardStatePoller({
   getCurrentVersionFn = () => 0,
   onVersionUpdated = null,
   onStateUpdated = null,
+  isPusherConnectedFn = isPusherConnected,
 } = {}) {
   const endpoint = stateEndpoint ?? routes?.state ?? null;
 
@@ -318,21 +326,55 @@ export function createBoardStatePoller({
 
   function start() {
     if (!endpoint || typeof windowRef?.setInterval !== 'function' || typeof fetchFn !== 'function') {
-      return { stop() {} };
+      return { stop() {}, reconfigure() {} };
     }
 
-    // Polling interval for board state
-    // When Pusher is connected, we use a longer interval as a fallback
-    // When Pusher is not connected, we poll more frequently
-    const BOARD_STATE_POLL_INTERVAL_MS = isPusherConnected()
-      ? 10000  // 10 seconds when Pusher is connected (fallback only)
-      : 1000;  // 1 second when no real-time connection
+    // The poller has two modes:
+    //   - Fallback mode (Pusher down): poll every POLL_FALLBACK_INTERVAL_MS
+    //   - Safety-net mode (Pusher up): poll every POLL_SAFETY_NET_INTERVAL_MS
+    // Pick the initial mode from the current Pusher state. Later connection
+    // changes go through reconfigure() below.
+    let currentIntervalMs =
+      typeof isPusherConnectedFn === 'function' && isPusherConnectedFn()
+        ? POLL_SAFETY_NET_INTERVAL_MS
+        : POLL_FALLBACK_INTERVAL_MS;
+    let intervalId = null;
+
+    function schedule(intervalMs) {
+      if (intervalId !== null && typeof windowRef?.clearInterval === 'function') {
+        windowRef.clearInterval(intervalId);
+      }
+      currentIntervalMs = intervalMs;
+      intervalId = windowRef.setInterval(poll, currentIntervalMs);
+    }
+
+    // Initial poll, then start the interval.
     poll();
-    const intervalId = windowRef.setInterval(poll, BOARD_STATE_POLL_INTERVAL_MS);
+    schedule(currentIntervalMs);
+
     return {
       stop() {
-        if (typeof windowRef?.clearInterval === 'function') {
+        if (intervalId !== null && typeof windowRef?.clearInterval === 'function') {
           windowRef.clearInterval(intervalId);
+        }
+        intervalId = null;
+      },
+      reconfigure({ pusherConnected } = {}) {
+        const nextIntervalMs = pusherConnected
+          ? POLL_SAFETY_NET_INTERVAL_MS
+          : POLL_FALLBACK_INTERVAL_MS;
+        if (nextIntervalMs === currentIntervalMs) {
+          return; // no-op when the mode has not actually changed
+        }
+        const enteringFallback = !pusherConnected;
+        schedule(nextIntervalMs);
+        if (enteringFallback) {
+          // Pusher just dropped. Fire one poll immediately so the user does
+          // not have to wait up to a full interval for the first fetch.
+          // When going the other way (fallback -> safety-net) we deliberately
+          // do NOT fire an immediate poll, because Pusher itself is about to
+          // deliver fresh state.
+          poll();
         }
       },
     };
@@ -1624,6 +1666,10 @@ export function mountBoardInteractions(store, routes = {}) {
   let pusherInterface = null;
   let pusherConnected = false;
   let currentBoardStateVersion = 0;
+  // Handle returned by the board state poller's start(). Captured so
+  // handlePusherConnectionChange() can call reconfigure() when Pusher
+  // connects or drops mid-session.
+  let boardStatePollerHandle = null;
   // Reduced polling interval when Pusher is connected (fallback only)
   const PUSHER_FALLBACK_POLL_INTERVAL_MS = 10000;
   // Normal polling interval when Pusher is not available
@@ -2698,7 +2744,7 @@ export function mountBoardInteractions(store, routes = {}) {
       onStateUpdated: applyCombatStateFromBoardState,
     });
 
-    poller.start();
+    boardStatePollerHandle = poller.start();
   }
 
   function startCombatStateRefreshLoop() {
@@ -2996,10 +3042,12 @@ export function mountBoardInteractions(store, routes = {}) {
     pusherConnected = state.connected;
     console.log('[VTT Pusher] Connection state:', state.connected ? 'connected' : 'disconnected');
 
-    // If we just reconnected, trigger a resync by fetching fresh state
-    if (state.connected) {
-      // The poller will naturally fetch fresh state on its next tick
-      // We could also trigger an immediate fetch here if needed
+    // Tell the board state poller to swap modes:
+    //   connected    -> safety-net mode (poll every 30s)
+    //   disconnected -> fallback mode (poll every 1s, immediate poll)
+    // reconfigure() is a no-op when the mode has not actually changed.
+    if (boardStatePollerHandle && typeof boardStatePollerHandle.reconfigure === 'function') {
+      boardStatePollerHandle.reconfigure({ pusherConnected: state.connected });
     }
   }
 

--- a/docs/vtt-sync-refactor/README.md
+++ b/docs/vtt-sync-refactor/README.md
@@ -40,11 +40,11 @@ Each fix document is structured identically:
 
 You can only do a fix if its prerequisites are already merged to the branch. The safe order is:
 
-| Fix | Depends on |
-|---|---|
-| `phase-0-security.md` | nothing |
-| `phase-1-1-init-order.md` | nothing |
-| `phase-1-2-dynamic-poller.md` | 1-1 |
+| Fix | Depends on | Status |
+|---|---|---|
+| `phase-0-security.md` | nothing | |
+| `phase-1-1-init-order.md` | nothing | ✅ done (PR #662) |
+| `phase-1-2-dynamic-poller.md` | 1-1 | |
 | `phase-1-3-combat-loop.md` | 1-1, 1-2 |
 | `phase-1-4-socket-id.md` | 1-1 |
 | `phase-1-5-nonblocking-broadcast.md` | nothing (server-side only) |

--- a/docs/vtt-sync-refactor/phase-1-1-init-order.md
+++ b/docs/vtt-sync-refactor/phase-1-1-init-order.md
@@ -1,5 +1,7 @@
 # Phase 1-1 — Fix Pusher / Poller Initialization Order
 
+> **Status:** ✅ Done. Committed as `a1e2549` on `claude/app-communication-architecture-y5g1l`, PR [#662](https://github.com/Tastanis/gmscreen/pull/662).
+
 > **Prerequisite reading:** `README.md`, `diagnosis-findings.md` (findings C1 and C2), `pre-flight-investigation.md`.
 
 ## Context


### PR DESCRIPTION
## Summary

Implements phase 1-2 of the VTT sync refactor (`docs/vtt-sync-refactor/phase-1-2-dynamic-poller.md`). The board state poller used to lock its interval at whatever Pusher reported on startup and never re-evaluate. If Pusher dropped mid-session the poller stayed stuck in whatever mode it started in, wasting requests or missing updates.

- Add module-level constants `POLL_FALLBACK_INTERVAL_MS` (1s, Pusher down) and `POLL_SAFETY_NET_INTERVAL_MS` (30s, Pusher up).
- Rewrite `createBoardStatePoller().start()` so it returns a handle with `stop()` **and** `reconfigure({ pusherConnected })`. `reconfigure` clears the old `setInterval`, schedules a new one with the appropriate interval, and is a no-op when the mode has not actually changed.
- On the "Pusher just dropped" transition, fire one immediate poll so the user does not wait up to a second for the first fetch. On the "Pusher just connected" transition, deliberately do **not** fire an immediate poll — Pusher itself is about to deliver fresh state.
- Capture the handle returned by `start()` in a module-level `boardStatePollerHandle` so `handlePusherConnectionChange` can call `reconfigure` on every connection event.
- Thread an injectable `isPusherConnectedFn` into the factory (defaults to the imported `isPusherConnected`) so tests can control the initial mode.

## Tests

Added seven new cases to `board-state-poller.test.mjs` covering:

- Start-up picks 1s when Pusher is down and 30s when Pusher is up.
- `reconfigure({ pusherConnected: true })` clears the old interval and schedules a 30s one.
- `reconfigure({ pusherConnected: false })` goes back to 1s and fires the immediate-poll side effect.
- `reconfigure({ pusherConnected: true })` does NOT fire an immediate poll.
- Calling `reconfigure` twice with the same state is a no-op (no extra `setInterval`/`clearInterval`).
- The no-op poller handle (when `setInterval` is unavailable) still exposes a safe `reconfigure`.

All 21 tests in `board-state-poller.test.mjs` pass. Seven other unrelated test files fail on both this branch and the base (missing `jsdom`, phase-1-1 fallout, etc.) and were confirmed pre-existing per the refactor plan.

## Test plan

- [x] `node --test dnd/vtt/assets/js/ui/__tests__/board-state-poller.test.mjs`
- [ ] Browser: load VTT, open DevTools → Network, confirm `state.php` fires every 30s while Pusher is connected.
- [ ] Browser: block the Pusher WebSocket, confirm `state.php` rate jumps to every 1s and one immediate poll fires on the transition.
- [ ] Browser: restore the network, confirm `state.php` drops back to 30s and no immediate poll is fired on reconnect.
