### PR TITLE
Remove redundant combat state refresh interval loop

### DIFF
--- a/dnd/vtt/assets/js/ui/board-interactions.js
+++ b/dnd/vtt/assets/js/ui/board-interactions.js
@@ -1065,10 +1065,6 @@ export function mountBoardInteractions(store, routes = {}) {
   let lastBoardStateHeartbeatSignature = null;
   let lastBoardStateHeartbeatAt = 0;
   const BOARD_STATE_HEARTBEAT_DEBOUNCE_MS = 2000;
-  let combatStateRefreshIntervalId = null;
-  // Combat state refresh is now triggered immediately by board state poller callback.
-  // This backup interval only runs as a safety fallback in case the callback fails.
-  const COMBAT_STATE_REFRESH_INTERVAL_MS = 5000;
   // Double-click activation debounce to prevent rapid re-activations
   let lastTrackerActivationAt = 0;
   const TRACKER_ACTIVATION_DEBOUNCE_MS = 300;
@@ -2743,33 +2739,6 @@ export function mountBoardInteractions(store, routes = {}) {
     boardStatePollerHandle = poller.start();
   }
 
-  function startCombatStateRefreshLoop() {
-    if (
-      combatStateRefreshIntervalId !== null ||
-      typeof window === 'undefined' ||
-      typeof window.setInterval !== 'function'
-    ) {
-      return;
-    }
-
-    // This is a backup fallback loop. Primary combat state refresh now happens
-    // immediately via the board state poller's onStateUpdated callback.
-    // This loop catches any edge cases where the callback might not fire.
-    combatStateRefreshIntervalId = window.setInterval(() => {
-      // Skip refresh if a combat state save is pending to avoid race conditions
-      const pendingInfo = getPendingBoardStateSaveInfo();
-      if (pendingInfo.pending) {
-        return;
-      }
-
-      const state = boardApi.getState?.();
-      if (!state) {
-        return;
-      }
-      applyCombatStateFromBoardState(state);
-    }, COMBAT_STATE_REFRESH_INTERVAL_MS);
-  }
-
   /**
    * Initialize Pusher for real-time state synchronization.
    * This provides instant updates instead of relying on polling.
@@ -3928,7 +3897,7 @@ export function mountBoardInteractions(store, routes = {}) {
   const pusherReady = initializePusherSync();
   Promise.resolve(pusherReady).then(() => {
     startBoardStatePoller();
-    startCombatStateRefreshLoop();
+    // (combat refresh removed — covered by Pusher + main poller)
   });
 
   startListeningForSheetSync();


### PR DESCRIPTION
## Summary
Removes the backup combat state refresh interval loop that is no longer needed, as combat state updates are now handled by the board state poller's callback and Pusher real-time synchronization.

## Key Changes
- Removed `combatStateRefreshIntervalId` variable and `COMBAT_STATE_REFRESH_INTERVAL_MS` constant
- Deleted the `startCombatStateRefreshLoop()` function that ran a 5-second interval as a fallback mechanism
- Replaced the `startCombatStateRefreshLoop()` call with a comment explaining that combat refresh is now covered by Pusher and the main poller

## Implementation Details
The combat state refresh was previously handled by both:
1. An immediate callback from the board state poller (`onStateUpdated`)
2. A backup 5-second interval as a safety fallback

Since the primary mechanism (board state poller callback + Pusher sync) is now reliable, the redundant interval loop has been removed to reduce unnecessary polling and improve efficiency. The comment in the initialization code documents this change for future maintainers.

https://claude.ai/code/session_01T67PmGJyf2QuBV8mLygv1s