### PR TITLE
Fix stale socket ID handling in Pusher reconnection

### DIFF
--- a/dnd/vtt/api/state.php
+++ b/dnd/vtt/api/state.php
@@ -168,6 +168,11 @@ if (!defined('VTT_STATE_API_INCLUDE_ONLY')) {
             $clientSocketId = isset($rawState['_socketId']) && is_string($rawState['_socketId'])
                 ? trim($rawState['_socketId'])
                 : null;
+            // Empty string after trim is meaningless for exclusion; normalize to null
+            // so PusherClient::trigger() does not attempt to include an empty socket_id.
+            if ($clientSocketId === '') {
+                $clientSocketId = null;
+            }
             // Check if this is a delta-only update (only changed entities)
             $isDeltaOnly = !empty($rawState['_deltaOnly']);
             // Scenes whose drawings should be fully replaced (after erasing/clearing)

--- a/dnd/vtt/assets/js/services/pusher-service.js
+++ b/dnd/vtt/assets/js/services/pusher-service.js
@@ -170,6 +170,10 @@ function handleConnected() {
  */
 function handleDisconnected() {
   isConnected = false;
+  // Clear the cached socket ID — on reconnect Pusher assigns a new one,
+  // and any save that happens while we are disconnected must not carry
+  // a stale socket ID.
+  currentSocketId = null;
   console.log('[VTT Pusher] Disconnected');
 
   if (typeof onConnectionStateChangeCallback === 'function') {
@@ -197,6 +201,23 @@ function handleError(error) {
  */
 function handleStateChange(states) {
   console.log('[VTT Pusher] State change:', states.previous, '->', states.current);
+
+  // Keep currentSocketId in sync with the connection state. This is the
+  // single source of truth for the cached socket ID. Any state that is
+  // not 'connected' means we do not currently hold a valid socket and
+  // must not advertise one on saves.
+  if (states && typeof states === 'object') {
+    if (states.current === 'connected') {
+      currentSocketId = pusherInstance?.connection?.socket_id || null;
+    } else if (
+      states.current === 'disconnected' ||
+      states.current === 'failed' ||
+      states.current === 'unavailable' ||
+      states.current === 'connecting'
+    ) {
+      currentSocketId = null;
+    }
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary
This PR fixes a bug where stale socket IDs could be sent to other clients after a Pusher disconnection and reconnection. The socket ID is now properly cleared on disconnect and kept in sync with the actual connection state.

## Key Changes
- **pusher-service.js**: Clear `currentSocketId` when disconnected, since Pusher will assign a new socket ID on reconnection
- **pusher-service.js**: Add state change handler to keep `currentSocketId` synchronized with Pusher's connection state (only valid when state is 'connected')
- **state.php**: Normalize empty socket IDs to `null` after trimming to prevent passing invalid empty strings to the Pusher client

## Implementation Details
The fix addresses two related issues:
1. The JavaScript service now explicitly clears the cached socket ID on disconnect and monitors all connection state changes to maintain a single source of truth
2. The PHP backend now normalizes empty socket IDs (which can result from trimming whitespace) to `null` to prevent the Pusher client from attempting to use invalid socket IDs for exclusion

This ensures that only valid, current socket IDs are advertised to other clients, preventing stale socket references from being used after reconnection.

https://claude.ai/code/session_01DbqQvFBxge3i1rSrDEDV6c