### PR TITLE
Optimize VTT state updates to unblock clients faster

### DIFF
--- a/dnd/vtt/api/state.php
+++ b/dnd/vtt/api/state.php
@@ -503,13 +503,33 @@ if (!defined('VTT_STATE_API_INCLUDE_ONLY')) {
                 $broadcastData['overlay'] = $updates['overlay'];
             }
 
-            // Broadcast asynchronously (don't wait for response)
-            broadcastVttStateUpdate($broadcastData, $clientSocketId);
-
+            // Send the response to the client first so the sender is not
+            // blocked waiting for the Pusher broadcast to complete. Pusher's
+            // cURL call can take up to the full timeout (several seconds) in
+            // degraded conditions; the client does not need that on its
+            // critical path.
             respondJson(200, [
                 'success' => true,
                 'data' => $responseState,
-            ]);
+            ], false);
+
+            // Release the session lock so other requests from the same user
+            // are not serialized behind this one's remaining work.
+            if (session_status() === PHP_SESSION_ACTIVE) {
+                session_write_close();
+            }
+
+            // Flush PHP-FPM's response so the client is already unblocked
+            // before we start the Pusher broadcast.
+            if (function_exists('fastcgi_finish_request')) {
+                fastcgi_finish_request();
+            }
+
+            // Now perform the Pusher broadcast. The client has already
+            // received its response; errors are still logged inside
+            // broadcastVttStateUpdate() but no longer delay the save.
+            broadcastVttStateUpdate($broadcastData, $clientSocketId);
+            return;
         }
 
         respondJson(405, [
@@ -1841,9 +1861,11 @@ function coerceFloat($value, ?float $fallback, int $precision): ?float
     return round($float, $precision);
 }
 
-function respondJson(int $status, array $payload): void
+function respondJson(int $status, array $payload, bool $exit = true): void
 {
     http_response_code($status);
     echo json_encode($payload);
-    exit;
+    if ($exit) {
+        exit;
+    }
 }


### PR DESCRIPTION
## Summary
This change optimizes the VTT state update endpoint to unblock clients immediately after sending their response, rather than waiting for the Pusher broadcast to complete. This prevents slow network conditions or Pusher timeouts from blocking the client's critical path.

## Key Changes
- Modified `respondJson()` to accept an optional `$exit` parameter, allowing callers to send a response without immediately terminating the script
- Restructured the VTT state update flow to:
  1. Send the JSON response to the client first
  2. Release the PHP session lock to unblock other concurrent requests from the same user
  3. Flush the FastCGI response buffer to ensure the client receives the response immediately
  4. Perform the asynchronous Pusher broadcast after the client is already unblocked
- Added explicit `return` statement after the broadcast to prevent further execution

## Implementation Details
- The session lock release (`session_write_close()`) is important for preventing request serialization when the same user makes multiple concurrent requests
- The `fastcgi_finish_request()` call ensures the response is flushed to the client in FastCGI/PHP-FPM environments before continuing with the broadcast
- Error handling in `broadcastVttStateUpdate()` remains unchanged and will still log any broadcast failures, but these no longer impact client response time
- The change is backward compatible; existing calls to `respondJson()` without the `$exit` parameter will maintain the original behavior

https://claude.ai/code/session_01UQsajsLCnkcNvd3WMsJkeq