### PR TITLE
vtt-sync: phase 2-3 guard save responses against stale versions

### DIFF
--- a/dnd/vtt/assets/js/state/__tests__/version-guard.test.mjs
+++ b/dnd/vtt/assets/js/state/__tests__/version-guard.test.mjs
@@ -1,0 +1,38 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { shouldApplyIncomingVersion } from '../version-guard.js';
+
+test('applies a strictly newer version', () => {
+  assert.equal(shouldApplyIncomingVersion(11, 10), true);
+  assert.equal(shouldApplyIncomingVersion(1, 0), true);
+});
+
+test('skips an equal version to match the Pusher guard', () => {
+  assert.equal(shouldApplyIncomingVersion(10, 10), false);
+  assert.equal(shouldApplyIncomingVersion(0, 0), false);
+});
+
+test('skips an older version', () => {
+  assert.equal(shouldApplyIncomingVersion(9, 10), false);
+  assert.equal(shouldApplyIncomingVersion(1, 100), false);
+});
+
+test('accepts any incoming version when no last-applied is tracked', () => {
+  assert.equal(shouldApplyIncomingVersion(5, undefined), true);
+  assert.equal(shouldApplyIncomingVersion(5, null), true);
+  assert.equal(shouldApplyIncomingVersion(0, undefined), true);
+});
+
+test('rejects missing or non-numeric incoming versions', () => {
+  assert.equal(shouldApplyIncomingVersion(undefined, 5), false);
+  assert.equal(shouldApplyIncomingVersion(null, 5), false);
+  assert.equal(shouldApplyIncomingVersion('7', 5), false);
+  assert.equal(shouldApplyIncomingVersion(NaN, 5), false);
+  assert.equal(shouldApplyIncomingVersion(Infinity, 5), false);
+});
+
+test('rejects when both sides are missing or invalid', () => {
+  assert.equal(shouldApplyIncomingVersion(undefined, undefined), false);
+  assert.equal(shouldApplyIncomingVersion('a', 'b'), false);
+});

--- a/dnd/vtt/assets/js/state/version-guard.js
+++ b/dnd/vtt/assets/js/state/version-guard.js
@@ -1,0 +1,28 @@
+/**
+ * Decide whether an incoming state update should be applied based on its
+ * `_version` relative to the last version the client has already applied.
+ *
+ * All three realtime ingestion paths (Pusher broadcasts, HTTP poll responses,
+ * and the client's own save response) share the same rule: only accept
+ * strictly newer versions. Equal versions are skipped so that a save response
+ * arriving after Pusher has already broadcast the same change does not cause
+ * redundant reapplication or state churn, matching the Pusher guard's
+ * `version <= lastAppliedVersion` behavior.
+ *
+ * @param {unknown} incomingVersion
+ *   The `_version` value from the server response, Pusher payload, or poll.
+ * @param {unknown} lastAppliedVersion
+ *   The highest version the client has already applied locally.
+ * @returns {boolean}
+ *   True if the caller should apply the incoming update, false if it should
+ *   be treated as stale and dropped.
+ */
+export function shouldApplyIncomingVersion(incomingVersion, lastAppliedVersion) {
+  if (typeof incomingVersion !== 'number' || !Number.isFinite(incomingVersion)) {
+    return false;
+  }
+  if (typeof lastAppliedVersion !== 'number' || !Number.isFinite(lastAppliedVersion)) {
+    return true;
+  }
+  return incomingVersion > lastAppliedVersion;
+}

--- a/dnd/vtt/assets/js/ui/board-interactions.js
+++ b/dnd/vtt/assets/js/ui/board-interactions.js
@@ -20,6 +20,7 @@ import {
   normalizeMonsterSnapshot,
   normalizePlayerTokenFolderName,
 } from '../state/store.js';
+import { shouldApplyIncomingVersion } from '../state/version-guard.js';
 import { close as closeMonsterStatBlock, open as openMonsterStatBlock } from './monster-stat-block.js';
 import { createCombatTimerService } from '../services/combat-timer-service.js';
 import { showCombatTimerReport } from './combat-timer-report.js';
@@ -2282,13 +2283,30 @@ export function mountBoardInteractions(store, routes = {}) {
           // Clear dirty tracking after successful save
           clearDirtyTracking();
 
-          // Update version from server response
+          // Update version from server response.
+          // The save response is the third ingestion path for state updates
+          // (alongside Pusher broadcasts and the HTTP poller). Guard it with
+          // the shared version rule so that a save reply whose _version is
+          // not strictly greater than what the client has already applied
+          // is dropped - matching how Pusher deliveries and poll responses
+          // are filtered. Side effects above (clearing dirty tracking,
+          // updating the persisted hash/signature) still run unconditionally.
           const newVersion = result?.data?._version;
-          if (typeof newVersion === 'number' && newVersion > currentBoardStateVersion) {
+          if (shouldApplyIncomingVersion(newVersion, currentBoardStateVersion)) {
             currentBoardStateVersion = newVersion;
             if (pusherInterface?.setLastAppliedVersion) {
               pusherInterface.setLastAppliedVersion(newVersion);
             }
+          } else if (typeof newVersion === 'number') {
+            console.log(
+              '[VTT] Skipping stale save response,',
+              'version:', newVersion,
+              'current:', currentBoardStateVersion
+            );
+          } else {
+            console.warn(
+              '[VTT] Save response missing _version; not updating version tracker'
+            );
           }
         } else {
           // CRITICAL: Clear the pending entry on failure so the poller is not
@@ -2727,7 +2745,7 @@ export function mountBoardInteractions(store, routes = {}) {
       // arrive after Pusher real-time updates, which would overwrite newer state
       getCurrentVersionFn: () => currentBoardStateVersion,
       onVersionUpdated: (version) => {
-        if (typeof version === 'number' && version > currentBoardStateVersion) {
+        if (shouldApplyIncomingVersion(version, currentBoardStateVersion)) {
           currentBoardStateVersion = version;
         }
       },
@@ -2792,7 +2810,7 @@ export function mountBoardInteractions(store, routes = {}) {
 
     // ALWAYS update version tracking first, regardless of other state
     // This prevents the poller from applying stale data later
-    if (typeof delta.version === 'number' && delta.version > currentBoardStateVersion) {
+    if (shouldApplyIncomingVersion(delta.version, currentBoardStateVersion)) {
       currentBoardStateVersion = delta.version;
       if (pusherInterface?.setLastAppliedVersion) {
         pusherInterface.setLastAppliedVersion(delta.version);


### PR DESCRIPTION
The save response handler used to apply the server's returned _version
using an inline check. With Phase 2-1 making server-side versions
reliable, centralize the rule so the client drops any save response
whose _version is not strictly greater than currentBoardStateVersion -
matching how Pusher-delivered updates and poll responses are already
filtered.

Shared shouldApplyIncomingVersion() helper in state/version-guard.js
with unit tests (newer, older, equal, missing, non-numeric). The save
response handler, the Pusher delta version-tracker update, and the
poller's onVersionUpdated callback all now delegate to the helper so
the three ingestion paths cannot drift apart. Side effects that must
run regardless (clearing dirty tracking, updating persisted
hash/signature, clearing pendingBoardStateSave) are kept outside the
guard. Stale save responses now log a [VTT] Skipping stale save
response line instead of silently no-oping.

See docs/vtt-sync-refactor/phase-2-3-client-version-guard.md.