### PR TITLE
Implement conditional GET with ETag support for board state polling

### DIFF
--- a/dnd/vtt/api/state.php
+++ b/dnd/vtt/api/state.php
@@ -144,6 +144,27 @@ if (!defined('VTT_STATE_API_INCLUDE_ONLY')) {
 
     try {
         if ($method === 'GET') {
+            // Phase 3-A: Conditional GET. The polling fallback hits this
+            // endpoint every 30 seconds (safety-net) or 1 second (fallback).
+            // When the board state version has not advanced since the
+            // client's last applied version, return 304 Not Modified with
+            // no body so the safety-net poll is effectively free on the
+            // server: no scene/token loads, no player-view filtering, no
+            // JSON serialization. We use a weak ETag because the response
+            // body varies by user role (player view vs. GM view), but the
+            // version is always a sufficient freshness key.
+            $currentVersion = getVttBoardStateVersion();
+            $currentEtag = 'W/"v' . $currentVersion . '"';
+            $clientEtag = isset($_SERVER['HTTP_IF_NONE_MATCH'])
+                ? trim((string) $_SERVER['HTTP_IF_NONE_MATCH'])
+                : '';
+            if ($clientEtag !== '' && $clientEtag === $currentEtag) {
+                header('ETag: ' . $currentEtag);
+                header('Cache-Control: no-store');
+                http_response_code(304);
+                exit;
+            }
+
             $config = getVttBootstrapConfig();
             $auth = getVttUserContext();
             if (!($auth['isGM'] ?? false)) {
@@ -151,9 +172,8 @@ if (!defined('VTT_STATE_API_INCLUDE_ONLY')) {
             }
 
             // Include version for sync conflict detection
-            $version = getVttBoardStateVersion();
             $boardState = $config['boardState'] ?? [];
-            $boardState['_version'] = $version;
+            $boardState['_version'] = $currentVersion;
             // Mark as full sync so clients know to replace (not merge) scene data
             // This enables proper deletion sync - items not in this response should be removed
             $boardState['_fullSync'] = true;
@@ -161,6 +181,8 @@ if (!defined('VTT_STATE_API_INCLUDE_ONLY')) {
             // Include Pusher config for client-side initialization
             $pusherConfig = getVttPusherConfig();
 
+            header('ETag: ' . $currentEtag);
+            header('Cache-Control: no-store');
             respondJson(200, [
                 'success' => true,
                 'data' => [

--- a/dnd/vtt/assets/js/ui/__tests__/board-state-poller.test.mjs
+++ b/dnd/vtt/assets/js/ui/__tests__/board-state-poller.test.mjs
@@ -1042,3 +1042,146 @@ test('start() returns a no-op reconfigure when no setInterval is available', asy
   handle.reconfigure({ pusherConnected: false });
   handle.stop();
 });
+
+// Phase 3-A: Conditional GET tests.
+test('poller sends If-None-Match header with the current version', async () => {
+  const { createBoardStatePoller } = await modulePromise;
+
+  const fetchCalls = [];
+  const fetchFn = async (endpoint, options) => {
+    fetchCalls.push({ endpoint, options });
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({ data: { boardState: { _version: 42 } } }),
+    };
+  };
+
+  const boardStateContainer = {
+    boardState: { placements: {} },
+    user: { name: 'GM User', isGM: true },
+  };
+
+  const poller = createBoardStatePoller({
+    stateEndpoint: '/state',
+    boardApi: {
+      getState: () => boardStateContainer,
+      updateState: (mutator) => mutator(boardStateContainer),
+    },
+    fetchFn,
+    windowRef: { setInterval: () => 0, clearInterval: () => {} },
+    documentRef: { visibilityState: 'visible' },
+    hashBoardStateSnapshotFn: (snapshot) => JSON.stringify(snapshot),
+    safeJsonStringifyFn: (value) => JSON.stringify(value),
+    mergeBoardStateSnapshotFn: (existing, incoming) => incoming ?? existing,
+    getCurrentUserIdFn: () => 'gm user',
+    normalizeProfileIdFn: (value) =>
+      typeof value === 'string' ? value.trim().toLowerCase() : null,
+    getPendingSaveInfo: () => ({ pending: false }),
+    getLastPersistedHashFn: () => null,
+    getLastPersistedSignatureFn: () => null,
+    getCurrentVersionFn: () => 42,
+  });
+
+  await poller.poll();
+
+  assert.equal(fetchCalls.length, 1);
+  const headers = fetchCalls[0].options?.headers ?? {};
+  assert.equal(headers['If-None-Match'], 'W/"v42"');
+});
+
+test('poller omits If-None-Match when no version is known yet', async () => {
+  const { createBoardStatePoller } = await modulePromise;
+
+  const fetchCalls = [];
+  const fetchFn = async (endpoint, options) => {
+    fetchCalls.push({ endpoint, options });
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({ data: { boardState: { _version: 1 } } }),
+    };
+  };
+
+  const boardStateContainer = {
+    boardState: { placements: {} },
+    user: { name: 'GM User', isGM: true },
+  };
+
+  const poller = createBoardStatePoller({
+    stateEndpoint: '/state',
+    boardApi: {
+      getState: () => boardStateContainer,
+      updateState: (mutator) => mutator(boardStateContainer),
+    },
+    fetchFn,
+    windowRef: { setInterval: () => 0, clearInterval: () => {} },
+    documentRef: { visibilityState: 'visible' },
+    hashBoardStateSnapshotFn: (snapshot) => JSON.stringify(snapshot),
+    safeJsonStringifyFn: (value) => JSON.stringify(value),
+    mergeBoardStateSnapshotFn: (existing, incoming) => incoming ?? existing,
+    getCurrentUserIdFn: () => 'gm user',
+    normalizeProfileIdFn: (value) =>
+      typeof value === 'string' ? value.trim().toLowerCase() : null,
+    getPendingSaveInfo: () => ({ pending: false }),
+    getLastPersistedHashFn: () => null,
+    getLastPersistedSignatureFn: () => null,
+    getCurrentVersionFn: () => 0,
+  });
+
+  await poller.poll();
+
+  assert.equal(fetchCalls.length, 1);
+  const headers = fetchCalls[0].options?.headers ?? {};
+  assert.equal('If-None-Match' in headers, false);
+});
+
+test('poller treats a 304 response as a no-op without applying state', async () => {
+  const { createBoardStatePoller } = await modulePromise;
+
+  const boardStateContainer = {
+    boardState: { placements: { token: { x: 9 } } },
+    user: { name: 'GM User', isGM: true },
+  };
+
+  const updateCalls = [];
+  const boardApi = {
+    getState: () => boardStateContainer,
+    updateState: (mutator) => {
+      updateCalls.push(mutator);
+      mutator(boardStateContainer);
+    },
+  };
+
+  const fetchFn = async () => ({
+    status: 304,
+    // No `ok`, no `json`. The poller must NOT call .json() on a 304.
+  });
+
+  const poller = createBoardStatePoller({
+    stateEndpoint: '/state',
+    boardApi,
+    fetchFn,
+    windowRef: { setInterval: () => 0, clearInterval: () => {} },
+    documentRef: { visibilityState: 'visible' },
+    hashBoardStateSnapshotFn: (snapshot) => JSON.stringify(snapshot),
+    safeJsonStringifyFn: (value) => JSON.stringify(value),
+    mergeBoardStateSnapshotFn: (existing, incoming) => incoming ?? existing,
+    getCurrentUserIdFn: () => 'gm user',
+    normalizeProfileIdFn: (value) =>
+      typeof value === 'string' ? value.trim().toLowerCase() : null,
+    getPendingSaveInfo: () => ({ pending: false }),
+    getLastPersistedHashFn: () => null,
+    getLastPersistedSignatureFn: () => null,
+    getCurrentVersionFn: () => 7,
+  });
+
+  await poller.poll();
+
+  assert.equal(updateCalls.length, 0, 'updateState must not be called on 304');
+  assert.deepEqual(
+    boardStateContainer.boardState,
+    { placements: { token: { x: 9 } } },
+    'board state must remain untouched on 304',
+  );
+});

--- a/dnd/vtt/assets/js/ui/board-interactions.js
+++ b/dnd/vtt/assets/js/ui/board-interactions.js
@@ -132,7 +132,29 @@ export function createBoardStatePoller({
 
     isPolling = true;
     try {
-      const response = await fetchFn(endpoint, { cache: 'no-store' });
+      // Phase 3-A: Conditional GET. Send If-None-Match with the version
+      // we last applied so the server can return 304 Not Modified when
+      // nothing has changed. Safety-net polls (every 30s while Pusher is
+      // up) become near-zero work on both client and server.
+      const headers = { Accept: 'application/json' };
+      const knownVersion = typeof getCurrentVersionFn === 'function'
+        ? getCurrentVersionFn()
+        : 0;
+      if (typeof knownVersion === 'number' && knownVersion > 0) {
+        headers['If-None-Match'] = `W/"v${knownVersion}"`;
+      }
+
+      const response = await fetchFn(endpoint, {
+        cache: 'no-store',
+        headers,
+      });
+      if (response?.status === 304) {
+        // Nothing has changed since our last applied version. Treat as a
+        // successful no-op: do not touch lastHash, do not update state,
+        // do not log an error.
+        pollErrorLogged = false;
+        return;
+      }
       if (!response?.ok) {
         throw new Error(`Unexpected status ${response?.status ?? 'unknown'}`);
       }


### PR DESCRIPTION
## Summary
This PR implements HTTP conditional GET (304 Not Modified) support for the board state polling mechanism, reducing unnecessary server processing and bandwidth when the board state hasn't changed.

## Key Changes

- **Backend (state.php)**: Added ETag generation and conditional GET handling
  - Generate weak ETags based on board state version (`W/"v{version}"`)
  - Check incoming `If-None-Match` header against current ETag
  - Return 304 Not Modified with no body when versions match
  - Include ETag and Cache-Control headers in all responses

- **Frontend (board-interactions.js)**: Enhanced polling to use conditional requests
  - Send `If-None-Match` header with the last known board state version
  - Handle 304 responses as successful no-ops without state updates
  - Only send the header when a version > 0 is known
  - Maintain existing error handling for other response statuses

- **Tests (board-state-poller.test.mjs)**: Added comprehensive test coverage
  - Verify `If-None-Match` header is sent with current version
  - Verify header is omitted when no version is known yet
  - Verify 304 responses don't trigger state updates or call `.json()`

## Implementation Details

- Uses weak ETags (`W/"v{version}"`) because response bodies vary by user role (player vs. GM view), but the version is a sufficient freshness indicator
- Safety-net polls (every 30s while Pusher is connected) become near-zero work on both client and server when nothing has changed
- The 304 response path avoids scene/token loads, player-view filtering, and JSON serialization
- Maintains backward compatibility: clients without a known version will receive full 200 responses

https://claude.ai/code/session_01NfshAiUEHWXvyhcDKBLAgF