### PR TITLE
Phase 3-B commit 2: Delta-op saves for token drag operations

### DIFF
--- a/dnd/vtt/api/state.php
+++ b/dnd/vtt/api/state.php
@@ -784,8 +784,14 @@ function applyBoardStateOp(array $state, array $op): array
             if ($entryId === null || $entryId !== $placementId) {
                 continue;
             }
-            $entry['x'] = $x;
-            $entry['y'] = $y;
+            // The op wire format uses `x`/`y` for coordinates (matching
+            // the doc), but placement entries in this codebase store
+            // positions as `column`/`row` (see the client store
+            // normalizer and the snapshot save path). Writing `x`/`y`
+            // directly would leave the canonical `column`/`row` stale
+            // and the move would silently fail to apply on readback.
+            $entry['column'] = $x;
+            $entry['row'] = $y;
             // Stamp `_lastModified` so downstream timestamp-based merges
             // (player saves, delta reconciliation) treat this move as
             // newer than any stale payload already in flight.

--- a/dnd/vtt/api/state.php
+++ b/dnd/vtt/api/state.php
@@ -235,8 +235,20 @@ if (!defined('VTT_STATE_API_INCLUDE_ONLY')) {
             // Remove internal fields before processing
             unset($rawState['_version'], $rawState['_socketId'], $rawState['_deltaOnly'], $rawState['_replaceDrawings']);
 
+            // Phase 3-B (commit 1): optional delta ops live at
+            // `payload.ops` (top-level, alongside boardState). They are
+            // sanitized for shape here and applied inside the state
+            // lock below. The client does not send ops yet — this
+            // commit only teaches the server to accept them. Existing
+            // snapshot-only payloads are unaffected because `$ops`
+            // stays empty when `payload.ops` is absent.
+            $ops = [];
+            if (isset($payload['ops']) && is_array($payload['ops'])) {
+                $ops = sanitizeBoardStateOps($payload['ops']);
+            }
+
             $updates = sanitizeBoardStateUpdates($rawState);
-            if (empty($updates)) {
+            if (empty($updates) && empty($ops)) {
                 respondJson(422, [
                     'success' => false,
                     'error' => 'No board state changes were provided.',
@@ -246,7 +258,7 @@ if (!defined('VTT_STATE_API_INCLUDE_ONLY')) {
             // Determine what changed for targeted Pusher broadcasts
             $changedFields = array_keys($updates);
 
-            $lockResult = withVttBoardStateLock(function () use ($updates, $auth, $clientVersion, $isDeltaOnly, $replaceDrawingScenes) {
+            $lockResult = withVttBoardStateLock(function () use ($updates, $ops, $auth, $clientVersion, $isDeltaOnly, $replaceDrawingScenes) {
                 $existing = loadVttJson('board-state.json');
 
                 // Determine the starting version. Prefer the `_version` field
@@ -268,6 +280,19 @@ if (!defined('VTT_STATE_API_INCLUDE_ONLY')) {
 
                 $nextState = normalizeBoardState($existing);
                 $nextState['_version'] = $previousVersion;
+
+                // Phase 3-B (commit 1): apply delta ops to the
+                // normalized state before any snapshot-merge logic
+                // runs. Ops mutate the canonical state in place; the
+                // existing snapshot path, when a boardState payload is
+                // also present, will layer on top exactly as before.
+                // No client sends ops yet, so in practice `$ops` is
+                // always empty on this commit and this loop is a no-op.
+                if (!empty($ops)) {
+                    foreach ($ops as $op) {
+                        $nextState = applyBoardStateOp($nextState, $op);
+                    }
+                }
 
                 $isGm = (bool) ($auth['isGM'] ?? false);
                 if (!$isGm) {
@@ -295,7 +320,13 @@ if (!defined('VTT_STATE_API_INCLUDE_ONLY')) {
                     $hasDrawingUpdates = !empty($drawingUpdates);
                     $hasPingUpdates = !empty($pingUpdates);
 
-                    if (!$hasCombatUpdates && !$hasPlacementUpdates && !$hasTemplateUpdates && !$hasDrawingUpdates && !$hasPingUpdates) {
+                    // Phase 3-B (commit 1): an ops-only payload from a
+                    // player is also acceptable. Only `placement.move`
+                    // is supported today, which is strictly an update
+                    // to an existing placement (no create, no delete),
+                    // so it fits the same "players may only modify"
+                    // policy this branch enforces for snapshot saves.
+                    if (!$hasCombatUpdates && !$hasPlacementUpdates && !$hasTemplateUpdates && !$hasDrawingUpdates && !$hasPingUpdates && empty($ops)) {
                         respondJson(403, [
                             'success' => false,
                             'error' => 'Only combat, placement, template, drawing, or ping updates are permitted for players.',
@@ -657,6 +688,118 @@ function readJsonInput(): array
 
     $data = json_decode($raw, true);
     return is_array($data) ? $data : [];
+}
+
+/**
+ * Phase 3-B: Sanitize a list of delta ops coming in on `payload.ops`.
+ *
+ * Each op is an associative array describing a single, typed mutation
+ * of the board state (for example `{type: 'placement.move', sceneId,
+ * placementId, x, y}`). Unknown op types are preserved in the returned
+ * list so `applyBoardStateOp` can decide how to handle them; malformed
+ * entries (non-arrays, missing or non-string `type`) are dropped.
+ *
+ * This helper performs shape validation only. It does not touch the
+ * board state — application happens later, inside the state lock.
+ *
+ * @param array<int,mixed> $rawOps
+ * @return array<int,array<string,mixed>>
+ */
+function sanitizeBoardStateOps(array $rawOps): array
+{
+    $sanitized = [];
+    foreach ($rawOps as $rawOp) {
+        if (!is_array($rawOp)) {
+            continue;
+        }
+        $type = $rawOp['type'] ?? null;
+        if (!is_string($type) || trim($type) === '') {
+            continue;
+        }
+        $rawOp['type'] = trim($type);
+        $sanitized[] = $rawOp;
+    }
+    return $sanitized;
+}
+
+/**
+ * Phase 3-B: Apply a single delta op to an in-memory board state array.
+ *
+ * Commit 1 supports only `placement.move`, which updates the `x`/`y`
+ * coordinates of an existing placement in a given scene. Unknown or
+ * unsupported op types are ignored so older servers can tolerate
+ * payloads from newer clients without erroring out. The state returned
+ * is always a valid board state — if the op cannot be applied (missing
+ * scene, missing placement, bad coordinates), the input is returned
+ * unchanged.
+ *
+ * The caller is responsible for running this inside the state lock so
+ * two concurrent writers cannot interleave mutations on the same
+ * placement.
+ *
+ * @param array<string,mixed> $state
+ * @param array<string,mixed> $op
+ * @return array<string,mixed>
+ */
+function applyBoardStateOp(array $state, array $op): array
+{
+    $type = isset($op['type']) && is_string($op['type']) ? $op['type'] : '';
+
+    if ($type === 'placement.move') {
+        $sceneId = isset($op['sceneId']) && is_string($op['sceneId']) ? trim($op['sceneId']) : '';
+        if ($sceneId === '') {
+            return $state;
+        }
+        $placementId = '';
+        if (isset($op['placementId'])) {
+            $rawId = $op['placementId'];
+            if (is_string($rawId)) {
+                $placementId = trim($rawId);
+            } elseif (is_int($rawId) || is_float($rawId)) {
+                $placementId = (string) $rawId;
+            }
+        }
+        if ($placementId === '') {
+            return $state;
+        }
+        if (!isset($op['x']) || !is_numeric($op['x']) || !isset($op['y']) || !is_numeric($op['y'])) {
+            return $state;
+        }
+        $x = (float) $op['x'];
+        $y = (float) $op['y'];
+
+        if (!isset($state['placements']) || !is_array($state['placements'])) {
+            return $state;
+        }
+        if (!isset($state['placements'][$sceneId]) || !is_array($state['placements'][$sceneId])) {
+            return $state;
+        }
+
+        $nowMs = (int) round(microtime(true) * 1000);
+        foreach ($state['placements'][$sceneId] as $idx => $entry) {
+            if (!is_array($entry)) {
+                continue;
+            }
+            $entryId = extractBoardEntryIdentifier($entry);
+            if ($entryId === null || $entryId !== $placementId) {
+                continue;
+            }
+            $entry['x'] = $x;
+            $entry['y'] = $y;
+            // Stamp `_lastModified` so downstream timestamp-based merges
+            // (player saves, delta reconciliation) treat this move as
+            // newer than any stale payload already in flight.
+            $entry['_lastModified'] = $nowMs;
+            $state['placements'][$sceneId][$idx] = $entry;
+            break;
+        }
+        return $state;
+    }
+
+    // Unknown op types are silently ignored so older servers can
+    // tolerate payloads from newer clients. Commits 2+ will add more
+    // `placement.*`, `template.*`, and `drawing.*` op types here.
+    return $state;
 }
 
 /**

--- a/dnd/vtt/assets/js/services/__tests__/board-state-ops.test.mjs
+++ b/dnd/vtt/assets/js/services/__tests__/board-state-ops.test.mjs
@@ -1,0 +1,243 @@
+import { describe, test, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+
+// ---------------------------------------------------------------------------
+// Phase 3-B (commit 2): `persistBoardStateOps` is the new delta-op save path
+// used by token-drag saves. These tests lock in the wire shape the client
+// sends (`{ops: [...], boardState: {metadata, _version, _socketId}}`), the
+// same-key coalescing behavior (later move of the same token replaces the
+// earlier one in the buffer), the cross-call accumulation that protects
+// unrelated tokens from being lost if a second save starts while the first
+// is still in flight, and the escape-hatch that tells the caller to fall
+// back to a full snapshot when the buffer grows too big.
+// ---------------------------------------------------------------------------
+
+describe('Board State – delta ops persistence (phase 3-B commit 2)', () => {
+  let originalFetch;
+  let originalWindow;
+  let capturedPayloads;
+  let pendingFetchResolvers;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    originalWindow = globalThis.window;
+
+    capturedPayloads = [];
+    pendingFetchResolvers = [];
+
+    // Default fetch stub: captures the POST body and resolves immediately
+    // with a successful response. Individual tests can override by
+    // reassigning `globalThis.fetch`.
+    globalThis.fetch = async (_url, options = {}) => {
+      if (options?.body) {
+        capturedPayloads.push(JSON.parse(options.body));
+      }
+      return { ok: true, json: async () => ({ success: true, data: { _version: 42 } }) };
+    };
+
+    globalThis.window = {
+      ...(globalThis.window ?? {}),
+      setTimeout: (fn, _ms) => {
+        fn();
+        return 0;
+      },
+    };
+  });
+
+  afterEach(async () => {
+    // Drain the buffer so state never leaks between tests.
+    const { _resetBoardStateOpsBufferForTest } = await import('../board-state-service.js');
+    _resetBoardStateOpsBufferForTest();
+
+    if (originalFetch === undefined) {
+      delete globalThis.fetch;
+    } else {
+      globalThis.fetch = originalFetch;
+    }
+
+    if (originalWindow === undefined) {
+      delete globalThis.window;
+    } else {
+      globalThis.window = originalWindow;
+    }
+
+    // Resolve any still-pending fetches so the event loop can drain.
+    while (pendingFetchResolvers.length > 0) {
+      const resolve = pendingFetchResolvers.shift();
+      resolve?.({ ok: true, json: async () => ({ success: true, data: { _version: 1 } }) });
+    }
+  });
+
+  test('persistBoardStateOps sends `ops` at the top level and wraps internal fields in boardState', async () => {
+    const { persistBoardStateOps, _resetBoardStateOpsBufferForTest } = await import(
+      '../board-state-service.js'
+    );
+    _resetBoardStateOpsBufferForTest();
+
+    const ops = [
+      { type: 'placement.move', sceneId: 'scene-1', placementId: 'hero', x: 3, y: 4 },
+    ];
+    const envelope = {
+      metadata: { updatedAt: 1, signature: 'gm:1', authorRole: 'gm', authorId: 'gm' },
+      _version: 17,
+      _socketId: 'socket-abc',
+    };
+
+    await persistBoardStateOps('/api/state', ops, envelope);
+
+    assert.equal(capturedPayloads.length, 1, 'one POST should be made');
+    const payload = capturedPayloads[0];
+
+    assert.ok(Array.isArray(payload.ops), 'ops should live at the top level of the payload');
+    assert.equal(payload.ops.length, 1, 'payload should contain exactly one op');
+    assert.deepEqual(payload.ops[0], {
+      type: 'placement.move',
+      sceneId: 'scene-1',
+      placementId: 'hero',
+      x: 3,
+      y: 4,
+    });
+
+    assert.ok(payload.boardState, 'boardState envelope should be present');
+    assert.equal(payload.boardState._version, 17, '_version should be forwarded via boardState');
+    assert.equal(payload.boardState._socketId, 'socket-abc', '_socketId should be forwarded');
+    assert.deepEqual(payload.boardState.metadata, envelope.metadata);
+    // The full snapshot fields (placements, templates, drawings, etc.) must
+    // not be present — this is a delta-op save, not a snapshot save.
+    assert.equal(payload.boardState.placements, undefined);
+    assert.equal(payload.boardState.templates, undefined);
+    assert.equal(payload.boardState.drawings, undefined);
+  });
+
+  test('two placement.move ops for the same (sceneId, placementId) coalesce (later wins)', async () => {
+    const { persistBoardStateOps, _resetBoardStateOpsBufferForTest } = await import(
+      '../board-state-service.js'
+    );
+    _resetBoardStateOpsBufferForTest();
+
+    // Hold the first fetch open so the second call batches into the
+    // same pending buffer instead of after a clean resolution.
+    globalThis.fetch = async (_url, options = {}) => {
+      if (options?.body) {
+        capturedPayloads.push(JSON.parse(options.body));
+      }
+      return new Promise((resolve) => {
+        pendingFetchResolvers.push(resolve);
+      });
+    };
+
+    persistBoardStateOps(
+      '/api/state',
+      [{ type: 'placement.move', sceneId: 'scene-1', placementId: 'hero', x: 1, y: 1 }],
+      {}
+    );
+    persistBoardStateOps(
+      '/api/state',
+      [{ type: 'placement.move', sceneId: 'scene-1', placementId: 'hero', x: 9, y: 9 }],
+      {}
+    );
+
+    // The first (in-flight) call was aborted by the coalesce-replace in
+    // queueSave; the second call carries the newest coordinates for the
+    // same token and only one op is in the buffer.
+    const secondPayload = capturedPayloads[capturedPayloads.length - 1];
+    assert.ok(secondPayload, 'a second POST should have been initiated');
+    assert.equal(secondPayload.ops.length, 1, 'same-token coalescing leaves a single op');
+    assert.equal(secondPayload.ops[0].x, 9, 'later position wins');
+    assert.equal(secondPayload.ops[0].y, 9);
+  });
+
+  test('moves of different tokens accumulate across calls while a save is in flight', async () => {
+    const { persistBoardStateOps, _resetBoardStateOpsBufferForTest } = await import(
+      '../board-state-service.js'
+    );
+    _resetBoardStateOpsBufferForTest();
+
+    globalThis.fetch = async (_url, options = {}) => {
+      if (options?.body) {
+        capturedPayloads.push(JSON.parse(options.body));
+      }
+      return new Promise((resolve) => {
+        pendingFetchResolvers.push(resolve);
+      });
+    };
+
+    persistBoardStateOps(
+      '/api/state',
+      [{ type: 'placement.move', sceneId: 'scene-1', placementId: 'hero', x: 1, y: 1 }],
+      {}
+    );
+    persistBoardStateOps(
+      '/api/state',
+      [{ type: 'placement.move', sceneId: 'scene-1', placementId: 'goblin', x: 2, y: 2 }],
+      {}
+    );
+
+    // The second call's payload must carry BOTH ops — otherwise the first
+    // token's move would be lost if the aborted in-flight save never
+    // reached the server.
+    const secondPayload = capturedPayloads[capturedPayloads.length - 1];
+    assert.ok(secondPayload, 'a second POST should have been initiated');
+    assert.equal(secondPayload.ops.length, 2, 'different-token ops must accumulate');
+    const ids = secondPayload.ops.map((op) => op.placementId).sort();
+    assert.deepEqual(ids, ['goblin', 'hero']);
+  });
+
+  test('returns {escape: true} when the ops buffer exceeds PHASE_3B_MAX_OPS_PER_FLUSH', async () => {
+    const {
+      persistBoardStateOps,
+      PHASE_3B_MAX_OPS_PER_FLUSH,
+      _resetBoardStateOpsBufferForTest,
+    } = await import('../board-state-service.js');
+    _resetBoardStateOpsBufferForTest();
+
+    const ops = [];
+    for (let i = 0; i < PHASE_3B_MAX_OPS_PER_FLUSH + 1; i += 1) {
+      ops.push({
+        type: 'placement.move',
+        sceneId: 'scene-1',
+        placementId: `token-${i}`,
+        x: i,
+        y: i,
+      });
+    }
+
+    const result = persistBoardStateOps('/api/state', ops, {});
+    assert.ok(result, 'escape result should not be null');
+    assert.equal(result.escape, true, 'escape flag should be set when over the op threshold');
+    assert.equal(capturedPayloads.length, 0, 'no POST should have been issued');
+  });
+
+  test('returns null if ops is not an array or is empty and no buffer is pending', async () => {
+    const { persistBoardStateOps, _resetBoardStateOpsBufferForTest } = await import(
+      '../board-state-service.js'
+    );
+    _resetBoardStateOpsBufferForTest();
+
+    assert.equal(persistBoardStateOps('/api/state', null, {}), null);
+    assert.equal(persistBoardStateOps('/api/state', [], {}), null);
+    assert.equal(capturedPayloads.length, 0);
+  });
+
+  test('silently drops malformed ops (missing sceneId or placementId)', async () => {
+    const { persistBoardStateOps, _resetBoardStateOpsBufferForTest } = await import(
+      '../board-state-service.js'
+    );
+    _resetBoardStateOpsBufferForTest();
+
+    await persistBoardStateOps(
+      '/api/state',
+      [
+        { type: 'placement.move', sceneId: '', placementId: 'hero', x: 1, y: 1 },
+        { type: 'placement.move', sceneId: 'scene-1', placementId: 'hero', x: 1, y: 1 },
+        { type: 'placement.move', sceneId: 'scene-1', placementId: '', x: 1, y: 1 },
+      ],
+      {}
+    );
+
+    assert.equal(capturedPayloads.length, 1);
+    assert.equal(capturedPayloads[0].ops.length, 1, 'only the well-formed op should be sent');
+    assert.equal(capturedPayloads[0].ops[0].sceneId, 'scene-1');
+    assert.equal(capturedPayloads[0].ops[0].placementId, 'hero');
+  });
+});

--- a/dnd/vtt/assets/js/services/board-state-service.js
+++ b/dnd/vtt/assets/js/services/board-state-service.js
@@ -3,6 +3,43 @@ import { queueSave } from '../state/persistence.js';
 const SAVE_KEY = 'board-state';
 const COMBAT_SAVE_KEY_PREFIX = 'combat-state';
 
+// Phase 3-B (commit 2): delta-op escape thresholds. If a single flush
+// would carry more than this many ops, or ops spanning more than this
+// many scenes, `persistBoardStateOps` bails out and asks the caller to
+// fall back to a full snapshot save. These are deliberately generous;
+// the intent is to catch pathological cases (e.g. a scene-wide template
+// change) rather than to nudge normal multi-select drags into the
+// snapshot path.
+export const PHASE_3B_MAX_OPS_PER_FLUSH = 64;
+export const PHASE_3B_MAX_SCENES_PER_FLUSH = 4;
+
+// Cross-call ops buffer. Rapidly repeated moves of the same token get
+// coalesced by key (the later op overwrites the earlier one), matching
+// how the full-snapshot path already behaves. Moves of *different*
+// tokens, on the other hand, accumulate so that a second drag started
+// while the first save is still in flight does not cause the first
+// token to "pop back" to its pre-save position. Entries are cleared
+// from the buffer only after the save that carried them resolves
+// successfully, so an aborted/failed save leaves its ops in place for
+// the next flush to pick up.
+let boardStateOpSendSequence = 0;
+const pendingBoardStateOps = new Map();
+
+function boardStateOpDedupKey(op) {
+  if (!op || typeof op !== 'object') {
+    return null;
+  }
+  if (op.type === 'placement.move') {
+    const sceneId = typeof op.sceneId === 'string' ? op.sceneId.trim() : '';
+    const placementId = typeof op.placementId === 'string' ? op.placementId.trim() : '';
+    if (!sceneId || !placementId) {
+      return null;
+    }
+    return `placement.move:${sceneId}:${placementId}`;
+  }
+  return null;
+}
+
 export async function fetchBoardState(endpoint, { fetchFn = typeof fetch === 'function' ? fetch : null } = {}) {
   if (!endpoint || typeof fetchFn !== 'function') {
     return null;
@@ -50,6 +87,115 @@ export function persistBoardState(endpoint, boardState = {}, options = {}) {
   // where stale state could be applied by polling, preventing token popback
   const normalizedOptions = { immediate: true, ...options };
   return queueSave(SAVE_KEY, { boardState: payload }, endpoint, normalizedOptions);
+}
+
+/**
+ * Phase 3-B (commit 2): queue a delta-op save for the board state.
+ *
+ * Accepts a list of typed ops (currently only `placement.move`) plus a
+ * small envelope carrying the metadata / `_version` / `_socketId` that
+ * the existing snapshot path rides on the payload. Returns either:
+ *   - the save promise, identical in shape to `persistBoardState`; or
+ *   - `null` if there is nothing to send / the endpoint is missing; or
+ *   - `{ escape: true }` if the pending ops buffer exceeds the size or
+ *     scene-count thresholds. The caller should treat this as "ops path
+ *     unavailable for this flush, fall back to snapshot."
+ *
+ * Rapidly repeated ops for the same (type, sceneId, placementId) are
+ * deduplicated: the later op overwrites the earlier one, so only the
+ * freshest intent is sent. Ops for *different* keys accumulate in a
+ * process-wide buffer until a save resolves successfully, then the
+ * sent ops are drained. This matches the snapshot path's behavior
+ * where the later snapshot always wins, but preserves concurrent
+ * work on unrelated tokens that would otherwise be lost if a second
+ * call simply aborted the first's in-flight save.
+ */
+export function persistBoardStateOps(endpoint, ops, envelope = {}, options = {}) {
+  if (!endpoint || !Array.isArray(ops)) {
+    return null;
+  }
+
+  boardStateOpSendSequence += 1;
+  const sendSeq = boardStateOpSendSequence;
+
+  for (const op of ops) {
+    const key = boardStateOpDedupKey(op);
+    if (!key) {
+      continue;
+    }
+    pendingBoardStateOps.set(key, { op, seq: sendSeq });
+  }
+
+  const bufferedOps = Array.from(pendingBoardStateOps.values(), (entry) => entry.op);
+  if (bufferedOps.length === 0) {
+    return null;
+  }
+
+  const uniqueScenes = new Set();
+  for (const op of bufferedOps) {
+    if (op && typeof op.sceneId === 'string') {
+      uniqueScenes.add(op.sceneId);
+    }
+  }
+  if (
+    bufferedOps.length > PHASE_3B_MAX_OPS_PER_FLUSH ||
+    uniqueScenes.size > PHASE_3B_MAX_SCENES_PER_FLUSH
+  ) {
+    // Signal "use snapshot fallback" to the caller. The buffered ops
+    // are intentionally left in place: a subsequent snapshot save will
+    // persist the canonical state, and then the next op-based save
+    // (if any) will observe an empty or reduced buffer.
+    return { escape: true };
+  }
+
+  // Build the wire payload. `ops` lives at the top level; metadata and
+  // internal fields (`_version`, `_socketId`) ride in a small
+  // `boardState` envelope so the server's existing extraction logic
+  // for those fields works unchanged.
+  const boardStateEnvelope = {};
+  if (envelope && typeof envelope === 'object') {
+    if (envelope.metadata && typeof envelope.metadata === 'object') {
+      boardStateEnvelope.metadata = envelope.metadata;
+    }
+    if (typeof envelope._version === 'number' && envelope._version > 0) {
+      boardStateEnvelope._version = envelope._version;
+    }
+    if (typeof envelope._socketId === 'string' && envelope._socketId.trim()) {
+      boardStateEnvelope._socketId = envelope._socketId.trim();
+    }
+  }
+
+  const wirePayload = { ops: bufferedOps };
+  if (Object.keys(boardStateEnvelope).length > 0) {
+    wirePayload.boardState = boardStateEnvelope;
+  }
+
+  const normalizedOptions = { immediate: true, ...options };
+  const savePromise = queueSave(SAVE_KEY, wirePayload, endpoint, normalizedOptions);
+
+  if (savePromise && typeof savePromise.then === 'function') {
+    savePromise.then((result) => {
+      if (result?.success) {
+        for (const [key, entry] of pendingBoardStateOps) {
+          if (entry.seq <= sendSeq) {
+            pendingBoardStateOps.delete(key);
+          }
+        }
+      }
+      return result;
+    });
+  }
+
+  return savePromise;
+}
+
+/**
+ * Test-only helper. Clears the module-level ops buffer between tests
+ * so state from one test does not leak into another.
+ */
+export function _resetBoardStateOpsBufferForTest() {
+  boardStateOpSendSequence = 0;
+  pendingBoardStateOps.clear();
 }
 
 export function persistCombatState(endpoint, sceneId, combatState = {}, options = {}) {

--- a/dnd/vtt/assets/js/ui/board-interactions.js
+++ b/dnd/vtt/assets/js/ui/board-interactions.js
@@ -13,7 +13,11 @@ import {
   isDrawingToolMounted,
   consumeFullSyncNeeded,
 } from './drawing-tool.js';
-import { persistBoardState, persistCombatState } from '../services/board-state-service.js';
+import {
+  persistBoardState,
+  persistBoardStateOps,
+  persistCombatState,
+} from '../services/board-state-service.js';
 import { initializePusher, getSocketId, isPusherConnected } from '../services/pusher-service.js';
 import {
   PLAYER_VISIBLE_TOKEN_FOLDER,
@@ -2202,7 +2206,15 @@ export function mountBoardInteractions(store, routes = {}) {
   updateStartCombatButton();
   updateCombatModeIndicators();
 
-  const persistBoardStateSnapshot = (options = {}) => {
+  // Phase 3-B (commit 2): when true, token-drag saves go out as delta
+  // ops (`{ops: [{type: 'placement.move', ...}]}`) instead of full
+  // snapshots. Flip to `false` to force the legacy snapshot path for
+  // every save while the op path is bedding in. Only placement.move is
+  // routed through ops today; every other save type still uses the
+  // snapshot path regardless of this flag.
+  const USE_DELTA_SAVES = true;
+
+  const persistBoardStateSnapshot = (options = {}, opsOverride = null) => {
     if (!routes?.state || typeof boardApi.getState !== 'function') {
       console.warn('[VTT] Cannot persist board state: routes.state missing or boardApi.getState unavailable');
       return;
@@ -2216,25 +2228,39 @@ export function mountBoardInteractions(store, routes = {}) {
     }
 
     const isGmUser = Boolean(latest?.user?.isGM);
-    // Use delta-only saves when we have dirty tracking info
-    const useDelta = hasDirtyState();
-    const snapshot = buildBoardStateSnapshotForPersistence(boardState, { isGm: isGmUser, deltaOnly: useDelta });
-    if (!snapshot) {
-      console.warn('[VTT] Cannot persist board state: failed to build snapshot');
-      clearDirtyTracking(); // Clear dirty state even on failure
-      return;
-    }
 
-    // Skip save if delta mode but nothing to save
-    if (useDelta && Object.keys(snapshot).length === 0) {
-      console.log('[VTT] Skipping save: no dirty entities to persist');
-      clearDirtyTracking();
-      return;
-    }
+    // Phase 3-B: if the caller passed a non-empty ops list AND the
+    // feature flag is on, take the delta-op save path. Otherwise build
+    // a full snapshot as before. The metadata / version / socket-id
+    // wiring below is shared so both paths end up in the same pending
+    // save tracking and response handler.
+    const useOpsPath =
+      USE_DELTA_SAVES && Array.isArray(opsOverride) && opsOverride.length > 0;
 
-    // Mark as delta save for server-side handling
-    if (useDelta) {
-      snapshot._deltaOnly = true;
+    let snapshot = null;
+    let useDelta = false;
+
+    if (!useOpsPath) {
+      // Use delta-only saves when we have dirty tracking info
+      useDelta = hasDirtyState();
+      snapshot = buildBoardStateSnapshotForPersistence(boardState, { isGm: isGmUser, deltaOnly: useDelta });
+      if (!snapshot) {
+        console.warn('[VTT] Cannot persist board state: failed to build snapshot');
+        clearDirtyTracking(); // Clear dirty state even on failure
+        return;
+      }
+
+      // Skip save if delta mode but nothing to save
+      if (useDelta && Object.keys(snapshot).length === 0) {
+        console.log('[VTT] Skipping save: no dirty entities to persist');
+        clearDirtyTracking();
+        return;
+      }
+
+      // Mark as delta save for server-side handling
+      if (useDelta) {
+        snapshot._deltaOnly = true;
+      }
     }
 
     const previousMetadata = cloneBoardSection(boardState.metadata ?? boardState.meta);
@@ -2257,17 +2283,23 @@ export function mountBoardInteractions(store, routes = {}) {
       metadata.authorId = authorId;
     }
 
-    snapshot.metadata = metadata;
-
-    // Include current version for server-side conflict detection
-    if (currentBoardStateVersion > 0) {
-      snapshot._version = currentBoardStateVersion;
-    }
-
-    // Include Pusher socket ID so server can exclude us from the broadcast
+    // Snapshot path attaches metadata/version/socketId directly onto
+    // the snapshot blob; ops path will pass them via the envelope to
+    // `persistBoardStateOps` below.
     const socketId = getSocketId?.();
-    if (socketId) {
-      snapshot._socketId = socketId;
+
+    if (!useOpsPath) {
+      snapshot.metadata = metadata;
+
+      // Include current version for server-side conflict detection
+      if (currentBoardStateVersion > 0) {
+        snapshot._version = currentBoardStateVersion;
+      }
+
+      // Include Pusher socket ID so server can exclude us from the broadcast
+      if (socketId) {
+        snapshot._socketId = socketId;
+      }
     }
 
     boardApi.updateState?.((draft) => {
@@ -2276,10 +2308,29 @@ export function mountBoardInteractions(store, routes = {}) {
       Object.assign(metadataDraft, metadata);
     });
 
-    const snapshotHashCandidate = hashBoardStateSnapshot(snapshot);
-    const snapshotHash = snapshotHashCandidate ?? safeJsonStringify(snapshot) ?? null;
+    const hashInput = useOpsPath ? { ops: opsOverride, metadata, _version: currentBoardStateVersion } : snapshot;
+    const snapshotHashCandidate = hashBoardStateSnapshot(hashInput);
+    const snapshotHash = snapshotHashCandidate ?? safeJsonStringify(hashInput) ?? null;
 
-    const savePromise = persistBoardState(routes.state, snapshot, options);
+    let savePromise = null;
+    if (useOpsPath) {
+      const envelope = {
+        metadata,
+        _version: currentBoardStateVersion > 0 ? currentBoardStateVersion : undefined,
+        _socketId: socketId || undefined,
+      };
+      const opsResult = persistBoardStateOps(routes.state, opsOverride, envelope, options);
+      // Escape hatch: the ops buffer is too large or spans too many
+      // scenes for a single delta flush. Fall back to a full-snapshot
+      // save by re-entering without the override.
+      if (opsResult && typeof opsResult === 'object' && opsResult.escape === true) {
+        return persistBoardStateSnapshot(options, null);
+      }
+      savePromise = opsResult ?? null;
+    } else {
+      savePromise = persistBoardState(routes.state, snapshot, options);
+    }
+
     if (savePromise && typeof savePromise.then === 'function') {
       const pendingEntry = {
         promise: savePromise,
@@ -4660,7 +4711,40 @@ export function mountBoardInteractions(store, routes = {}) {
     if (movedCount) {
       // Mark only the moved placements as dirty
       movedIds.forEach((id) => markPlacementDirty(activeSceneId, id));
-      persistBoardStateSnapshot();
+
+      // Phase 3-B (commit 2): this is the one and only save path that
+      // currently goes out as delta ops. Every other write path in
+      // this file still calls `persistBoardStateSnapshot()` with no
+      // override, which preserves the legacy full-snapshot behavior.
+      // Build one `placement.move` op per moved id using the freshly
+      // committed column/row we just wrote into the store, then let
+      // `persistBoardStateSnapshot` route it through the ops path.
+      // The ops helper will fall back to a full snapshot on its own
+      // if the op list is too large or spans too many scenes.
+      let placementMoveOps = null;
+      if (USE_DELTA_SAVES) {
+        const latestPlacements =
+          boardApi.getState?.()?.boardState?.placements?.[activeSceneId] ?? [];
+        const ops = [];
+        movedIds.forEach((id) => {
+          const placement = latestPlacements.find((entry) => entry?.id === id);
+          if (!placement) {
+            return;
+          }
+          ops.push({
+            type: 'placement.move',
+            sceneId: activeSceneId,
+            placementId: id,
+            x: placement.column,
+            y: placement.row,
+          });
+        });
+        if (ops.length > 0) {
+          placementMoveOps = ops;
+        }
+      }
+
+      persistBoardStateSnapshot({}, placementMoveOps);
     }
 
     if (movedCount && status) {


### PR DESCRIPTION
## Summary

Implements the client-side delta-op save path for token drag operations, completing Phase 3-B commit 2. Token moves now send lightweight `{ops: [{type: 'placement.move', ...}]}` payloads instead of full board state snapshots, with automatic fallback to snapshots when the op buffer exceeds size thresholds.

## Key Changes

**Server-side (state.php)**
- Added `sanitizeBoardStateOps()` to validate incoming delta ops for shape and type
- Added `applyBoardStateOp()` to apply `placement.move` ops to the canonical board state within the state lock
- Modified the state update handler to accept and process ops from `payload.ops` alongside traditional snapshot updates
- Ops are applied before snapshot merging, allowing both paths to coexist

**Client-side (board-state-service.js)**
- Introduced `persistBoardStateOps()` function to queue delta-op saves with cross-call accumulation
- Implemented deduplication by (type, sceneId, placementId) so repeated moves of the same token coalesce
- Added escape hatch: returns `{escape: true}` when buffer exceeds `PHASE_3B_MAX_OPS_PER_FLUSH` (64 ops) or `PHASE_3B_MAX_SCENES_PER_FLUSH` (4 scenes), triggering fallback to snapshot
- Ops accumulate in a process-wide buffer while saves are in flight, protecting unrelated tokens from being lost if a second drag starts before the first save completes
- Successfully sent ops are drained from the buffer only after the save resolves

**UI Integration (board-interactions.js)**
- Added `USE_DELTA_SAVES` feature flag (currently enabled) to control the ops path
- Modified `persistBoardStateSnapshot()` to accept an optional `opsOverride` parameter
- When token drag completes, builds `placement.move` ops from the moved placements and routes them through the ops path
- Automatically falls back to full snapshot if the ops path returns the escape signal

**Tests (board-state-ops.test.mjs)**
- Comprehensive test suite covering wire format, same-token coalescing, cross-call accumulation, escape thresholds, and malformed op filtering

## Notable Implementation Details

- The ops wire format places `ops` at the top level and wraps metadata/version/socketId in a `boardState` envelope, allowing the server's existing field extraction logic to work unchanged
- Placement coordinates are converted from the wire format (`x`/`y`) to the internal format (`column`/`row`) during application
- `_lastModified` timestamps are updated on each op application to ensure downstream merges treat the move as newer than stale payloads
- The deduplication key includes both sceneId and placementId, allowing the same token to be moved in different scenes without collision
- Unknown op types are silently ignored, enabling forward compatibility with future op types from newer clients

https://claude.ai/code/session_01DXSTVtFWHYM6eKhc4VSnFG