### PR TITLE
Add placement.add/remove/update delta ops (phase 3-B commit 3)

### DIFF
--- a/dnd/vtt/api/state.php
+++ b/dnd/vtt/api/state.php
@@ -286,15 +286,22 @@ if (!defined('VTT_STATE_API_INCLUDE_ONLY')) {
                 // runs. Ops mutate the canonical state in place; the
                 // existing snapshot path, when a boardState payload is
                 // also present, will layer on top exactly as before.
-                // No client sends ops yet, so in practice `$ops` is
-                // always empty on this commit and this loop is a no-op.
+                // Phase 3-B (commit 3): `$isGm` is computed up-front
+                // now so it can be forwarded to `applyBoardStateOp`,
+                // which uses it to gate destructive op types like
+                // `placement.remove` behind the same GM-only rule the
+                // snapshot path already enforces. This prevents a
+                // player from bypassing the snapshot path's
+                // timestamp-merge (which cannot delete) by sending a
+                // `placement.remove` op directly.
+                $isGm = (bool) ($auth['isGM'] ?? false);
                 if (!empty($ops)) {
+                    $opContext = ['isGm' => $isGm];
                     foreach ($ops as $op) {
-                        $nextState = applyBoardStateOp($nextState, $op);
+                        $nextState = applyBoardStateOp($nextState, $op, $opContext);
                     }
                 }
 
-                $isGm = (bool) ($auth['isGM'] ?? false);
                 if (!$isGm) {
                     $combatUpdates = [];
                     if (isset($updates['sceneState']) && is_array($updates['sceneState'])) {
@@ -725,40 +732,41 @@ function sanitizeBoardStateOps(array $rawOps): array
 /**
  * Phase 3-B: Apply a single delta op to an in-memory board state array.
  *
- * Commit 1 supports only `placement.move`, which updates the `x`/`y`
- * coordinates of an existing placement in a given scene. Unknown or
- * unsupported op types are ignored so older servers can tolerate
- * payloads from newer clients without erroring out. The state returned
- * is always a valid board state — if the op cannot be applied (missing
- * scene, missing placement, bad coordinates), the input is returned
- * unchanged.
+ * Commit 1 introduced `placement.move`. Commit 3 adds `placement.add`,
+ * `placement.remove`, and `placement.update` so every placement-level
+ * mutation on the client can travel as a typed op instead of a full
+ * snapshot. Unknown or unsupported op types are ignored so older
+ * servers can tolerate payloads from newer clients without erroring
+ * out. The state returned is always a valid board state — if the op
+ * cannot be applied (missing scene, missing placement, bad fields,
+ * permission denied for a non-GM destructive op), the input is
+ * returned unchanged.
  *
  * The caller is responsible for running this inside the state lock so
  * two concurrent writers cannot interleave mutations on the same
- * placement.
+ * placement. The caller is also responsible for setting
+ * `$context['isGm']` so destructive ops can be gated: without this
+ * flag, a non-GM caller could bypass the snapshot path's
+ * timestamp-merge-only policy by sending `placement.remove` directly.
  *
  * @param array<string,mixed> $state
  * @param array<string,mixed> $op
+ * @param array<string,mixed> $context Optional context with keys:
+ *   - `isGm` (bool): caller is GM. Defaults to false. Required for
+ *     destructive ops (`placement.remove`) to be applied.
  * @return array<string,mixed>
  */
-function applyBoardStateOp(array $state, array $op): array
+function applyBoardStateOp(array $state, array $op, array $context = []): array
 {
     $type = isset($op['type']) && is_string($op['type']) ? $op['type'] : '';
+    $isGm = (bool) ($context['isGm'] ?? false);
 
     if ($type === 'placement.move') {
         $sceneId = isset($op['sceneId']) && is_string($op['sceneId']) ? trim($op['sceneId']) : '';
         if ($sceneId === '') {
             return $state;
         }
-        $placementId = '';
-        if (isset($op['placementId'])) {
-            $rawId = $op['placementId'];
-            if (is_string($rawId)) {
-                $placementId = trim($rawId);
-            } elseif (is_int($rawId) || is_float($rawId)) {
-                $placementId = (string) $rawId;
-            }
-        }
+        $placementId = extractBoardStateOpPlacementId($op);
         if ($placementId === '') {
             return $state;
         }
@@ -802,10 +810,166 @@ function applyBoardStateOp(array $state, array $op): array
         return $state;
     }
 
+    if ($type === 'placement.add') {
+        // `placement.add` carries the full new placement entry in the
+        // `placement` field. If a placement with the same id already
+        // exists in the scene, it is replaced in-place (same semantics
+        // as a later-wins dedup on the client). Non-GM callers are
+        // allowed — the snapshot path already accepts new placements
+        // from players via `mergeSceneEntriesByTimestamp`.
+        $sceneId = isset($op['sceneId']) && is_string($op['sceneId']) ? trim($op['sceneId']) : '';
+        if ($sceneId === '') {
+            return $state;
+        }
+        if (!isset($op['placement']) || !is_array($op['placement'])) {
+            return $state;
+        }
+        $placement = $op['placement'];
+        $placementId = extractBoardEntryIdentifier($placement);
+        if ($placementId === null || $placementId === '') {
+            return $state;
+        }
+
+        if (!isset($state['placements']) || !is_array($state['placements'])) {
+            $state['placements'] = [];
+        }
+        if (!isset($state['placements'][$sceneId]) || !is_array($state['placements'][$sceneId])) {
+            $state['placements'][$sceneId] = [];
+        }
+
+        // Stamp `_lastModified` so subsequent timestamp-based merges
+        // treat this add as newer than any stale payload already in
+        // flight. This also mirrors the client-side stamping done at
+        // drop time.
+        $nowMs = (int) round(microtime(true) * 1000);
+        $placement['_lastModified'] = $nowMs;
+
+        $replaced = false;
+        foreach ($state['placements'][$sceneId] as $idx => $existing) {
+            if (!is_array($existing)) {
+                continue;
+            }
+            $existingId = extractBoardEntryIdentifier($existing);
+            if ($existingId === $placementId) {
+                $state['placements'][$sceneId][$idx] = $placement;
+                $replaced = true;
+                break;
+            }
+        }
+        if (!$replaced) {
+            $state['placements'][$sceneId][] = $placement;
+        }
+        return $state;
+    }
+
+    if ($type === 'placement.remove') {
+        // Gate removals behind the GM-only rule the snapshot path
+        // already enforces (snapshot path uses `mergeSceneEntriesByTimestamp`
+        // which never deletes, so player removals are silently dropped
+        // today). We do the same here by ignoring the op when the
+        // caller is not a GM.
+        if (!$isGm) {
+            return $state;
+        }
+        $sceneId = isset($op['sceneId']) && is_string($op['sceneId']) ? trim($op['sceneId']) : '';
+        if ($sceneId === '') {
+            return $state;
+        }
+        $placementId = extractBoardStateOpPlacementId($op);
+        if ($placementId === '') {
+            return $state;
+        }
+        if (!isset($state['placements'][$sceneId]) || !is_array($state['placements'][$sceneId])) {
+            return $state;
+        }
+        $filtered = [];
+        foreach ($state['placements'][$sceneId] as $entry) {
+            if (!is_array($entry)) {
+                $filtered[] = $entry;
+                continue;
+            }
+            $entryId = extractBoardEntryIdentifier($entry);
+            if ($entryId === $placementId) {
+                continue;
+            }
+            $filtered[] = $entry;
+        }
+        // Re-index so json_encode serializes as a JSON array, not an
+        // object with numeric string keys.
+        $state['placements'][$sceneId] = array_values($filtered);
+        return $state;
+    }
+
+    if ($type === 'placement.update') {
+        // `placement.update` carries a shallow `patch` object that is
+        // shallow-merged onto an existing placement. Fields not
+        // present in the patch are left untouched. The `id` field is
+        // never overwritten. `_lastModified` is always re-stamped by
+        // the server so timestamp-based merges downstream treat this
+        // as the newest version.
+        $sceneId = isset($op['sceneId']) && is_string($op['sceneId']) ? trim($op['sceneId']) : '';
+        if ($sceneId === '') {
+            return $state;
+        }
+        $placementId = extractBoardStateOpPlacementId($op);
+        if ($placementId === '') {
+            return $state;
+        }
+        if (!isset($op['patch']) || !is_array($op['patch'])) {
+            return $state;
+        }
+        $patch = $op['patch'];
+        if (!isset($state['placements'][$sceneId]) || !is_array($state['placements'][$sceneId])) {
+            return $state;
+        }
+        $nowMs = (int) round(microtime(true) * 1000);
+        foreach ($state['placements'][$sceneId] as $idx => $entry) {
+            if (!is_array($entry)) {
+                continue;
+            }
+            $entryId = extractBoardEntryIdentifier($entry);
+            if ($entryId === null || $entryId !== $placementId) {
+                continue;
+            }
+            foreach ($patch as $key => $value) {
+                if ($key === 'id') {
+                    continue;
+                }
+                $entry[$key] = $value;
+            }
+            $entry['_lastModified'] = $nowMs;
+            $state['placements'][$sceneId][$idx] = $entry;
+            break;
+        }
+        return $state;
+    }
+
     // Unknown op types are silently ignored so older servers can
-    // tolerate payloads from newer clients. Commits 2+ will add more
-    // `placement.*`, `template.*`, and `drawing.*` op types here.
+    // tolerate payloads from newer clients. Commits 4+ will add
+    // `template.*` and `drawing.*` op types here.
     return $state;
+}
+
+/**
+ * Phase 3-B: Normalize a placementId field on an incoming op. Accepts
+ * strings, ints, or floats and returns a trimmed string. Returns an
+ * empty string if the field is missing or empty.
+ *
+ * @param array<string,mixed> $op
+ */
+function extractBoardStateOpPlacementId(array $op): string
+{
+    if (!isset($op['placementId'])) {
+        return '';
+    }
+    $raw = $op['placementId'];
+    if (is_string($raw)) {
+        return trim($raw);
+    }
+    if (is_int($raw) || is_float($raw)) {
+        return (string) $raw;
+    }
+    return '';
 }
 
 /**

--- a/dnd/vtt/assets/js/services/__tests__/board-state-ops.test.mjs
+++ b/dnd/vtt/assets/js/services/__tests__/board-state-ops.test.mjs
@@ -241,3 +241,339 @@ describe('Board State – delta ops persistence (phase 3-B commit 2)', () => {
     assert.equal(capturedPayloads[0].ops[0].placementId, 'hero');
   });
 });
+
+// ---------------------------------------------------------------------------
+// Phase 3-B (commit 3): the delta-ops path now covers every placement
+// mutation — add, remove, and update — in addition to the moves that
+// commit 2 shipped. These tests lock in the wire shape of each new op
+// type, the dedup key behavior (per-type keys, same-key later-wins for
+// add/remove, shallow-merge-patches for two consecutive updates), and
+// the accumulation of cross-type ops on the same placement so the
+// server applies them in the order they were produced.
+// ---------------------------------------------------------------------------
+
+describe('Board State – delta ops persistence (phase 3-B commit 3)', () => {
+  let originalFetch;
+  let originalWindow;
+  let capturedPayloads;
+  let pendingFetchResolvers;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    originalWindow = globalThis.window;
+    capturedPayloads = [];
+    pendingFetchResolvers = [];
+
+    globalThis.fetch = async (_url, options = {}) => {
+      if (options?.body) {
+        capturedPayloads.push(JSON.parse(options.body));
+      }
+      return { ok: true, json: async () => ({ success: true, data: { _version: 99 } }) };
+    };
+
+    globalThis.window = {
+      ...(globalThis.window ?? {}),
+      setTimeout: (fn, _ms) => {
+        fn();
+        return 0;
+      },
+    };
+  });
+
+  afterEach(async () => {
+    const { _resetBoardStateOpsBufferForTest } = await import('../board-state-service.js');
+    _resetBoardStateOpsBufferForTest();
+
+    if (originalFetch === undefined) {
+      delete globalThis.fetch;
+    } else {
+      globalThis.fetch = originalFetch;
+    }
+    if (originalWindow === undefined) {
+      delete globalThis.window;
+    } else {
+      globalThis.window = originalWindow;
+    }
+    while (pendingFetchResolvers.length > 0) {
+      const resolve = pendingFetchResolvers.shift();
+      resolve?.({ ok: true, json: async () => ({ success: true, data: { _version: 1 } }) });
+    }
+  });
+
+  test('placement.add ships the full placement object under payload.ops', async () => {
+    const { persistBoardStateOps, _resetBoardStateOpsBufferForTest } = await import(
+      '../board-state-service.js'
+    );
+    _resetBoardStateOpsBufferForTest();
+
+    const placement = {
+      id: 'new-hero',
+      tokenId: 'lib-hero',
+      column: 5,
+      row: 7,
+      width: 1,
+      height: 1,
+      hidden: false,
+    };
+
+    await persistBoardStateOps(
+      '/api/state',
+      [{ type: 'placement.add', sceneId: 'scene-1', placement }],
+      {}
+    );
+
+    assert.equal(capturedPayloads.length, 1);
+    const op = capturedPayloads[0].ops[0];
+    assert.equal(op.type, 'placement.add');
+    assert.equal(op.sceneId, 'scene-1');
+    assert.deepEqual(op.placement, placement);
+  });
+
+  test('placement.remove ships just sceneId + placementId', async () => {
+    const { persistBoardStateOps, _resetBoardStateOpsBufferForTest } = await import(
+      '../board-state-service.js'
+    );
+    _resetBoardStateOpsBufferForTest();
+
+    await persistBoardStateOps(
+      '/api/state',
+      [{ type: 'placement.remove', sceneId: 'scene-1', placementId: 'goblin-42' }],
+      {}
+    );
+
+    assert.equal(capturedPayloads.length, 1);
+    const op = capturedPayloads[0].ops[0];
+    assert.deepEqual(op, {
+      type: 'placement.remove',
+      sceneId: 'scene-1',
+      placementId: 'goblin-42',
+    });
+  });
+
+  test('placement.update ships a shallow patch object', async () => {
+    const { persistBoardStateOps, _resetBoardStateOpsBufferForTest } = await import(
+      '../board-state-service.js'
+    );
+    _resetBoardStateOpsBufferForTest();
+
+    await persistBoardStateOps(
+      '/api/state',
+      [
+        {
+          type: 'placement.update',
+          sceneId: 'scene-1',
+          placementId: 'hero',
+          patch: { hp: { current: '5', max: '10' } },
+        },
+      ],
+      {}
+    );
+
+    assert.equal(capturedPayloads.length, 1);
+    const op = capturedPayloads[0].ops[0];
+    assert.equal(op.type, 'placement.update');
+    assert.deepEqual(op.patch, { hp: { current: '5', max: '10' } });
+  });
+
+  test('two placement.update ops for the same placement shallow-merge their patches', async () => {
+    const { persistBoardStateOps, _resetBoardStateOpsBufferForTest } = await import(
+      '../board-state-service.js'
+    );
+    _resetBoardStateOpsBufferForTest();
+
+    // Hold the first fetch open so both ops land in the pending buffer.
+    globalThis.fetch = async (_url, options = {}) => {
+      if (options?.body) {
+        capturedPayloads.push(JSON.parse(options.body));
+      }
+      return new Promise((resolve) => {
+        pendingFetchResolvers.push(resolve);
+      });
+    };
+
+    persistBoardStateOps(
+      '/api/state',
+      [
+        {
+          type: 'placement.update',
+          sceneId: 'scene-1',
+          placementId: 'hero',
+          patch: { hp: { current: '5', max: '10' } },
+        },
+      ],
+      {}
+    );
+    persistBoardStateOps(
+      '/api/state',
+      [
+        {
+          type: 'placement.update',
+          sceneId: 'scene-1',
+          placementId: 'hero',
+          patch: { conditions: [{ name: 'prone' }] },
+        },
+      ],
+      {}
+    );
+
+    const secondPayload = capturedPayloads[capturedPayloads.length - 1];
+    assert.ok(secondPayload, 'a second POST should have been initiated');
+    assert.equal(secondPayload.ops.length, 1, 'same-placement updates coalesce to one op');
+    assert.deepEqual(
+      secondPayload.ops[0].patch,
+      {
+        hp: { current: '5', max: '10' },
+        conditions: [{ name: 'prone' }],
+      },
+      'both field changes must survive the shallow-merge',
+    );
+  });
+
+  test('later placement.update for the same key wins when patch fields overlap', async () => {
+    const { persistBoardStateOps, _resetBoardStateOpsBufferForTest } = await import(
+      '../board-state-service.js'
+    );
+    _resetBoardStateOpsBufferForTest();
+
+    globalThis.fetch = async (_url, options = {}) => {
+      if (options?.body) {
+        capturedPayloads.push(JSON.parse(options.body));
+      }
+      return new Promise((resolve) => {
+        pendingFetchResolvers.push(resolve);
+      });
+    };
+
+    persistBoardStateOps(
+      '/api/state',
+      [
+        {
+          type: 'placement.update',
+          sceneId: 'scene-1',
+          placementId: 'hero',
+          patch: { hp: { current: '5', max: '10' } },
+        },
+      ],
+      {}
+    );
+    persistBoardStateOps(
+      '/api/state',
+      [
+        {
+          type: 'placement.update',
+          sceneId: 'scene-1',
+          placementId: 'hero',
+          patch: { hp: { current: '3', max: '10' } },
+        },
+      ],
+      {}
+    );
+
+    const secondPayload = capturedPayloads[capturedPayloads.length - 1];
+    assert.equal(secondPayload.ops.length, 1);
+    assert.deepEqual(secondPayload.ops[0].patch, { hp: { current: '3', max: '10' } });
+  });
+
+  test('add, update, and remove on the same placement coexist in one flush (per-type keys)', async () => {
+    const {
+      persistBoardStateOps,
+      _resetBoardStateOpsBufferForTest,
+    } = await import('../board-state-service.js');
+    _resetBoardStateOpsBufferForTest();
+
+    // Hold each fetch open so every call gets merged into the buffer
+    // before any save resolves.
+    globalThis.fetch = async (_url, options = {}) => {
+      if (options?.body) {
+        capturedPayloads.push(JSON.parse(options.body));
+      }
+      return new Promise((resolve) => {
+        pendingFetchResolvers.push(resolve);
+      });
+    };
+
+    persistBoardStateOps(
+      '/api/state',
+      [
+        {
+          type: 'placement.add',
+          sceneId: 'scene-1',
+          placement: { id: 'hero', column: 1, row: 1 },
+        },
+      ],
+      {}
+    );
+    persistBoardStateOps(
+      '/api/state',
+      [
+        {
+          type: 'placement.update',
+          sceneId: 'scene-1',
+          placementId: 'hero',
+          patch: { hp: { current: '5', max: '10' } },
+        },
+      ],
+      {}
+    );
+    persistBoardStateOps(
+      '/api/state',
+      [
+        {
+          type: 'placement.remove',
+          sceneId: 'scene-1',
+          placementId: 'hero',
+        },
+      ],
+      {}
+    );
+
+    const lastPayload = capturedPayloads[capturedPayloads.length - 1];
+    assert.ok(lastPayload);
+    const types = lastPayload.ops.map((op) => op.type).sort();
+    assert.deepEqual(
+      types,
+      ['placement.add', 'placement.remove', 'placement.update'],
+      'all three ops must be present because they have distinct dedup keys',
+    );
+    // Insertion order in the buffer must match the call order so the
+    // server applies add → update → remove.
+    assert.deepEqual(
+      lastPayload.ops.map((op) => op.type),
+      ['placement.add', 'placement.update', 'placement.remove'],
+    );
+  });
+
+  test('malformed new-type ops are silently dropped', async () => {
+    const { persistBoardStateOps, _resetBoardStateOpsBufferForTest } = await import(
+      '../board-state-service.js'
+    );
+    _resetBoardStateOpsBufferForTest();
+
+    await persistBoardStateOps(
+      '/api/state',
+      [
+        // placement.add without placement object
+        { type: 'placement.add', sceneId: 'scene-1' },
+        // placement.add with placement but no id
+        { type: 'placement.add', sceneId: 'scene-1', placement: { column: 1, row: 1 } },
+        // placement.remove without placementId
+        { type: 'placement.remove', sceneId: 'scene-1' },
+        // placement.update without patch
+        { type: 'placement.update', sceneId: 'scene-1', placementId: 'hero' },
+        // well-formed survivor
+        {
+          type: 'placement.update',
+          sceneId: 'scene-1',
+          placementId: 'hero',
+          patch: { hidden: true },
+        },
+      ],
+      {}
+    );
+
+    assert.equal(capturedPayloads.length, 1);
+    assert.equal(capturedPayloads[0].ops.length, 1, 'only the well-formed op should survive');
+    assert.equal(capturedPayloads[0].ops[0].type, 'placement.update');
+    assert.deepEqual(capturedPayloads[0].ops[0].patch, { hidden: true });
+  });
+});

--- a/dnd/vtt/assets/js/services/board-state-service.js
+++ b/dnd/vtt/assets/js/services/board-state-service.js
@@ -22,6 +22,16 @@ export const PHASE_3B_MAX_SCENES_PER_FLUSH = 4;
 // from the buffer only after the save that carried them resolves
 // successfully, so an aborted/failed save leaves its ops in place for
 // the next flush to pick up.
+//
+// Phase 3-B (commit 3): `placement.add`, `placement.remove`, and
+// `placement.update` join `placement.move` in the buffer. Keys are
+// per-type so cross-type ops on the same placement are preserved in
+// insertion order (e.g. an add followed by an update lands in that
+// order on the server). Same-key collisions follow the commit-2
+// convention (later wins) for add/remove/move, but two
+// `placement.update` ops for the same placement instead *shallow-merge*
+// their patches so distinct field changes (HP and conditions, for
+// example) both reach the server.
 let boardStateOpSendSequence = 0;
 const pendingBoardStateOps = new Map();
 
@@ -29,13 +39,41 @@ function boardStateOpDedupKey(op) {
   if (!op || typeof op !== 'object') {
     return null;
   }
+  const sceneId = typeof op.sceneId === 'string' ? op.sceneId.trim() : '';
+  if (!sceneId) {
+    return null;
+  }
   if (op.type === 'placement.move') {
-    const sceneId = typeof op.sceneId === 'string' ? op.sceneId.trim() : '';
     const placementId = typeof op.placementId === 'string' ? op.placementId.trim() : '';
-    if (!sceneId || !placementId) {
+    if (!placementId) {
       return null;
     }
     return `placement.move:${sceneId}:${placementId}`;
+  }
+  if (op.type === 'placement.remove') {
+    const placementId = typeof op.placementId === 'string' ? op.placementId.trim() : '';
+    if (!placementId) {
+      return null;
+    }
+    return `placement.remove:${sceneId}:${placementId}`;
+  }
+  if (op.type === 'placement.update') {
+    const placementId = typeof op.placementId === 'string' ? op.placementId.trim() : '';
+    if (!placementId || !op.patch || typeof op.patch !== 'object') {
+      return null;
+    }
+    return `placement.update:${sceneId}:${placementId}`;
+  }
+  if (op.type === 'placement.add') {
+    const placement = op.placement;
+    if (!placement || typeof placement !== 'object') {
+      return null;
+    }
+    const placementId = typeof placement.id === 'string' ? placement.id.trim() : '';
+    if (!placementId) {
+      return null;
+    }
+    return `placement.add:${sceneId}:${placementId}`;
   }
   return null;
 }
@@ -122,6 +160,30 @@ export function persistBoardStateOps(endpoint, ops, envelope = {}, options = {})
     const key = boardStateOpDedupKey(op);
     if (!key) {
       continue;
+    }
+    // Phase 3-B (commit 3): two `placement.update` ops for the same
+    // placement shallow-merge their patches. This preserves distinct
+    // field changes (e.g. an HP edit followed by a condition toggle)
+    // that would otherwise be clobbered by a plain later-wins replace.
+    // All other op types keep the commit-2 "later wins" semantic.
+    if (op.type === 'placement.update') {
+      const existing = pendingBoardStateOps.get(key);
+      if (
+        existing &&
+        existing.op &&
+        existing.op.type === 'placement.update' &&
+        existing.op.patch &&
+        typeof existing.op.patch === 'object' &&
+        op.patch &&
+        typeof op.patch === 'object'
+      ) {
+        const mergedPatch = { ...existing.op.patch, ...op.patch };
+        pendingBoardStateOps.set(key, {
+          op: { ...op, patch: mergedPatch },
+          seq: sendSeq,
+        });
+        continue;
+      }
     }
     pendingBoardStateOps.set(key, { op, seq: sendSeq });
   }

--- a/dnd/vtt/assets/js/ui/board-interactions.js
+++ b/dnd/vtt/assets/js/ui/board-interactions.js
@@ -1668,6 +1668,67 @@ export function mountBoardInteractions(store, routes = {}) {
            dirtyTopLevel.size > 0;
   }
 
+  // Phase 3-B (commit 3): true when any NON-placement entity is dirty.
+  // Used at placement-mutation call sites to decide whether it is safe
+  // to route through the delta-op path: the ops path only carries
+  // placement ops today, so if templates/drawings/scene state/pings/etc.
+  // are also waiting to flush, we must fall back to the snapshot path
+  // to avoid dropping those changes on the floor. Commits 4+ will shrink
+  // what counts as "non-placement" as more op types come online.
+  function hasNonPlacementDirtyState() {
+    return dirtyTemplates.size > 0 ||
+           dirtyDrawings.size > 0 ||
+           drawingFullReplaceScenes.size > 0 ||
+           dirtyPings ||
+           dirtySceneState.size > 0 ||
+           dirtyTopLevel.size > 0;
+  }
+
+  // Phase 3-B (commit 3): helpers for building `placement.update` ops
+  // via a before/after diff. Mutator-based update call sites
+  // (`updatePlacementById`, `updatePlacementsByIds`) snapshot the
+  // placement before running the mutator, then compare top-level keys
+  // to ship only the fields that actually changed. The server applies
+  // the patch as a shallow merge. `id` is never in the patch (the
+  // server refuses to overwrite it anyway) and `_lastModified` is
+  // excluded so the server's own fresh stamp wins.
+  function clonePlacementForDiff(placement) {
+    if (!placement || typeof placement !== 'object') {
+      return null;
+    }
+    try {
+      return JSON.parse(JSON.stringify(placement));
+    } catch (error) {
+      return null;
+    }
+  }
+
+  function buildPlacementUpdatePatch(before, after) {
+    if (!after || typeof after !== 'object') {
+      return null;
+    }
+    const beforeObj = before && typeof before === 'object' ? before : {};
+    const patch = {};
+    const keys = new Set([...Object.keys(beforeObj), ...Object.keys(after)]);
+    for (const key of keys) {
+      if (key === 'id' || key === '_lastModified') {
+        continue;
+      }
+      const beforeVal = beforeObj[key];
+      const afterVal = after[key];
+      let changed = false;
+      try {
+        changed = JSON.stringify(beforeVal) !== JSON.stringify(afterVal);
+      } catch (error) {
+        changed = true;
+      }
+      if (changed) {
+        patch[key] = afterVal;
+      }
+    }
+    return Object.keys(patch).length > 0 ? patch : null;
+  }
+
   // Track dirty combat state fields to prevent remote state from overwriting local changes
   // This is separate from the general dirty tracking because combat state has special
   // sync logic in syncCombatStateToStore that handles remote vs local state merging
@@ -2206,12 +2267,21 @@ export function mountBoardInteractions(store, routes = {}) {
   updateStartCombatButton();
   updateCombatModeIndicators();
 
-  // Phase 3-B (commit 2): when true, token-drag saves go out as delta
-  // ops (`{ops: [{type: 'placement.move', ...}]}`) instead of full
-  // snapshots. Flip to `false` to force the legacy snapshot path for
-  // every save while the op path is bedding in. Only placement.move is
-  // routed through ops today; every other save type still uses the
-  // snapshot path regardless of this flag.
+  // Phase 3-B: when true, placement mutations go out as delta ops
+  // instead of full snapshots. Flip to `false` to force the legacy
+  // snapshot path for every save while the op path is bedding in.
+  //
+  //   - commit 2: `placement.move` on drag-release (`commitDragPreview`)
+  //   - commit 3: `placement.move` on arrow-key nudge, `placement.add`
+  //     on token drop, `placement.remove` on token delete (GM only),
+  //     and `placement.update` on every mutator-driven placement edit
+  //     (HP/stamina, conditions, hidden flag, triggered action, etc.)
+  //
+  // Templates, drawings, pings, scene state, fog, combat, and overlay
+  // saves still go through the snapshot path regardless of this flag;
+  // those will be moved to ops in commits 4-5. Call sites that detect
+  // non-placement dirty state also fall back to the snapshot path so
+  // the ops path never silently drops templates/drawings/etc.
   const USE_DELTA_SAVES = true;
 
   const persistBoardStateSnapshot = (options = {}, opsOverride = null) => {
@@ -3794,7 +3864,25 @@ export function mountBoardInteractions(store, routes = {}) {
 
     // Mark placement as dirty for delta save
     markPlacementDirty(activeSceneId, placement.id);
-    persistBoardStateSnapshot();
+
+    // Phase 3-B (commit 3): route the drop through a `placement.add`
+    // op when the delta-saves feature flag is on AND no non-placement
+    // state is also waiting to flush. The ops path cannot carry
+    // templates/drawings/etc. today, so if anything else is dirty we
+    // fall back to the legacy snapshot path to avoid losing those
+    // changes. This guard is applied at every commit-3 call site for
+    // the same reason.
+    let tokenAddOps = null;
+    if (USE_DELTA_SAVES && !hasNonPlacementDirtyState()) {
+      tokenAddOps = [
+        {
+          type: 'placement.add',
+          sceneId: activeSceneId,
+          placement,
+        },
+      ];
+    }
+    persistBoardStateSnapshot({}, tokenAddOps);
 
     // For PC folder tokens, fetch and apply character sheet stamina
     if (isTokenSourcePlayerVisible(template)) {
@@ -5274,7 +5362,35 @@ export function mountBoardInteractions(store, routes = {}) {
     if (moved) {
       // Mark moved placements as dirty for delta save
       movedIds.forEach((id) => markPlacementDirty(activeSceneId, id));
-      persistBoardStateSnapshot();
+
+      // Phase 3-B (commit 3): arrow-key movement is a pure
+      // placement.move path, same shape as the drag-release path
+      // (commit 2). Build one `placement.move` op per moved id from
+      // the freshly-committed store and hand it to
+      // `persistBoardStateSnapshot` so the delta-op save path runs.
+      let keyboardMoveOps = null;
+      if (USE_DELTA_SAVES && !hasNonPlacementDirtyState()) {
+        const latestPlacements =
+          boardApi.getState?.()?.boardState?.placements?.[activeSceneId] ?? [];
+        const opsList = [];
+        movedIds.forEach((id) => {
+          const placement = latestPlacements.find((entry) => entry?.id === id);
+          if (!placement) {
+            return;
+          }
+          opsList.push({
+            type: 'placement.move',
+            sceneId: activeSceneId,
+            placementId: id,
+            x: placement.column,
+            y: placement.row,
+          });
+        });
+        if (opsList.length > 0) {
+          keyboardMoveOps = opsList;
+        }
+      }
+      persistBoardStateSnapshot({}, keyboardMoveOps);
     }
 
     if (moved && status) {
@@ -5306,6 +5422,7 @@ export function mountBoardInteractions(store, routes = {}) {
     }
 
     let removedCount = 0;
+    const removedIds = [];
     boardApi.updateState?.((draft) => {
       const scenePlacements = ensureScenePlacementDraft(draft, activeSceneId);
       if (!Array.isArray(scenePlacements) || !scenePlacements.length) {
@@ -5322,6 +5439,7 @@ export function mountBoardInteractions(store, routes = {}) {
         if (!isGM && placement.hidden) {
           return true;
         }
+        removedIds.push(placement.id);
         return false;
       });
       removedCount = scenePlacements.length - nextPlacements.length;
@@ -5331,10 +5449,27 @@ export function mountBoardInteractions(store, routes = {}) {
     });
 
     if (removedCount > 0) {
-      // Clear dirty tracking to force a full state save for deletions
-      // Delta saves can't represent deletions, so we need to send full state
-      clearDirtyTracking();
-      persistBoardStateSnapshot();
+      // Phase 3-B (commit 3): route token deletion through
+      // `placement.remove` ops when it is safe (delta-saves flag on,
+      // no non-placement dirty state pending, and the caller is a GM —
+      // the server ignores remove ops from non-GM callers to match the
+      // snapshot path's "players can't delete" policy). When any of
+      // those conditions fails we fall back to the legacy behavior of
+      // clearing dirty tracking and sending a full snapshot so the
+      // delete still reaches the server.
+      let removeOps = null;
+      if (USE_DELTA_SAVES && isGM && !hasNonPlacementDirtyState()) {
+        removeOps = removedIds.map((id) => ({
+          type: 'placement.remove',
+          sceneId: activeSceneId,
+          placementId: id,
+        }));
+      } else {
+        // Clear dirty tracking to force a full state save for deletions
+        // Delta saves can't represent deletions, so we need to send full state
+        clearDirtyTracking();
+      }
+      persistBoardStateSnapshot({}, removeOps);
       selectedTokenIds.clear();
       notifySelectionChanged();
       if (status) {
@@ -10284,6 +10419,7 @@ export function mountBoardInteractions(store, routes = {}) {
     }
 
     let mutated = false;
+    const mutatedIds = [];
     boardApi.updateState?.((draft) => {
       const scenePlacements = ensureScenePlacementDraft(draft, activeSceneId);
       scenePlacements.forEach((placement) => {
@@ -10293,12 +10429,28 @@ export function mountBoardInteractions(store, routes = {}) {
         if (placement.triggeredActionReady !== true) {
           placement.triggeredActionReady = true;
           mutated = true;
+          if (placement.id) {
+            mutatedIds.push(placement.id);
+          }
         }
       });
     });
 
     if (mutated) {
-      persistBoardStateSnapshot();
+      // Phase 3-B (commit 3): every reset here is the same single-
+      // field flip (`triggeredActionReady: true`) across many
+      // placements. Emit one `placement.update` op per mutated id
+      // instead of a full snapshot.
+      let resetOps = null;
+      if (USE_DELTA_SAVES && !hasNonPlacementDirtyState() && mutatedIds.length > 0) {
+        resetOps = mutatedIds.map((id) => ({
+          type: 'placement.update',
+          sceneId: activeSceneId,
+          placementId: id,
+          patch: { triggeredActionReady: true },
+        }));
+      }
+      persistBoardStateSnapshot({}, resetOps);
       refreshTokenSettings();
     }
   }
@@ -12358,7 +12510,23 @@ export function mountBoardInteractions(store, routes = {}) {
       return false;
     }
 
-    persistBoardStateSnapshot();
+    // Phase 3-B (commit 3): the only field that changed here is
+    // `triggeredActionReady`, so we can hand-build a `placement.update`
+    // op with a tiny patch instead of running a diff. Fall back to the
+    // snapshot path if the delta flag is off or non-placement state is
+    // also waiting to flush.
+    let triggeredOps = null;
+    if (USE_DELTA_SAVES && !hasNonPlacementDirtyState()) {
+      triggeredOps = [
+        {
+          type: 'placement.update',
+          sceneId: activeSceneId,
+          placementId,
+          patch: { triggeredActionReady: nextReady },
+        },
+      ];
+    }
+    persistBoardStateSnapshot({}, triggeredOps);
 
     const latestState = boardApi.getState?.() ?? {};
     const placement = resolvePlacementById(latestState, activeSceneId, placementId);
@@ -13127,12 +13295,18 @@ export function mountBoardInteractions(store, routes = {}) {
     const gmUser = Boolean(state?.user?.isGM);
     let updated = false;
     let savePromise = null;
+    let beforeSnapshot = null;
+    let afterSnapshot = null;
     boardApi.updateState?.((draft) => {
       const scenePlacements = ensureScenePlacementDraft(draft, activeSceneId);
       const target = scenePlacements.find((item) => item && item.id === placementId);
       if (!target) {
         return;
       }
+      // Phase 3-B (commit 3): snapshot before and after the mutator so
+      // we can ship a minimal `placement.update` op containing only the
+      // fields that actually changed.
+      beforeSnapshot = clonePlacementForDiff(target);
       mutator(target);
       // Set _lastModified so server-side timestamp-based conflict resolution
       // correctly identifies this as a newer update.
@@ -13140,12 +13314,32 @@ export function mountBoardInteractions(store, routes = {}) {
       if (gmUser) {
         markPlacementAsGmAuthored(target, { isGm: gmUser });
       }
+      afterSnapshot = clonePlacementForDiff(target);
       updated = true;
     });
 
     if (updated && syncBoard) {
       markPlacementDirty(activeSceneId, placementId);
-      savePromise = persistBoardStateSnapshot();
+
+      // Phase 3-B (commit 3): build a `placement.update` op from the
+      // diff and route it through the delta-op path. If the diff is
+      // empty (mutator was a no-op) or non-placement state is also
+      // dirty, fall through to the snapshot path unchanged.
+      let updateOps = null;
+      if (USE_DELTA_SAVES && !hasNonPlacementDirtyState()) {
+        const patch = buildPlacementUpdatePatch(beforeSnapshot, afterSnapshot);
+        if (patch) {
+          updateOps = [
+            {
+              type: 'placement.update',
+              sceneId: activeSceneId,
+              placementId,
+              patch,
+            },
+          ];
+        }
+      }
+      savePromise = persistBoardStateSnapshot({}, updateOps);
     }
 
     if (returnSavePromise) {
@@ -13182,6 +13376,11 @@ export function mountBoardInteractions(store, routes = {}) {
     const gmUser = Boolean(state?.user?.isGM);
     let updatedIds = [];
     let savePromise = null;
+    // Phase 3-B (commit 3): snapshot before and after the mutator for
+    // each placement so we can ship one `placement.update` op per
+    // changed placement instead of a full dirty-tracked snapshot.
+    const patchBeforeById = new Map();
+    const patchAfterById = new Map();
     boardApi.updateState?.((draft) => {
       const scenePlacements = ensureScenePlacementDraft(draft, activeSceneId);
       if (!Array.isArray(scenePlacements) || !scenePlacements.length) {
@@ -13195,6 +13394,7 @@ export function mountBoardInteractions(store, routes = {}) {
         if (!uniqueIds.has(placement.id)) {
           return;
         }
+        patchBeforeById.set(placement.id, clonePlacementForDiff(placement));
         mutator(placement);
         // Set _lastModified so server-side timestamp-based conflict resolution
         // correctly identifies this as a newer update. Without this, the timestamp
@@ -13203,6 +13403,7 @@ export function mountBoardInteractions(store, routes = {}) {
         if (gmUser) {
           markPlacementAsGmAuthored(placement, { isGm: gmUser });
         }
+        patchAfterById.set(placement.id, clonePlacementForDiff(placement));
         updatedIds.push(placement.id);
       });
     });
@@ -13212,7 +13413,32 @@ export function mountBoardInteractions(store, routes = {}) {
       // Without this, property changes (e.g. hidden flag toggles) would be lost
       // when other dirty entities exist and a delta save is built.
       updatedIds.forEach((id) => markPlacementDirty(activeSceneId, id));
-      savePromise = persistBoardStateSnapshot();
+
+      // Phase 3-B (commit 3): build one `placement.update` op per
+      // changed placement from the per-id before/after diff and route
+      // through the delta-op path.
+      let updateOps = null;
+      if (USE_DELTA_SAVES && !hasNonPlacementDirtyState()) {
+        const opsList = [];
+        updatedIds.forEach((id) => {
+          const patch = buildPlacementUpdatePatch(
+            patchBeforeById.get(id),
+            patchAfterById.get(id)
+          );
+          if (patch) {
+            opsList.push({
+              type: 'placement.update',
+              sceneId: activeSceneId,
+              placementId: id,
+              patch,
+            });
+          }
+        });
+        if (opsList.length > 0) {
+          updateOps = opsList;
+        }
+      }
+      savePromise = persistBoardStateSnapshot({}, updateOps);
     }
 
     if (returnSavePromise) {


### PR DESCRIPTION
Extends the delta-ops persistence system to cover all placement mutations, not just moves. This allows token drops, deletions, and property edits to travel as typed operations instead of full board state snapshots.

## Summary

Phase 3-B commit 3 completes the placement-level delta-ops implementation by adding three new operation types (`placement.add`, `placement.remove`, `placement.update`) alongside the existing `placement.move` from commit 2. The ops path now handles every placement mutation on the client side, with intelligent fallback to snapshots when non-placement state (templates, drawings, etc.) is also pending.

## Key Changes

**Client-side (board-interactions.js & board-state-service.js):**
- Added `hasNonPlacementDirtyState()` guard to prevent ops-only saves from silently dropping templates, drawings, pings, and scene state
- Implemented `clonePlacementForDiff()` and `buildPlacementUpdatePatch()` helpers to generate minimal patches for placement mutations
- Routed token drops through `placement.add` ops
- Routed token deletions (GM-only) through `placement.remove` ops
- Routed arrow-key nudges through `placement.move` ops (same as drag-release)
- Routed all mutator-driven placement edits (HP, conditions, hidden flag, triggered actions) through `placement.update` ops
- Implemented shallow-merge dedup for consecutive `placement.update` ops on the same placement (preserves distinct field changes)
- Maintained per-type dedup keys so cross-type ops on the same placement coexist in insertion order

**Server-side (state.php):**
- Extended `applyBoardStateOp()` to handle `placement.add`, `placement.remove`, and `placement.update` in addition to `placement.move`
- Added `$context['isGm']` parameter to gate destructive ops (`placement.remove`) behind GM-only rule, matching snapshot path behavior
- Implemented `extractBoardStateOpPlacementId()` helper to normalize placementId fields across op types
- `placement.add` replaces existing placements with same id (later-wins semantics) and stamps `_lastModified`
- `placement.remove` filters out target placement and re-indexes array for proper JSON serialization
- `placement.update` shallow-merges patch onto existing placement, protects `id` field, and re-stamps `_lastModified`

**Tests (board-state-ops.test.mjs):**
- Added comprehensive test suite for all three new op types
- Verified wire shape of each op type
- Tested dedup key behavior (per-type keys, later-wins for add/remove, shallow-merge for consecutive updates)
- Verified cross-type ops accumulate in insertion order on same placement
- Tested malformed op filtering

## Notable Implementation Details

- Ops path falls back to snapshot path whenever non-placement dirty state is detected, preventing silent data loss
- `placement.update` patches are shallow-merged rather than replaced, allowing multiple edits to different fields to coexist
- Server re-stamps `_lastModified` on all mutations to ensure timestamp-based conflict resolution treats ops as fresh
- GM-only enforcement for `placement.remove` prevents players from bypassing the snapshot path's timestamp-merge-only policy
- All call sites snapshot placements before/after mutations to compute minimal patches, reducing bandwidth

https://claude.ai/code/session_01BH9XvyKVke8hYRPn8Y17VK