### PR TITLE
Add delta ops for templates and drawings (phase 3-B commits 4-5)

### DIFF
--- a/dnd/vtt/api/state.php
+++ b/dnd/vtt/api/state.php
@@ -735,19 +735,21 @@ function sanitizeBoardStateOps(array $rawOps): array
  * Commit 1 introduced `placement.move`. Commit 3 adds `placement.add`,
  * `placement.remove`, and `placement.update` so every placement-level
  * mutation on the client can travel as a typed op instead of a full
- * snapshot. Unknown or unsupported op types are ignored so older
- * servers can tolerate payloads from newer clients without erroring
- * out. The state returned is always a valid board state — if the op
- * cannot be applied (missing scene, missing placement, bad fields,
+ * snapshot. Commit 4 adds `template.upsert` and `template.remove` so
+ * every template commit (the `commitShapes` path in the client) can
+ * also travel as ops. Unknown or unsupported op types are ignored so
+ * older servers can tolerate payloads from newer clients without
+ * erroring out. The state returned is always a valid board state — if
+ * the op cannot be applied (missing scene, missing entry, bad fields,
  * permission denied for a non-GM destructive op), the input is
  * returned unchanged.
  *
  * The caller is responsible for running this inside the state lock so
  * two concurrent writers cannot interleave mutations on the same
- * placement. The caller is also responsible for setting
- * `$context['isGm']` so destructive ops can be gated: without this
- * flag, a non-GM caller could bypass the snapshot path's
- * timestamp-merge-only policy by sending `placement.remove` directly.
+ * entry. The caller is also responsible for setting `$context['isGm']`
+ * so destructive ops can be gated: without this flag, a non-GM caller
+ * could bypass the snapshot path's timestamp-merge-only policy by
+ * sending `placement.remove` or `template.remove` directly.
  *
  * @param array<string,mixed> $state
  * @param array<string,mixed> $op
@@ -944,9 +946,108 @@ function applyBoardStateOp(array $state, array $op, array $context = []): array
         return $state;
     }
 
+    if ($type === 'template.upsert') {
+        // `template.upsert` carries the full serialized template entry
+        // in the `template` field. If a template with the same id
+        // already exists in the scene, it is replaced in-place (later
+        // wins); otherwise it is appended. Non-GM callers are allowed
+        // — the snapshot player path accepts new/modified templates
+        // via `mergeSceneEntriesByTimestamp`, so there is no
+        // regression here.
+        $sceneId = isset($op['sceneId']) && is_string($op['sceneId']) ? trim($op['sceneId']) : '';
+        if ($sceneId === '') {
+            return $state;
+        }
+        if (!isset($op['template']) || !is_array($op['template'])) {
+            return $state;
+        }
+        $template = $op['template'];
+        $templateId = extractBoardEntryIdentifier($template);
+        if ($templateId === null || $templateId === '') {
+            return $state;
+        }
+
+        if (!isset($state['templates']) || !is_array($state['templates'])) {
+            $state['templates'] = [];
+        }
+        if (!isset($state['templates'][$sceneId]) || !is_array($state['templates'][$sceneId])) {
+            $state['templates'][$sceneId] = [];
+        }
+
+        // Stamp `_lastModified` so any downstream timestamp-based
+        // merge treats this upsert as newer than any stale payload
+        // already in flight.
+        $nowMs = (int) round(microtime(true) * 1000);
+        $template['_lastModified'] = $nowMs;
+
+        $replaced = false;
+        foreach ($state['templates'][$sceneId] as $idx => $existing) {
+            if (!is_array($existing)) {
+                continue;
+            }
+            $existingId = extractBoardEntryIdentifier($existing);
+            if ($existingId === $templateId) {
+                $state['templates'][$sceneId][$idx] = $template;
+                $replaced = true;
+                break;
+            }
+        }
+        if (!$replaced) {
+            $state['templates'][$sceneId][] = $template;
+        }
+        return $state;
+    }
+
+    if ($type === 'template.remove') {
+        // Mirror the `placement.remove` rule: gate destructive template
+        // removal behind the GM flag. The snapshot player path uses
+        // `mergeSceneEntriesByTimestamp`, which never deletes, so
+        // players cannot remove templates via the snapshot path today.
+        // Allowing a player to ship `template.remove` here would
+        // bypass that policy.
+        if (!$isGm) {
+            return $state;
+        }
+        $sceneId = isset($op['sceneId']) && is_string($op['sceneId']) ? trim($op['sceneId']) : '';
+        if ($sceneId === '') {
+            return $state;
+        }
+        $templateId = '';
+        if (isset($op['templateId'])) {
+            $raw = $op['templateId'];
+            if (is_string($raw)) {
+                $templateId = trim($raw);
+            } elseif (is_int($raw) || is_float($raw)) {
+                $templateId = (string) $raw;
+            }
+        }
+        if ($templateId === '') {
+            return $state;
+        }
+        if (!isset($state['templates'][$sceneId]) || !is_array($state['templates'][$sceneId])) {
+            return $state;
+        }
+        $filtered = [];
+        foreach ($state['templates'][$sceneId] as $entry) {
+            if (!is_array($entry)) {
+                $filtered[] = $entry;
+                continue;
+            }
+            $existingId = extractBoardEntryIdentifier($entry);
+            if ($existingId === $templateId) {
+                continue;
+            }
+            $filtered[] = $entry;
+        }
+        // Re-index so json_encode serializes as a JSON array, not an
+        // object with numeric string keys.
+        $state['templates'][$sceneId] = array_values($filtered);
+        return $state;
+    }
+
     // Unknown op types are silently ignored so older servers can
-    // tolerate payloads from newer clients. Commits 4+ will add
-    // `template.*` and `drawing.*` op types here.
+    // tolerate payloads from newer clients. Commit 5 will add
+    // `drawing.*` op types here.
     return $state;
 }
 

--- a/dnd/vtt/api/state.php
+++ b/dnd/vtt/api/state.php
@@ -737,19 +737,23 @@ function sanitizeBoardStateOps(array $rawOps): array
  * mutation on the client can travel as a typed op instead of a full
  * snapshot. Commit 4 adds `template.upsert` and `template.remove` so
  * every template commit (the `commitShapes` path in the client) can
- * also travel as ops. Unknown or unsupported op types are ignored so
- * older servers can tolerate payloads from newer clients without
- * erroring out. The state returned is always a valid board state — if
- * the op cannot be applied (missing scene, missing entry, bad fields,
- * permission denied for a non-GM destructive op), the input is
- * returned unchanged.
+ * also travel as ops. Commit 5 adds `drawing.add` and `drawing.remove`
+ * for the non-erase/non-clear drawing flows; the erase/clear path
+ * still rides the snapshot `_replaceDrawings` mechanism because it
+ * has no op equivalent. Unknown or unsupported op types are ignored
+ * so older servers can tolerate payloads from newer clients without
+ * erroring out. The state returned is always a valid board state —
+ * if the op cannot be applied (missing scene, missing entry, bad
+ * fields, permission denied for a non-GM destructive op), the input
+ * is returned unchanged.
  *
  * The caller is responsible for running this inside the state lock so
  * two concurrent writers cannot interleave mutations on the same
  * entry. The caller is also responsible for setting `$context['isGm']`
  * so destructive ops can be gated: without this flag, a non-GM caller
  * could bypass the snapshot path's timestamp-merge-only policy by
- * sending `placement.remove` or `template.remove` directly.
+ * sending `placement.remove`, `template.remove`, or `drawing.remove`
+ * directly.
  *
  * @param array<string,mixed> $state
  * @param array<string,mixed> $op
@@ -1045,9 +1049,106 @@ function applyBoardStateOp(array $state, array $op, array $context = []): array
         return $state;
     }
 
+    if ($type === 'drawing.add') {
+        // `drawing.add` carries the full new drawing entry in the
+        // `drawing` field. If a drawing with the same id already
+        // exists in the scene (should not happen in practice — each
+        // drawing is minted with a fresh id), it is replaced
+        // in-place. Non-GM callers are allowed: the draw flow is a
+        // user feature, not a GM-only tool, and the snapshot player
+        // path already accepts new drawings via
+        // `mergeSceneEntriesByTimestamp`.
+        $sceneId = isset($op['sceneId']) && is_string($op['sceneId']) ? trim($op['sceneId']) : '';
+        if ($sceneId === '') {
+            return $state;
+        }
+        if (!isset($op['drawing']) || !is_array($op['drawing'])) {
+            return $state;
+        }
+        $drawing = $op['drawing'];
+        $drawingId = extractBoardEntryIdentifier($drawing);
+        if ($drawingId === null || $drawingId === '') {
+            return $state;
+        }
+
+        if (!isset($state['drawings']) || !is_array($state['drawings'])) {
+            $state['drawings'] = [];
+        }
+        if (!isset($state['drawings'][$sceneId]) || !is_array($state['drawings'][$sceneId])) {
+            $state['drawings'][$sceneId] = [];
+        }
+
+        $nowMs = (int) round(microtime(true) * 1000);
+        $drawing['_lastModified'] = $nowMs;
+
+        $replaced = false;
+        foreach ($state['drawings'][$sceneId] as $idx => $existing) {
+            if (!is_array($existing)) {
+                continue;
+            }
+            $existingId = extractBoardEntryIdentifier($existing);
+            if ($existingId === $drawingId) {
+                $state['drawings'][$sceneId][$idx] = $drawing;
+                $replaced = true;
+                break;
+            }
+        }
+        if (!$replaced) {
+            $state['drawings'][$sceneId][] = $drawing;
+        }
+        return $state;
+    }
+
+    if ($type === 'drawing.remove') {
+        // Gate destructive drawing removal behind the GM flag. The
+        // snapshot player path uses `mergeSceneEntriesByTimestamp`,
+        // which cannot delete, so players cannot remove individual
+        // drawings via the snapshot path today. Players still have
+        // access to erase/clear, which ride the `_replaceDrawings`
+        // full-sync mechanism; that path is untouched by commit 5
+        // and continues to work regardless of role.
+        if (!$isGm) {
+            return $state;
+        }
+        $sceneId = isset($op['sceneId']) && is_string($op['sceneId']) ? trim($op['sceneId']) : '';
+        if ($sceneId === '') {
+            return $state;
+        }
+        $drawingId = '';
+        if (isset($op['drawingId'])) {
+            $raw = $op['drawingId'];
+            if (is_string($raw)) {
+                $drawingId = trim($raw);
+            } elseif (is_int($raw) || is_float($raw)) {
+                $drawingId = (string) $raw;
+            }
+        }
+        if ($drawingId === '') {
+            return $state;
+        }
+        if (!isset($state['drawings'][$sceneId]) || !is_array($state['drawings'][$sceneId])) {
+            return $state;
+        }
+        $filtered = [];
+        foreach ($state['drawings'][$sceneId] as $entry) {
+            if (!is_array($entry)) {
+                $filtered[] = $entry;
+                continue;
+            }
+            $existingId = extractBoardEntryIdentifier($entry);
+            if ($existingId === $drawingId) {
+                continue;
+            }
+            $filtered[] = $entry;
+        }
+        // Re-index so json_encode serializes as a JSON array, not an
+        // object with numeric string keys.
+        $state['drawings'][$sceneId] = array_values($filtered);
+        return $state;
+    }
+
     // Unknown op types are silently ignored so older servers can
-    // tolerate payloads from newer clients. Commit 5 will add
-    // `drawing.*` op types here.
+    // tolerate payloads from newer clients.
     return $state;
 }
 

--- a/dnd/vtt/assets/js/services/__tests__/board-state-ops.test.mjs
+++ b/dnd/vtt/assets/js/services/__tests__/board-state-ops.test.mjs
@@ -577,3 +577,228 @@ describe('Board State – delta ops persistence (phase 3-B commit 3)', () => {
     assert.deepEqual(capturedPayloads[0].ops[0].patch, { hidden: true });
   });
 });
+
+// ---------------------------------------------------------------------------
+// Phase 3-B (commit 4): template commits (the `commitShapes` path in the
+// client) now ship as `template.upsert` / `template.remove` ops instead of
+// a full snapshot. These tests lock in the wire shape of each new op type,
+// the per-type dedup keys (an upsert and a remove for the same template
+// coexist in the buffer), and the fact that malformed template ops are
+// dropped rather than shipped.
+// ---------------------------------------------------------------------------
+
+describe('Board State – delta ops persistence (phase 3-B commit 4)', () => {
+  let originalFetch;
+  let originalWindow;
+  let capturedPayloads;
+  let pendingFetchResolvers;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    originalWindow = globalThis.window;
+    capturedPayloads = [];
+    pendingFetchResolvers = [];
+
+    globalThis.fetch = async (_url, options = {}) => {
+      if (options?.body) {
+        capturedPayloads.push(JSON.parse(options.body));
+      }
+      return { ok: true, json: async () => ({ success: true, data: { _version: 123 } }) };
+    };
+
+    globalThis.window = {
+      ...(globalThis.window ?? {}),
+      setTimeout: (fn, _ms) => {
+        fn();
+        return 0;
+      },
+    };
+  });
+
+  afterEach(async () => {
+    const { _resetBoardStateOpsBufferForTest } = await import('../board-state-service.js');
+    _resetBoardStateOpsBufferForTest();
+
+    if (originalFetch === undefined) {
+      delete globalThis.fetch;
+    } else {
+      globalThis.fetch = originalFetch;
+    }
+    if (originalWindow === undefined) {
+      delete globalThis.window;
+    } else {
+      globalThis.window = originalWindow;
+    }
+    while (pendingFetchResolvers.length > 0) {
+      const resolve = pendingFetchResolvers.shift();
+      resolve?.({ ok: true, json: async () => ({ success: true, data: { _version: 1 } }) });
+    }
+  });
+
+  test('template.upsert ships the full template object under payload.ops', async () => {
+    const { persistBoardStateOps, _resetBoardStateOpsBufferForTest } = await import(
+      '../board-state-service.js'
+    );
+    _resetBoardStateOpsBufferForTest();
+
+    const template = {
+      id: 'tpl-1',
+      type: 'circle',
+      color: '#abcdef',
+      center: { column: 3, row: 4 },
+      radius: 5,
+    };
+
+    await persistBoardStateOps(
+      '/api/state',
+      [{ type: 'template.upsert', sceneId: 'scene-1', template }],
+      {}
+    );
+
+    assert.equal(capturedPayloads.length, 1);
+    const op = capturedPayloads[0].ops[0];
+    assert.equal(op.type, 'template.upsert');
+    assert.equal(op.sceneId, 'scene-1');
+    assert.deepEqual(op.template, template);
+  });
+
+  test('template.remove ships just sceneId + templateId', async () => {
+    const { persistBoardStateOps, _resetBoardStateOpsBufferForTest } = await import(
+      '../board-state-service.js'
+    );
+    _resetBoardStateOpsBufferForTest();
+
+    await persistBoardStateOps(
+      '/api/state',
+      [{ type: 'template.remove', sceneId: 'scene-1', templateId: 'tpl-zap' }],
+      {}
+    );
+
+    assert.equal(capturedPayloads.length, 1);
+    assert.deepEqual(capturedPayloads[0].ops[0], {
+      type: 'template.remove',
+      sceneId: 'scene-1',
+      templateId: 'tpl-zap',
+    });
+  });
+
+  test('template.upsert and template.remove on the same template coexist (per-type keys)', async () => {
+    const { persistBoardStateOps, _resetBoardStateOpsBufferForTest } = await import(
+      '../board-state-service.js'
+    );
+    _resetBoardStateOpsBufferForTest();
+
+    // Hold each fetch open so every call accumulates into the buffer.
+    globalThis.fetch = async (_url, options = {}) => {
+      if (options?.body) {
+        capturedPayloads.push(JSON.parse(options.body));
+      }
+      return new Promise((resolve) => {
+        pendingFetchResolvers.push(resolve);
+      });
+    };
+
+    persistBoardStateOps(
+      '/api/state',
+      [
+        {
+          type: 'template.upsert',
+          sceneId: 'scene-1',
+          template: { id: 'tpl-1', type: 'circle', center: { column: 1, row: 1 }, radius: 2 },
+        },
+      ],
+      {}
+    );
+    persistBoardStateOps(
+      '/api/state',
+      [{ type: 'template.remove', sceneId: 'scene-1', templateId: 'tpl-1' }],
+      {}
+    );
+
+    const lastPayload = capturedPayloads[capturedPayloads.length - 1];
+    assert.ok(lastPayload);
+    // Both must be present because per-type dedup keys prevent the
+    // remove from clobbering the upsert (or vice versa). Insertion
+    // order must also match the call order so the server applies
+    // upsert → remove.
+    assert.deepEqual(
+      lastPayload.ops.map((op) => op.type),
+      ['template.upsert', 'template.remove'],
+    );
+  });
+
+  test('two template.upsert ops for the same template coalesce (later wins)', async () => {
+    const { persistBoardStateOps, _resetBoardStateOpsBufferForTest } = await import(
+      '../board-state-service.js'
+    );
+    _resetBoardStateOpsBufferForTest();
+
+    globalThis.fetch = async (_url, options = {}) => {
+      if (options?.body) {
+        capturedPayloads.push(JSON.parse(options.body));
+      }
+      return new Promise((resolve) => {
+        pendingFetchResolvers.push(resolve);
+      });
+    };
+
+    persistBoardStateOps(
+      '/api/state',
+      [
+        {
+          type: 'template.upsert',
+          sceneId: 'scene-1',
+          template: { id: 'tpl-1', type: 'circle', center: { column: 1, row: 1 }, radius: 2 },
+        },
+      ],
+      {}
+    );
+    persistBoardStateOps(
+      '/api/state',
+      [
+        {
+          type: 'template.upsert',
+          sceneId: 'scene-1',
+          template: { id: 'tpl-1', type: 'circle', center: { column: 9, row: 9 }, radius: 4 },
+        },
+      ],
+      {}
+    );
+
+    const secondPayload = capturedPayloads[capturedPayloads.length - 1];
+    assert.equal(secondPayload.ops.length, 1, 'same-key upserts coalesce to one op');
+    assert.deepEqual(secondPayload.ops[0].template.center, { column: 9, row: 9 });
+    assert.equal(secondPayload.ops[0].template.radius, 4);
+  });
+
+  test('malformed template ops are silently dropped', async () => {
+    const { persistBoardStateOps, _resetBoardStateOpsBufferForTest } = await import(
+      '../board-state-service.js'
+    );
+    _resetBoardStateOpsBufferForTest();
+
+    await persistBoardStateOps(
+      '/api/state',
+      [
+        // missing template object
+        { type: 'template.upsert', sceneId: 'scene-1' },
+        // template present but missing id
+        { type: 'template.upsert', sceneId: 'scene-1', template: { type: 'circle' } },
+        // remove without templateId
+        { type: 'template.remove', sceneId: 'scene-1' },
+        // well-formed survivor
+        {
+          type: 'template.upsert',
+          sceneId: 'scene-1',
+          template: { id: 'tpl-ok', type: 'circle', center: { column: 0, row: 0 }, radius: 1 },
+        },
+      ],
+      {}
+    );
+
+    assert.equal(capturedPayloads.length, 1);
+    assert.equal(capturedPayloads[0].ops.length, 1, 'only the well-formed op survives');
+    assert.equal(capturedPayloads[0].ops[0].type, 'template.upsert');
+    assert.equal(capturedPayloads[0].ops[0].template.id, 'tpl-ok');
+  });
+});

--- a/dnd/vtt/assets/js/services/__tests__/board-state-ops.test.mjs
+++ b/dnd/vtt/assets/js/services/__tests__/board-state-ops.test.mjs
@@ -802,3 +802,186 @@ describe('Board State – delta ops persistence (phase 3-B commit 4)', () => {
     assert.equal(capturedPayloads[0].ops[0].template.id, 'tpl-ok');
   });
 });
+
+// ---------------------------------------------------------------------------
+// Phase 3-B (commit 5): drawings now ship as `drawing.add` / `drawing.remove`
+// ops for the non-erase/non-clear case. The erase/clear path still rides
+// the snapshot `_replaceDrawings` mechanism and is not exercised here —
+// these tests only lock in the wire shape and per-type dedup keys of the
+// new drawing op types that the diff path emits.
+// ---------------------------------------------------------------------------
+
+describe('Board State – delta ops persistence (phase 3-B commit 5)', () => {
+  let originalFetch;
+  let originalWindow;
+  let capturedPayloads;
+  let pendingFetchResolvers;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    originalWindow = globalThis.window;
+    capturedPayloads = [];
+    pendingFetchResolvers = [];
+
+    globalThis.fetch = async (_url, options = {}) => {
+      if (options?.body) {
+        capturedPayloads.push(JSON.parse(options.body));
+      }
+      return { ok: true, json: async () => ({ success: true, data: { _version: 321 } }) };
+    };
+
+    globalThis.window = {
+      ...(globalThis.window ?? {}),
+      setTimeout: (fn, _ms) => {
+        fn();
+        return 0;
+      },
+    };
+  });
+
+  afterEach(async () => {
+    const { _resetBoardStateOpsBufferForTest } = await import('../board-state-service.js');
+    _resetBoardStateOpsBufferForTest();
+
+    if (originalFetch === undefined) {
+      delete globalThis.fetch;
+    } else {
+      globalThis.fetch = originalFetch;
+    }
+    if (originalWindow === undefined) {
+      delete globalThis.window;
+    } else {
+      globalThis.window = originalWindow;
+    }
+    while (pendingFetchResolvers.length > 0) {
+      const resolve = pendingFetchResolvers.shift();
+      resolve?.({ ok: true, json: async () => ({ success: true, data: { _version: 1 } }) });
+    }
+  });
+
+  test('drawing.add ships the full drawing object under payload.ops', async () => {
+    const { persistBoardStateOps, _resetBoardStateOpsBufferForTest } = await import(
+      '../board-state-service.js'
+    );
+    _resetBoardStateOpsBufferForTest();
+
+    const drawing = {
+      id: 'drawing-abc',
+      points: [
+        { x: 10, y: 20 },
+        { x: 30, y: 40 },
+      ],
+      color: '#ff0000',
+      strokeWidth: 3,
+      authorId: 'alice',
+    };
+
+    await persistBoardStateOps(
+      '/api/state',
+      [{ type: 'drawing.add', sceneId: 'scene-1', drawing }],
+      {}
+    );
+
+    assert.equal(capturedPayloads.length, 1);
+    const op = capturedPayloads[0].ops[0];
+    assert.equal(op.type, 'drawing.add');
+    assert.equal(op.sceneId, 'scene-1');
+    assert.deepEqual(op.drawing, drawing);
+  });
+
+  test('drawing.remove ships just sceneId + drawingId', async () => {
+    const { persistBoardStateOps, _resetBoardStateOpsBufferForTest } = await import(
+      '../board-state-service.js'
+    );
+    _resetBoardStateOpsBufferForTest();
+
+    await persistBoardStateOps(
+      '/api/state',
+      [{ type: 'drawing.remove', sceneId: 'scene-1', drawingId: 'drawing-zap' }],
+      {}
+    );
+
+    assert.equal(capturedPayloads.length, 1);
+    assert.deepEqual(capturedPayloads[0].ops[0], {
+      type: 'drawing.remove',
+      sceneId: 'scene-1',
+      drawingId: 'drawing-zap',
+    });
+  });
+
+  test('drawing.add and drawing.remove coexist in one flush (per-type keys)', async () => {
+    const { persistBoardStateOps, _resetBoardStateOpsBufferForTest } = await import(
+      '../board-state-service.js'
+    );
+    _resetBoardStateOpsBufferForTest();
+
+    // Hold each fetch open so every call accumulates into the buffer.
+    globalThis.fetch = async (_url, options = {}) => {
+      if (options?.body) {
+        capturedPayloads.push(JSON.parse(options.body));
+      }
+      return new Promise((resolve) => {
+        pendingFetchResolvers.push(resolve);
+      });
+    };
+
+    persistBoardStateOps(
+      '/api/state',
+      [
+        {
+          type: 'drawing.add',
+          sceneId: 'scene-1',
+          drawing: { id: 'd-new', points: [{ x: 1, y: 1 }, { x: 2, y: 2 }], color: '#0f0' },
+        },
+      ],
+      {}
+    );
+    persistBoardStateOps(
+      '/api/state',
+      [{ type: 'drawing.remove', sceneId: 'scene-1', drawingId: 'd-gone' }],
+      {}
+    );
+
+    const lastPayload = capturedPayloads[capturedPayloads.length - 1];
+    assert.ok(lastPayload);
+    // Insertion order must match call order so the server applies
+    // the add before the remove.
+    assert.deepEqual(
+      lastPayload.ops.map((op) => op.type),
+      ['drawing.add', 'drawing.remove'],
+    );
+    assert.equal(lastPayload.ops[0].drawing.id, 'd-new');
+    assert.equal(lastPayload.ops[1].drawingId, 'd-gone');
+  });
+
+  test('malformed drawing ops are silently dropped', async () => {
+    const { persistBoardStateOps, _resetBoardStateOpsBufferForTest } = await import(
+      '../board-state-service.js'
+    );
+    _resetBoardStateOpsBufferForTest();
+
+    await persistBoardStateOps(
+      '/api/state',
+      [
+        // missing drawing object
+        { type: 'drawing.add', sceneId: 'scene-1' },
+        // drawing object missing id
+        { type: 'drawing.add', sceneId: 'scene-1', drawing: { points: [] } },
+        // remove without drawingId
+        { type: 'drawing.remove', sceneId: 'scene-1' },
+        // well-formed survivor
+        {
+          type: 'drawing.add',
+          sceneId: 'scene-1',
+          drawing: { id: 'd-ok', points: [{ x: 0, y: 0 }], color: '#000' },
+        },
+      ],
+      {}
+    );
+
+    assert.equal(capturedPayloads.length, 1);
+    assert.equal(capturedPayloads[0].ops.length, 1, 'only the well-formed op survives');
+    assert.equal(capturedPayloads[0].ops[0].type, 'drawing.add');
+    assert.equal(capturedPayloads[0].ops[0].drawing.id, 'd-ok');
+  });
+});

--- a/dnd/vtt/assets/js/services/board-state-service.js
+++ b/dnd/vtt/assets/js/services/board-state-service.js
@@ -98,6 +98,29 @@ function boardStateOpDedupKey(op) {
     }
     return `template.remove:${sceneId}:${templateId}`;
   }
+  // Phase 3-B (commit 5): drawing ops. Drawings are add-only or
+  // removed — the drawing tool never modifies a drawing in place
+  // (erase splits into new fragments with fresh ids; undo restores
+  // an older snapshot), so there is no drawing.upsert. Per-type
+  // later-wins dedup applies within a key, matching template.*.
+  if (op.type === 'drawing.add') {
+    const drawing = op.drawing;
+    if (!drawing || typeof drawing !== 'object') {
+      return null;
+    }
+    const drawingId = typeof drawing.id === 'string' ? drawing.id.trim() : '';
+    if (!drawingId) {
+      return null;
+    }
+    return `drawing.add:${sceneId}:${drawingId}`;
+  }
+  if (op.type === 'drawing.remove') {
+    const drawingId = typeof op.drawingId === 'string' ? op.drawingId.trim() : '';
+    if (!drawingId) {
+      return null;
+    }
+    return `drawing.remove:${sceneId}:${drawingId}`;
+  }
   return null;
 }
 

--- a/dnd/vtt/assets/js/services/board-state-service.js
+++ b/dnd/vtt/assets/js/services/board-state-service.js
@@ -75,6 +75,29 @@ function boardStateOpDedupKey(op) {
     }
     return `placement.add:${sceneId}:${placementId}`;
   }
+  // Phase 3-B (commit 4): template ops. Keys are per-type so an upsert
+  // and a remove for the same template can coexist in the buffer; the
+  // snapshot path that commitShapes used to take had no such conflict
+  // because it shipped the whole templates array. Later-wins dedup
+  // applies within a single key, matching placement.add/remove.
+  if (op.type === 'template.upsert') {
+    const template = op.template;
+    if (!template || typeof template !== 'object') {
+      return null;
+    }
+    const templateId = typeof template.id === 'string' ? template.id.trim() : '';
+    if (!templateId) {
+      return null;
+    }
+    return `template.upsert:${sceneId}:${templateId}`;
+  }
+  if (op.type === 'template.remove') {
+    const templateId = typeof op.templateId === 'string' ? op.templateId.trim() : '';
+    if (!templateId) {
+      return null;
+    }
+    return `template.remove:${sceneId}:${templateId}`;
+  }
   return null;
 }
 

--- a/dnd/vtt/assets/js/ui/board-interactions.js
+++ b/dnd/vtt/assets/js/ui/board-interactions.js
@@ -1668,16 +1668,21 @@ export function mountBoardInteractions(store, routes = {}) {
            dirtyTopLevel.size > 0;
   }
 
-  // Phase 3-B (commit 3): true when any NON-placement entity is dirty.
-  // Used at placement-mutation call sites to decide whether it is safe
-  // to route through the delta-op path: the ops path only carries
-  // placement ops today, so if templates/drawings/scene state/pings/etc.
-  // are also waiting to flush, we must fall back to the snapshot path
-  // to avoid dropping those changes on the floor. Commits 4+ will shrink
-  // what counts as "non-placement" as more op types come online.
+  // Phase 3-B (commit 3): true when any dirty entity cannot be shipped
+  // as a delta op. Used at op-routed call sites (placement mutations,
+  // commitShapes, syncDrawingsFromState) to decide whether it is safe
+  // to route through the delta-op path: if anything outside the
+  // ops-capable set is waiting to flush, we must fall back to the
+  // snapshot path to avoid dropping those changes on the floor.
+  //
+  // Phase 3-B (commit 4): templates moved out of the blocking set now
+  // that `commitShapes` emits `template.upsert`/`template.remove` ops.
+  // Drawings still block until commit 5. `drawingFullReplaceScenes`
+  // ALSO blocks — that is the erase/clear full-replace path that
+  // relies on the snapshot path's `_replaceDrawings` field to reach
+  // the server, and it has no op equivalent.
   function hasNonPlacementDirtyState() {
-    return dirtyTemplates.size > 0 ||
-           dirtyDrawings.size > 0 ||
+    return dirtyDrawings.size > 0 ||
            drawingFullReplaceScenes.size > 0 ||
            dirtyPings ||
            dirtySceneState.size > 0 ||
@@ -1727,6 +1732,83 @@ export function mountBoardInteractions(store, routes = {}) {
       }
     }
     return Object.keys(patch).length > 0 ? patch : null;
+  }
+
+  // Phase 3-B (commit 4): compute the delta between the prior
+  // templates-for-scene list and the freshly serialized next list,
+  // returning an array of `template.upsert`/`template.remove` ops.
+  // Upsert covers both creation and modification. Removals are emitted
+  // for any id in prior but not in next. `_lastModified` is excluded
+  // from the comparison so a server-side re-stamp doesn't look like a
+  // change. Returns an empty array if the two lists are functionally
+  // identical, allowing callers to skip an unnecessary save.
+  function templateDiffKey(entry) {
+    if (!entry || typeof entry !== 'object') {
+      return null;
+    }
+    const clone = { ...entry };
+    delete clone._lastModified;
+    try {
+      return JSON.stringify(clone);
+    } catch (error) {
+      return null;
+    }
+  }
+
+  function buildTemplateOpsFromDiff(sceneId, priorList, nextList) {
+    if (!sceneId) {
+      return [];
+    }
+    const ops = [];
+    const priorById = new Map();
+    const priorKeysById = new Map();
+    const prior = Array.isArray(priorList) ? priorList : [];
+    const next = Array.isArray(nextList) ? nextList : [];
+
+    prior.forEach((entry) => {
+      if (!entry || typeof entry !== 'object') {
+        return;
+      }
+      const id = typeof entry.id === 'string' ? entry.id : '';
+      if (!id) {
+        return;
+      }
+      priorById.set(id, entry);
+      priorKeysById.set(id, templateDiffKey(entry));
+    });
+
+    const nextIds = new Set();
+    next.forEach((entry) => {
+      if (!entry || typeof entry !== 'object') {
+        return;
+      }
+      const id = typeof entry.id === 'string' ? entry.id : '';
+      if (!id) {
+        return;
+      }
+      nextIds.add(id);
+      const nextKey = templateDiffKey(entry);
+      const priorKey = priorKeysById.has(id) ? priorKeysById.get(id) : null;
+      if (!priorById.has(id) || priorKey !== nextKey) {
+        ops.push({
+          type: 'template.upsert',
+          sceneId,
+          template: entry,
+        });
+      }
+    });
+
+    priorById.forEach((_unused, id) => {
+      if (!nextIds.has(id)) {
+        ops.push({
+          type: 'template.remove',
+          sceneId,
+          templateId: id,
+        });
+      }
+    });
+
+    return ops;
   }
 
   // Track dirty combat state fields to prevent remote state from overwriting local changes
@@ -17956,6 +18038,17 @@ function createTemplateTool() {
       return;
     }
 
+    // Phase 3-B (commit 4): capture the prior templates list BEFORE
+    // updateState mutates it. The op path needs this to diff against
+    // the freshly serialized list and emit `template.upsert` only for
+    // entries that actually changed and `template.remove` for ids
+    // that vanished. Serialized prior entries may carry a stale
+    // `_lastModified` stamp — that field is excluded from the diff
+    // below so a mere re-stamp is not counted as a change.
+    const priorTemplates = Array.isArray(state.boardState?.templates?.[activeSceneId])
+      ? state.boardState.templates[activeSceneId].slice()
+      : [];
+
     const commitTimestamp = Date.now();
     boardApi.updateState?.((draft) => {
       const templatesDraft = ensureSceneTemplateDraft(draft, activeSceneId);
@@ -17975,7 +18068,26 @@ function createTemplateTool() {
     });
 
     lastSyncedSnapshot = snapshotKey(serialized);
-    persistBoardStateSnapshot();
+
+    // Phase 3-B (commit 4): build `template.upsert`/`template.remove`
+    // ops from a diff of prior vs next. Upsert covers both add and
+    // modify. The comparison ignores `_lastModified` so a
+    // no-functional-change re-commit does not produce a wire op.
+    // Falls back to the snapshot path when USE_DELTA_SAVES is off or
+    // when any non-ops-capable dirty state is also waiting to flush
+    // (drawings, pings, sceneState, overlay, drawing full-replace).
+    let templateOps = null;
+    if (USE_DELTA_SAVES && !hasNonPlacementDirtyState()) {
+      templateOps = buildTemplateOpsFromDiff(activeSceneId, priorTemplates, serialized);
+      if (templateOps && templateOps.length === 0) {
+        // Nothing actually changed in the serialized templates list.
+        // Skip the network round-trip entirely and drain dirty tracking
+        // so subsequent saves are not starved by this no-op.
+        clearDirtyTracking();
+        return;
+      }
+    }
+    persistBoardStateSnapshot({}, templateOps);
   }
 
   if (templatesButton) {

--- a/dnd/vtt/assets/js/ui/board-interactions.js
+++ b/dnd/vtt/assets/js/ui/board-interactions.js
@@ -1028,6 +1028,14 @@ export function mountBoardInteractions(store, routes = {}) {
 
   // Drawing sync state - must be declared before applyStateToBoard is called
   let lastSyncedDrawingsHash = null;
+  // Phase 3-B (commit 5): parallel snapshot of the most recent synced
+  // drawings list so `syncDrawingsFromState` can diff prior vs next
+  // and emit `drawing.add` / `drawing.remove` ops. The scene id is
+  // tracked alongside so we only diff within the same scene — a
+  // scene switch invalidates the prior snapshot and falls back to
+  // the snapshot save path.
+  let lastSyncedDrawingsSceneId = null;
+  let lastSyncedDrawingsList = null;
 
   const defaultStatusText = status?.textContent ?? '';
   function updateStatus(message) {
@@ -1677,13 +1685,16 @@ export function mountBoardInteractions(store, routes = {}) {
   //
   // Phase 3-B (commit 4): templates moved out of the blocking set now
   // that `commitShapes` emits `template.upsert`/`template.remove` ops.
-  // Drawings still block until commit 5. `drawingFullReplaceScenes`
-  // ALSO blocks — that is the erase/clear full-replace path that
+  // Phase 3-B (commit 5): drawings moved out of the blocking set now
+  // that `syncDrawingsFromState` emits `drawing.add`/`drawing.remove`
+  // ops for the non-erase/non-clear case. `drawingFullReplaceScenes`
+  // still blocks — that is the erase/clear full-replace path that
   // relies on the snapshot path's `_replaceDrawings` field to reach
-  // the server, and it has no op equivalent.
+  // the server, and it has no op equivalent. Any call site that sees
+  // a pending full-replace drops back to snapshot so `_replaceDrawings`
+  // still reaches the server intact.
   function hasNonPlacementDirtyState() {
-    return dirtyDrawings.size > 0 ||
-           drawingFullReplaceScenes.size > 0 ||
+    return drawingFullReplaceScenes.size > 0 ||
            dirtyPings ||
            dirtySceneState.size > 0 ||
            dirtyTopLevel.size > 0;
@@ -1804,6 +1815,67 @@ export function mountBoardInteractions(store, routes = {}) {
           type: 'template.remove',
           sceneId,
           templateId: id,
+        });
+      }
+    });
+
+    return ops;
+  }
+
+  // Phase 3-B (commit 5): compute the delta between the prior
+  // drawings-for-scene list and the freshly synced next list,
+  // returning an array of `drawing.add`/`drawing.remove` ops.
+  // Drawings are never modified in place so there is no upsert — the
+  // diff only looks at ids. Returns an empty array when the two lists
+  // contain the same set of ids. Must NOT be called for the
+  // erase/clear full-replace path (that one still needs the snapshot
+  // `_replaceDrawings` mechanism); callers are responsible for
+  // short-circuiting when `consumeFullSyncNeeded()` returned true.
+  function buildDrawingOpsFromDiff(sceneId, priorList, nextList) {
+    if (!sceneId) {
+      return [];
+    }
+    const ops = [];
+    const priorIds = new Set();
+    const prior = Array.isArray(priorList) ? priorList : [];
+    const next = Array.isArray(nextList) ? nextList : [];
+
+    prior.forEach((entry) => {
+      if (!entry || typeof entry !== 'object') {
+        return;
+      }
+      const id = typeof entry.id === 'string' ? entry.id : '';
+      if (!id) {
+        return;
+      }
+      priorIds.add(id);
+    });
+
+    const nextIds = new Set();
+    next.forEach((entry) => {
+      if (!entry || typeof entry !== 'object') {
+        return;
+      }
+      const id = typeof entry.id === 'string' ? entry.id : '';
+      if (!id) {
+        return;
+      }
+      nextIds.add(id);
+      if (!priorIds.has(id)) {
+        ops.push({
+          type: 'drawing.add',
+          sceneId,
+          drawing: entry,
+        });
+      }
+    });
+
+    priorIds.forEach((id) => {
+      if (!nextIds.has(id)) {
+        ops.push({
+          type: 'drawing.remove',
+          sceneId,
+          drawingId: id,
         });
       }
     });
@@ -5170,14 +5242,28 @@ export function mountBoardInteractions(store, routes = {}) {
       return;
     }
 
+    // Phase 3-B (commit 5): capture the prior drawings list BEFORE we
+    // overwrite `lastSyncedDrawingsList`, so the op-routing branch
+    // below can diff it against the fresh list. Only usable when the
+    // prior snapshot is for the same scene — a scene switch resets
+    // the diff window and falls back to the snapshot path.
+    const priorDrawings =
+      lastSyncedDrawingsSceneId === activeSceneId && Array.isArray(lastSyncedDrawingsList)
+        ? lastSyncedDrawingsList
+        : null;
+
     lastSyncedDrawingsHash = hash;
+    lastSyncedDrawingsSceneId = activeSceneId;
+    lastSyncedDrawingsList = drawings.slice();
 
     // If sync is pending, the change came from the local drawing tool
     // Mark drawings as dirty for delta save
+    let fullSyncNeeded = false;
     if (isDrawingSyncPending()) {
       // Check if a full replace is needed (erasing/clearing removes drawings)
       if (consumeFullSyncNeeded()) {
         drawingFullReplaceScenes.add(activeSceneId);
+        fullSyncNeeded = true;
       }
       drawings.forEach((drawing) => {
         if (drawing && drawing.id) {
@@ -5186,10 +5272,38 @@ export function mountBoardInteractions(store, routes = {}) {
       });
     }
 
+    // Phase 3-B (commit 5): route through `drawing.add`/`drawing.remove`
+    // ops when the delta-saves feature flag is on, the change came
+    // from the local drawing tool (sync pending), this is NOT an
+    // erase/clear full-replace (those still need the snapshot path's
+    // `_replaceDrawings` mechanism to reach the server), we have a
+    // usable prior snapshot to diff against, and no non-ops-capable
+    // dirty state is also waiting to flush.
+    //
+    // Drawings are add-only or removed — never modified in place
+    // (verified by reading drawing-tool.js: endDrawing always creates
+    // new ids, erase splits into new fragments with new ids, undo
+    // restores an older whole snapshot). So the diff only ever emits
+    // `drawing.add` for newly-appeared ids and `drawing.remove` for
+    // ids that vanished.
+    let drawingOps = null;
+    if (
+      USE_DELTA_SAVES &&
+      isDrawingSyncPending() &&
+      !fullSyncNeeded &&
+      priorDrawings !== null &&
+      !hasNonPlacementDirtyState()
+    ) {
+      drawingOps = buildDrawingOpsFromDiff(activeSceneId, priorDrawings, drawings);
+      if (drawingOps.length === 0) {
+        drawingOps = null;
+      }
+    }
+
     // Always persist when drawings change to ensure they are saved to the server.
     // This fixes an issue where local drawings were not being persisted because
     // the sync pending check timing could miss the persist call.
-    persistBoardStateSnapshot();
+    persistBoardStateSnapshot({}, drawingOps);
 
     // If sync is pending, the change came from the local drawing tool
     // Don't update the drawing tool to preserve the undo stack


### PR DESCRIPTION
This PR extends the delta ops persistence system to support templates and drawings, eliminating the need for full snapshot serialization for these entity types in most cases.

## Summary

Implements Phase 3-B commits 4 and 5 of the delta ops persistence feature:
- **Commit 4**: Templates now ship as `template.upsert` and `template.remove` ops instead of full snapshots
- **Commit 5**: Drawings now ship as `drawing.add` and `drawing.remove` ops (except for erase/clear operations which still use the snapshot path)

## Key Changes

**Client-side (board-interactions.js)**:
- Added `buildTemplateOpsFromDiff()` to compute delta between prior and next template lists, emitting upsert ops for new/modified templates and remove ops for deleted ones
- Added `buildDrawingOpsFromDiff()` to compute delta between prior and next drawing lists, emitting add ops for new drawings and remove ops for deleted ones
- Modified `commitShapes()` to capture prior templates before mutation and route through the ops path when delta saves are enabled and no blocking dirty state exists
- Modified `syncDrawingsFromState()` to capture prior drawings and route through the ops path for non-erase/non-clear cases
- Updated `hasNonPlacementDirtyState()` to remove templates and drawings from the blocking set since they now have op equivalents (erase/clear full-replace still blocks)

**Server-side (state.php)**:
- Implemented `template.upsert` op handler: upserts full template object, stamps `_lastModified`, replaces in-place if exists or appends if new
- Implemented `template.remove` op handler: removes template by id (GM-only, mirrors placement.remove gating)
- Implemented `drawing.add` op handler: adds full drawing object, stamps `_lastModified`, replaces in-place if id exists (non-GM allowed)
- Implemented `drawing.remove` op handler: removes drawing by id (GM-only, mirrors template.remove gating)

**Dedup and validation (board-state-service.js)**:
- Added per-type dedup keys for template and drawing ops, allowing upsert and remove for the same entity to coexist in the buffer
- Validation ensures template.upsert has valid template with id, template.remove has valid templateId, drawing.add has valid drawing with id, and drawing.remove has valid drawingId
- Malformed ops are silently dropped

**Tests (board-state-ops.test.mjs)**:
- Added comprehensive test suite for template ops (commit 4): wire shape, per-type dedup keys, coalescing of duplicate upserts, malformed op handling
- Added comprehensive test suite for drawing ops (commit 5): wire shape, per-type dedup keys, coexistence of add/remove, malformed op handling

## Implementation Details

- Template diff excludes `_lastModified` field from comparison so server-side re-stamping doesn't trigger unnecessary updates
- Drawing diff only tracks ids (add-only or removed, never modified in-place per drawing tool design)
- Both paths fall back to snapshot serialization when delta saves are disabled or when non-ops-capable dirty state (pings, scene state, overlay, drawing full-replace) is pending
- Erase/clear drawing operations continue to use the snapshot `_replaceDrawings` mechanism as they have no op equivalent
- Server-side ops include `_lastModified` stamping to ensure downstream timestamp-based merges treat ops as newer than stale payloads in flight

https://claude.ai/code/session_01GNYE2X8ChED8x1nqAMxTJC