### PR TITLE
Phase 3-C: Implement delta ops broadcasting over Pusher

### DIFF
--- a/dnd/vtt/api/state.php
+++ b/dnd/vtt/api/state.php
@@ -9,6 +9,29 @@ const VTT_PING_RETENTION_MS = 10000;
 const VTT_VERSION_FILE = 'board-state-version.json';
 
 /**
+ * Phase 3-C: Feature flag for broadcasting delta ops over Pusher instead
+ * of the full board state. When `true`, an ops-only POST (one whose
+ * payload carried `payload.ops` and no snapshot updates) emits a compact
+ * `{type: 'ops', version, ops, ...}` Pusher message; subscribers apply
+ * the ops locally. When `false`, the existing full-state broadcast path
+ * runs unconditionally — useful as an emergency kill-switch without
+ * having to revert the whole phase.
+ */
+const VTT_USE_DELTA_BROADCASTS = true;
+
+/**
+ * Phase 3-C: Pusher imposes a 10 KB hard limit on a single message
+ * payload. We budget a little headroom for the channel/event metadata
+ * Pusher itself adds and refuse to broadcast anything larger. When an
+ * ops broadcast exceeds this size we fall back to a compact
+ * `ops-overflow` marker that forces every subscriber to GET fresh
+ * state. This is a safety net — the client-side ops escape hatch
+ * (PHASE_3B_MAX_OPS_PER_FLUSH) should already prevent ops payloads
+ * from getting this large in practice.
+ */
+const VTT_BROADCAST_MAX_BYTES = 9500;
+
+/**
  * Resolve the on-disk path to the version file.
  */
 function vttBoardStateVersionPath(): string
@@ -604,39 +627,106 @@ if (!defined('VTT_STATE_API_INCLUDE_ONLY')) {
             $responseState = $lockResult['state'];
             $newVersion = $lockResult['version'];
 
-            // Broadcast update via Pusher (non-blocking, fails silently)
-            $broadcastData = [
-                'version' => $newVersion,
-                'timestamp' => time() * 1000, // milliseconds for JS
-                'authorId' => strtolower(trim($auth['user'] ?? '')),
-                'authorRole' => ($auth['isGM'] ?? false) ? 'gm' : 'player',
-                'changedFields' => $changedFields,
-            ];
+            // Broadcast update via Pusher (non-blocking, fails silently).
+            //
+            // Phase 3-C: When the POST was an ops-only payload (no snapshot
+            // updates), broadcast a compact `{type: 'ops', ...}` message
+            // carrying the same ops the server already applied. Subscribers
+            // mirror the server's `applyBoardStateOp` and patch their own
+            // state in place. This drops the broadcast payload from
+            // hundreds of KB to a few hundred bytes for typical token
+            // moves and template/drawing edits.
+            //
+            // Mixed payloads (ops alongside snapshot updates) take the
+            // existing full-state path so the broadcast still carries
+            // every changed entity — the ops will be reapplied via the
+            // snapshot path on receivers, which is safe but redundant;
+            // we accept the redundancy because mixed payloads are rare
+            // and we don't want to maintain two parallel broadcast
+            // shapes for the same save.
+            //
+            // The full-state path is also the snapshot fallback for any
+            // op the client could not express as a delta (erase/clear,
+            // bulk fog, etc.) and is preserved unchanged.
+            $authorId = strtolower(trim($auth['user'] ?? ''));
+            $authorRole = ($auth['isGM'] ?? false) ? 'gm' : 'player';
+            $broadcastTimestampMs = time() * 1000;
 
-            // Include delta updates for efficient client-side merging
-            if (isset($updates['placements'])) {
-                $broadcastData['placements'] = $updates['placements'];
-            }
-            if (isset($updates['templates'])) {
-                $broadcastData['templates'] = $updates['templates'];
-            }
-            if (isset($updates['drawings'])) {
-                $broadcastData['drawings'] = $updates['drawings'];
-            }
-            if (isset($updates['pings'])) {
-                $broadcastData['pings'] = $updates['pings'];
-            }
-            if (isset($updates['sceneState'])) {
-                $broadcastData['sceneState'] = $updates['sceneState'];
-            }
-            if (isset($updates['activeSceneId'])) {
-                $broadcastData['activeSceneId'] = $updates['activeSceneId'];
-            }
-            if (isset($updates['mapUrl'])) {
-                $broadcastData['mapUrl'] = $updates['mapUrl'];
-            }
-            if (isset($updates['overlay'])) {
-                $broadcastData['overlay'] = $updates['overlay'];
+            $opsOnlyPayload = !empty($ops) && empty($updates);
+            $useOpsBroadcast = $opsOnlyPayload && VTT_USE_DELTA_BROADCASTS;
+
+            if ($useOpsBroadcast) {
+                $broadcastData = [
+                    'type' => 'ops',
+                    'version' => $newVersion,
+                    'timestamp' => $broadcastTimestampMs,
+                    'authorId' => $authorId,
+                    'authorRole' => $authorRole,
+                    'ops' => $ops,
+                ];
+
+                // Pusher's 10 KB per-message limit is a hard cap. If for
+                // any reason the ops list grew large enough to bust it
+                // (the client-side ops escape hatch should normally
+                // prevent this), fall back to a compact marker that
+                // forces every receiver to issue a fresh GET. We log
+                // because exceeding the cap is a signal that something
+                // upstream is sending too much in one save.
+                $encoded = json_encode($broadcastData);
+                if ($encoded === false || strlen($encoded) > VTT_BROADCAST_MAX_BYTES) {
+                    error_log(sprintf(
+                        '[VTT] Phase 3-C ops broadcast exceeded %d bytes (was %d, %d ops); falling back to ops-overflow marker',
+                        VTT_BROADCAST_MAX_BYTES,
+                        $encoded === false ? -1 : strlen($encoded),
+                        count($ops)
+                    ));
+                    $broadcastData = [
+                        'type' => 'ops-overflow',
+                        'version' => $newVersion,
+                        'timestamp' => $broadcastTimestampMs,
+                        'authorId' => $authorId,
+                        'authorRole' => $authorRole,
+                    ];
+                }
+            } else {
+                $broadcastData = [
+                    // Tag full-state broadcasts so the client subscriber
+                    // can dispatch on `type` even when the field is
+                    // missing on older messages. Older clients ignore
+                    // unknown fields, so this is non-breaking.
+                    'type' => 'full',
+                    'version' => $newVersion,
+                    'timestamp' => $broadcastTimestampMs, // milliseconds for JS
+                    'authorId' => $authorId,
+                    'authorRole' => $authorRole,
+                    'changedFields' => $changedFields,
+                ];
+
+                // Include delta updates for efficient client-side merging
+                if (isset($updates['placements'])) {
+                    $broadcastData['placements'] = $updates['placements'];
+                }
+                if (isset($updates['templates'])) {
+                    $broadcastData['templates'] = $updates['templates'];
+                }
+                if (isset($updates['drawings'])) {
+                    $broadcastData['drawings'] = $updates['drawings'];
+                }
+                if (isset($updates['pings'])) {
+                    $broadcastData['pings'] = $updates['pings'];
+                }
+                if (isset($updates['sceneState'])) {
+                    $broadcastData['sceneState'] = $updates['sceneState'];
+                }
+                if (isset($updates['activeSceneId'])) {
+                    $broadcastData['activeSceneId'] = $updates['activeSceneId'];
+                }
+                if (isset($updates['mapUrl'])) {
+                    $broadcastData['mapUrl'] = $updates['mapUrl'];
+                }
+                if (isset($updates['overlay'])) {
+                    $broadcastData['overlay'] = $updates['overlay'];
+                }
             }
 
             // Send the response to the client first so the sender is not

--- a/dnd/vtt/assets/js/services/__tests__/board-state-op-applier.test.mjs
+++ b/dnd/vtt/assets/js/services/__tests__/board-state-op-applier.test.mjs
@@ -1,0 +1,412 @@
+import { describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  applyBoardStateOpLocally,
+  applyBoardStateOpsLocally,
+} from '../board-state-op-applier.js';
+
+// ---------------------------------------------------------------------------
+// Phase 3-C: Client-side delta op applier. Mirrors the server's
+// `applyBoardStateOp()` in `dnd/vtt/api/state.php`. The Pusher subscriber
+// dispatches `{type: 'ops', ops: [...]}` broadcasts through this applier so
+// the client can patch its own board state in place instead of refetching
+// the full snapshot from `api/state.php`.
+//
+// These tests lock in:
+//   * the wire shape each op type accepts and how it mutates state in place
+//   * idempotent re-application semantics (replaying the same op is a no-op
+//     except for `_lastModified` re-stamping)
+//   * malformed-op tolerance (bad ops leave state unchanged, applier moves on)
+//   * ordering when ops are applied as a batch
+// ---------------------------------------------------------------------------
+
+function seedBoardState() {
+  return {
+    placements: {
+      'scene-1': [
+        { id: 'hero', column: 1, row: 2, hp: 10, _lastModified: 1 },
+        { id: 'goblin', column: 5, row: 5, hp: 4, _lastModified: 1 },
+      ],
+      'scene-2': [
+        { id: 'lich', column: 9, row: 9, _lastModified: 1 },
+      ],
+    },
+    templates: {
+      'scene-1': [
+        { id: 'fireball', shape: 'circle', radius: 20, _lastModified: 1 },
+      ],
+    },
+    drawings: {
+      'scene-1': [
+        { id: 'arrow-1', kind: 'line', _lastModified: 1 },
+      ],
+    },
+  };
+}
+
+describe('Board State Op Applier — placement.move', () => {
+  test('moves an existing placement and stamps _lastModified', () => {
+    const state = seedBoardState();
+    const before = state.placements['scene-1'][0]._lastModified;
+    const mutated = applyBoardStateOpLocally(state, {
+      type: 'placement.move',
+      sceneId: 'scene-1',
+      placementId: 'hero',
+      x: 7,
+      y: 8,
+    });
+    assert.equal(mutated, true);
+    const hero = state.placements['scene-1'].find((p) => p.id === 'hero');
+    assert.equal(hero.column, 7);
+    assert.equal(hero.row, 8);
+    assert.ok(hero._lastModified >= before, '_lastModified should be re-stamped');
+    // Other tokens are untouched.
+    const goblin = state.placements['scene-1'].find((p) => p.id === 'goblin');
+    assert.equal(goblin.column, 5);
+    assert.equal(goblin.row, 5);
+  });
+
+  test('returns false and leaves state untouched when sceneId is missing', () => {
+    const state = seedBoardState();
+    const snapshot = JSON.stringify(state);
+    const mutated = applyBoardStateOpLocally(state, {
+      type: 'placement.move',
+      placementId: 'hero',
+      x: 1,
+      y: 1,
+    });
+    assert.equal(mutated, false);
+    assert.equal(JSON.stringify(state), snapshot);
+  });
+
+  test('returns false when placementId is missing', () => {
+    const state = seedBoardState();
+    const snapshot = JSON.stringify(state);
+    const mutated = applyBoardStateOpLocally(state, {
+      type: 'placement.move',
+      sceneId: 'scene-1',
+      x: 1,
+      y: 1,
+    });
+    assert.equal(mutated, false);
+    assert.equal(JSON.stringify(state), snapshot);
+  });
+
+  test('returns false when x/y are non-numeric', () => {
+    const state = seedBoardState();
+    const snapshot = JSON.stringify(state);
+    const mutated = applyBoardStateOpLocally(state, {
+      type: 'placement.move',
+      sceneId: 'scene-1',
+      placementId: 'hero',
+      x: 'foo',
+      y: 'bar',
+    });
+    assert.equal(mutated, false);
+    assert.equal(JSON.stringify(state), snapshot);
+  });
+
+  test('returns false when target placement does not exist', () => {
+    const state = seedBoardState();
+    const snapshot = JSON.stringify(state);
+    const mutated = applyBoardStateOpLocally(state, {
+      type: 'placement.move',
+      sceneId: 'scene-1',
+      placementId: 'nonexistent',
+      x: 0,
+      y: 0,
+    });
+    assert.equal(mutated, false);
+    assert.equal(JSON.stringify(state), snapshot);
+  });
+
+  test('numeric placementId is coerced to string', () => {
+    const state = seedBoardState();
+    state.placements['scene-1'].push({ id: '42', column: 0, row: 0, _lastModified: 1 });
+    const mutated = applyBoardStateOpLocally(state, {
+      type: 'placement.move',
+      sceneId: 'scene-1',
+      placementId: 42,
+      x: 100,
+      y: 200,
+    });
+    assert.equal(mutated, true);
+    const moved = state.placements['scene-1'].find((p) => p.id === '42');
+    assert.equal(moved.column, 100);
+    assert.equal(moved.row, 200);
+  });
+});
+
+describe('Board State Op Applier — placement.add', () => {
+  test('appends a new placement when id is unseen', () => {
+    const state = seedBoardState();
+    const mutated = applyBoardStateOpLocally(state, {
+      type: 'placement.add',
+      sceneId: 'scene-1',
+      placement: { id: 'wizard', column: 3, row: 3, hp: 8 },
+    });
+    assert.equal(mutated, true);
+    const wizard = state.placements['scene-1'].find((p) => p.id === 'wizard');
+    assert.ok(wizard);
+    assert.equal(wizard.column, 3);
+    assert.equal(wizard.hp, 8);
+    assert.ok(typeof wizard._lastModified === 'number');
+  });
+
+  test('replaces in place when id already exists (later wins)', () => {
+    const state = seedBoardState();
+    const mutated = applyBoardStateOpLocally(state, {
+      type: 'placement.add',
+      sceneId: 'scene-1',
+      placement: { id: 'hero', column: 99, row: 99, hp: 1 },
+    });
+    assert.equal(mutated, true);
+    const hero = state.placements['scene-1'].find((p) => p.id === 'hero');
+    assert.equal(hero.column, 99);
+    assert.equal(hero.hp, 1);
+    // List length unchanged.
+    assert.equal(state.placements['scene-1'].length, 2);
+  });
+
+  test('initializes scene array when scene is unseen', () => {
+    const state = seedBoardState();
+    const mutated = applyBoardStateOpLocally(state, {
+      type: 'placement.add',
+      sceneId: 'scene-new',
+      placement: { id: 'rogue', column: 0, row: 0 },
+    });
+    assert.equal(mutated, true);
+    assert.deepEqual(
+      state.placements['scene-new'].map((p) => p.id),
+      ['rogue']
+    );
+  });
+
+  test('drops malformed payload (no placement field)', () => {
+    const state = seedBoardState();
+    const snapshot = JSON.stringify(state);
+    const mutated = applyBoardStateOpLocally(state, {
+      type: 'placement.add',
+      sceneId: 'scene-1',
+    });
+    assert.equal(mutated, false);
+    assert.equal(JSON.stringify(state), snapshot);
+  });
+});
+
+describe('Board State Op Applier — placement.remove', () => {
+  test('removes the matching placement', () => {
+    const state = seedBoardState();
+    const mutated = applyBoardStateOpLocally(state, {
+      type: 'placement.remove',
+      sceneId: 'scene-1',
+      placementId: 'goblin',
+    });
+    assert.equal(mutated, true);
+    assert.deepEqual(
+      state.placements['scene-1'].map((p) => p.id),
+      ['hero']
+    );
+  });
+
+  test('is idempotent: removing twice is a no-op the second time', () => {
+    const state = seedBoardState();
+    applyBoardStateOpLocally(state, {
+      type: 'placement.remove',
+      sceneId: 'scene-1',
+      placementId: 'goblin',
+    });
+    const mutated = applyBoardStateOpLocally(state, {
+      type: 'placement.remove',
+      sceneId: 'scene-1',
+      placementId: 'goblin',
+    });
+    assert.equal(mutated, false);
+  });
+});
+
+describe('Board State Op Applier — placement.update', () => {
+  test('shallow-merges patch fields and re-stamps _lastModified', () => {
+    const state = seedBoardState();
+    const mutated = applyBoardStateOpLocally(state, {
+      type: 'placement.update',
+      sceneId: 'scene-1',
+      placementId: 'hero',
+      patch: { hp: 5, conditions: ['dazed'] },
+    });
+    assert.equal(mutated, true);
+    const hero = state.placements['scene-1'].find((p) => p.id === 'hero');
+    assert.equal(hero.hp, 5);
+    assert.deepEqual(hero.conditions, ['dazed']);
+    // Untouched fields preserved.
+    assert.equal(hero.column, 1);
+    assert.equal(hero.row, 2);
+  });
+
+  test('refuses to overwrite the id field', () => {
+    const state = seedBoardState();
+    applyBoardStateOpLocally(state, {
+      type: 'placement.update',
+      sceneId: 'scene-1',
+      placementId: 'hero',
+      patch: { id: 'bogus', hp: 99 },
+    });
+    const hero = state.placements['scene-1'].find((p) => p.id === 'hero');
+    assert.ok(hero, 'hero with original id still exists');
+    assert.equal(hero.hp, 99);
+  });
+
+  test('drops payload when patch is missing', () => {
+    const state = seedBoardState();
+    const snapshot = JSON.stringify(state);
+    const mutated = applyBoardStateOpLocally(state, {
+      type: 'placement.update',
+      sceneId: 'scene-1',
+      placementId: 'hero',
+    });
+    assert.equal(mutated, false);
+    assert.equal(JSON.stringify(state), snapshot);
+  });
+});
+
+describe('Board State Op Applier — template.upsert / template.remove', () => {
+  test('template.upsert appends a new template entry', () => {
+    const state = seedBoardState();
+    const mutated = applyBoardStateOpLocally(state, {
+      type: 'template.upsert',
+      sceneId: 'scene-1',
+      template: { id: 'cone', shape: 'cone', length: 30 },
+    });
+    assert.equal(mutated, true);
+    const ids = state.templates['scene-1'].map((t) => t.id);
+    assert.deepEqual(ids, ['fireball', 'cone']);
+  });
+
+  test('template.upsert replaces in place when id matches', () => {
+    const state = seedBoardState();
+    const mutated = applyBoardStateOpLocally(state, {
+      type: 'template.upsert',
+      sceneId: 'scene-1',
+      template: { id: 'fireball', shape: 'circle', radius: 30 },
+    });
+    assert.equal(mutated, true);
+    const fb = state.templates['scene-1'].find((t) => t.id === 'fireball');
+    assert.equal(fb.radius, 30);
+    assert.equal(state.templates['scene-1'].length, 1);
+  });
+
+  test('template.remove deletes the matching entry', () => {
+    const state = seedBoardState();
+    const mutated = applyBoardStateOpLocally(state, {
+      type: 'template.remove',
+      sceneId: 'scene-1',
+      templateId: 'fireball',
+    });
+    assert.equal(mutated, true);
+    assert.equal(state.templates['scene-1'].length, 0);
+  });
+});
+
+describe('Board State Op Applier — drawing.add / drawing.remove', () => {
+  test('drawing.add appends new drawing', () => {
+    const state = seedBoardState();
+    const mutated = applyBoardStateOpLocally(state, {
+      type: 'drawing.add',
+      sceneId: 'scene-1',
+      drawing: { id: 'arrow-2', kind: 'arrow' },
+    });
+    assert.equal(mutated, true);
+    const ids = state.drawings['scene-1'].map((d) => d.id);
+    assert.deepEqual(ids, ['arrow-1', 'arrow-2']);
+  });
+
+  test('drawing.remove deletes the matching entry', () => {
+    const state = seedBoardState();
+    const mutated = applyBoardStateOpLocally(state, {
+      type: 'drawing.remove',
+      sceneId: 'scene-1',
+      drawingId: 'arrow-1',
+    });
+    assert.equal(mutated, true);
+    assert.equal(state.drawings['scene-1'].length, 0);
+  });
+});
+
+describe('Board State Op Applier — malformed / unknown op tolerance', () => {
+  test('returns false for null / non-object op', () => {
+    const state = seedBoardState();
+    const snapshot = JSON.stringify(state);
+    assert.equal(applyBoardStateOpLocally(state, null), false);
+    assert.equal(applyBoardStateOpLocally(state, 'not-an-op'), false);
+    assert.equal(applyBoardStateOpLocally(state, { type: '' }), false);
+    assert.equal(JSON.stringify(state), snapshot);
+  });
+
+  test('returns false for unknown op type', () => {
+    const state = seedBoardState();
+    const snapshot = JSON.stringify(state);
+    const mutated = applyBoardStateOpLocally(state, {
+      type: 'placement.teleport',
+      sceneId: 'scene-1',
+      placementId: 'hero',
+      x: 0,
+      y: 0,
+    });
+    assert.equal(mutated, false);
+    assert.equal(JSON.stringify(state), snapshot);
+  });
+
+  test('returns false when applied to a null/invalid board state', () => {
+    assert.equal(
+      applyBoardStateOpLocally(null, {
+        type: 'placement.move',
+        sceneId: 'scene-1',
+        placementId: 'hero',
+        x: 0,
+        y: 0,
+      }),
+      false
+    );
+  });
+});
+
+describe('Board State Op Applier — applyBoardStateOpsLocally batch helper', () => {
+  test('applies a batch of ops in order and counts mutations', () => {
+    const state = seedBoardState();
+    const ops = [
+      { type: 'placement.move', sceneId: 'scene-1', placementId: 'hero', x: 10, y: 10 },
+      { type: 'placement.add', sceneId: 'scene-1', placement: { id: 'cleric', column: 0, row: 0 } },
+      { type: 'template.upsert', sceneId: 'scene-1', template: { id: 'wall', shape: 'line' } },
+      // Bad op: should be counted as 0 mutations but not throw.
+      { type: 'placement.move', sceneId: 'scene-1', placementId: 'ghost', x: 1, y: 1 },
+      // Unknown op: also 0.
+      { type: 'fog.toggle', sceneId: 'scene-1' },
+    ];
+    const count = applyBoardStateOpsLocally(state, ops);
+    assert.equal(count, 3);
+    const hero = state.placements['scene-1'].find((p) => p.id === 'hero');
+    assert.deepEqual([hero.column, hero.row], [10, 10]);
+    assert.ok(state.placements['scene-1'].some((p) => p.id === 'cleric'));
+    assert.ok(state.templates['scene-1'].some((t) => t.id === 'wall'));
+  });
+
+  test('returns 0 when given a non-array', () => {
+    const state = seedBoardState();
+    assert.equal(applyBoardStateOpsLocally(state, null), 0);
+    assert.equal(applyBoardStateOpsLocally(state, undefined), 0);
+    assert.equal(applyBoardStateOpsLocally(state, { ops: [] }), 0);
+  });
+
+  test('matches server applyBoardStateOp ordering: later moves of the same token win', () => {
+    const state = seedBoardState();
+    const ops = [
+      { type: 'placement.move', sceneId: 'scene-1', placementId: 'hero', x: 1, y: 1 },
+      { type: 'placement.move', sceneId: 'scene-1', placementId: 'hero', x: 2, y: 2 },
+      { type: 'placement.move', sceneId: 'scene-1', placementId: 'hero', x: 3, y: 3 },
+    ];
+    applyBoardStateOpsLocally(state, ops);
+    const hero = state.placements['scene-1'].find((p) => p.id === 'hero');
+    assert.deepEqual([hero.column, hero.row], [3, 3]);
+  });
+});

--- a/dnd/vtt/assets/js/services/board-state-op-applier.js
+++ b/dnd/vtt/assets/js/services/board-state-op-applier.js
@@ -1,0 +1,272 @@
+/**
+ * Phase 3-C: Client-side delta op applier.
+ *
+ * Mirrors `applyBoardStateOp()` in `dnd/vtt/api/state.php` so a Pusher
+ * broadcast carrying `{type: 'ops', ops: [...]}` can be applied to the
+ * local board state without re-fetching the full state from
+ * `api/state.php`.
+ *
+ * Each function mutates the passed-in `boardState` object in place. The
+ * caller is expected to wrap calls in `boardApi.updateState((draft) => …)`
+ * (which uses Immer-style mutation under the hood) so the mutations
+ * become a single committed state transition.
+ *
+ * Op shapes:
+ *   { type: 'placement.move',   sceneId, placementId, x, y }
+ *   { type: 'placement.add',    sceneId, placement: { id, ... } }
+ *   { type: 'placement.remove', sceneId, placementId }
+ *   { type: 'placement.update', sceneId, placementId, patch: { ... } }
+ *   { type: 'template.upsert',  sceneId, template: { id, ... } }
+ *   { type: 'template.remove',  sceneId, templateId }
+ *   { type: 'drawing.add',      sceneId, drawing:  { id, ... } }
+ *   { type: 'drawing.remove',   sceneId, drawingId }
+ *
+ * Unknown or malformed ops are silently ignored — the function returns
+ * the boardState unchanged for that op. This matches the server's
+ * tolerance for ops it can't apply and protects clients on older
+ * builds from getting stuck on a payload they don't understand.
+ */
+
+/**
+ * Apply a single op to a board state object in place.
+ *
+ * @param {object} boardState - Mutable board state object (the `boardState`
+ *   slice of the store, not the wrapping container).
+ * @param {object} op - The op to apply.
+ * @returns {boolean} True if the op caused a state change, false otherwise.
+ */
+export function applyBoardStateOpLocally(boardState, op) {
+  if (!boardState || typeof boardState !== 'object') {
+    return false;
+  }
+  if (!op || typeof op !== 'object') {
+    return false;
+  }
+  const type = typeof op.type === 'string' ? op.type : '';
+  if (!type) {
+    return false;
+  }
+  const sceneId = extractSceneId(op);
+  if (!sceneId) {
+    return false;
+  }
+
+  if (type === 'placement.move') {
+    const placementId = extractOpEntityId(op, 'placementId');
+    if (!placementId) return false;
+    const x = Number(op.x);
+    const y = Number(op.y);
+    if (!Number.isFinite(x) || !Number.isFinite(y)) return false;
+    const list = boardState?.placements?.[sceneId];
+    if (!Array.isArray(list)) return false;
+    for (let i = 0; i < list.length; i++) {
+      const entry = list[i];
+      if (!entry || typeof entry !== 'object') continue;
+      if (entry.id !== placementId) continue;
+      // The wire format uses x/y for coordinates, but the canonical
+      // placement record stores column/row. Mirror the server.
+      entry.column = x;
+      entry.row = y;
+      // The server stamps `_lastModified` so timestamp-based merges
+      // downstream treat the move as newer than any in-flight stale
+      // payload. Mirror that locally too — without it, a polling
+      // response that arrived just before this Pusher broadcast could
+      // win the timestamp tie and snap the token back.
+      entry._lastModified = Date.now();
+      return true;
+    }
+    return false;
+  }
+
+  if (type === 'placement.add') {
+    if (!op.placement || typeof op.placement !== 'object') return false;
+    const placementId = entryId(op.placement);
+    if (!placementId) return false;
+    if (!boardState.placements || typeof boardState.placements !== 'object') {
+      boardState.placements = {};
+    }
+    if (!Array.isArray(boardState.placements[sceneId])) {
+      boardState.placements[sceneId] = [];
+    }
+    // Clone to avoid sharing the broadcast object across the store.
+    const next = { ...op.placement, _lastModified: Date.now() };
+    const list = boardState.placements[sceneId];
+    for (let i = 0; i < list.length; i++) {
+      const existing = list[i];
+      if (existing && typeof existing === 'object' && entryId(existing) === placementId) {
+        list[i] = next;
+        return true;
+      }
+    }
+    list.push(next);
+    return true;
+  }
+
+  if (type === 'placement.remove') {
+    const placementId = extractOpEntityId(op, 'placementId');
+    if (!placementId) return false;
+    const list = boardState?.placements?.[sceneId];
+    if (!Array.isArray(list)) return false;
+    const filtered = list.filter((entry) => {
+      if (!entry || typeof entry !== 'object') return true;
+      return entryId(entry) !== placementId;
+    });
+    if (filtered.length === list.length) return false;
+    boardState.placements[sceneId] = filtered;
+    return true;
+  }
+
+  if (type === 'placement.update') {
+    const placementId = extractOpEntityId(op, 'placementId');
+    if (!placementId) return false;
+    if (!op.patch || typeof op.patch !== 'object') return false;
+    const list = boardState?.placements?.[sceneId];
+    if (!Array.isArray(list)) return false;
+    for (let i = 0; i < list.length; i++) {
+      const entry = list[i];
+      if (!entry || typeof entry !== 'object') continue;
+      if (entryId(entry) !== placementId) continue;
+      // Shallow merge — never overwrite the id.
+      for (const key of Object.keys(op.patch)) {
+        if (key === 'id') continue;
+        entry[key] = op.patch[key];
+      }
+      entry._lastModified = Date.now();
+      return true;
+    }
+    return false;
+  }
+
+  if (type === 'template.upsert') {
+    if (!op.template || typeof op.template !== 'object') return false;
+    const templateId = entryId(op.template);
+    if (!templateId) return false;
+    if (!boardState.templates || typeof boardState.templates !== 'object') {
+      boardState.templates = {};
+    }
+    if (!Array.isArray(boardState.templates[sceneId])) {
+      boardState.templates[sceneId] = [];
+    }
+    const next = { ...op.template, _lastModified: Date.now() };
+    const list = boardState.templates[sceneId];
+    for (let i = 0; i < list.length; i++) {
+      const existing = list[i];
+      if (existing && typeof existing === 'object' && entryId(existing) === templateId) {
+        list[i] = next;
+        return true;
+      }
+    }
+    list.push(next);
+    return true;
+  }
+
+  if (type === 'template.remove') {
+    const templateId = extractOpEntityId(op, 'templateId');
+    if (!templateId) return false;
+    const list = boardState?.templates?.[sceneId];
+    if (!Array.isArray(list)) return false;
+    const filtered = list.filter((entry) => {
+      if (!entry || typeof entry !== 'object') return true;
+      return entryId(entry) !== templateId;
+    });
+    if (filtered.length === list.length) return false;
+    boardState.templates[sceneId] = filtered;
+    return true;
+  }
+
+  if (type === 'drawing.add') {
+    if (!op.drawing || typeof op.drawing !== 'object') return false;
+    const drawingId = entryId(op.drawing);
+    if (!drawingId) return false;
+    if (!boardState.drawings || typeof boardState.drawings !== 'object') {
+      boardState.drawings = {};
+    }
+    if (!Array.isArray(boardState.drawings[sceneId])) {
+      boardState.drawings[sceneId] = [];
+    }
+    const next = { ...op.drawing, _lastModified: Date.now() };
+    const list = boardState.drawings[sceneId];
+    for (let i = 0; i < list.length; i++) {
+      const existing = list[i];
+      if (existing && typeof existing === 'object' && entryId(existing) === drawingId) {
+        list[i] = next;
+        return true;
+      }
+    }
+    list.push(next);
+    return true;
+  }
+
+  if (type === 'drawing.remove') {
+    const drawingId = extractOpEntityId(op, 'drawingId');
+    if (!drawingId) return false;
+    const list = boardState?.drawings?.[sceneId];
+    if (!Array.isArray(list)) return false;
+    const filtered = list.filter((entry) => {
+      if (!entry || typeof entry !== 'object') return true;
+      return entryId(entry) !== drawingId;
+    });
+    if (filtered.length === list.length) return false;
+    boardState.drawings[sceneId] = filtered;
+    return true;
+  }
+
+  // Unknown op type — ignored so the client tolerates payloads from
+  // newer servers without crashing.
+  return false;
+}
+
+/**
+ * Apply a list of ops to a board state in order. Returns the count of
+ * ops that actually mutated state. Stops if any op throws (it
+ * shouldn't, but if it does the partial application would leave the
+ * state inconsistent and the caller should resync).
+ *
+ * @param {object} boardState
+ * @param {Array<object>} ops
+ * @returns {number}
+ */
+export function applyBoardStateOpsLocally(boardState, ops) {
+  if (!Array.isArray(ops) || ops.length === 0) return 0;
+  let mutated = 0;
+  for (const op of ops) {
+    if (applyBoardStateOpLocally(boardState, op)) {
+      mutated++;
+    }
+  }
+  return mutated;
+}
+
+function extractSceneId(op) {
+  const raw = op.sceneId;
+  if (typeof raw === 'string') {
+    const trimmed = raw.trim();
+    return trimmed === '' ? '' : trimmed;
+  }
+  return '';
+}
+
+function extractOpEntityId(op, field) {
+  const raw = op[field];
+  if (typeof raw === 'string') {
+    const trimmed = raw.trim();
+    return trimmed === '' ? '' : trimmed;
+  }
+  if (typeof raw === 'number' && Number.isFinite(raw)) {
+    return String(raw);
+  }
+  return '';
+}
+
+function entryId(entry) {
+  if (!entry || typeof entry !== 'object') return '';
+  const raw = entry.id;
+  if (typeof raw === 'string') {
+    const trimmed = raw.trim();
+    return trimmed === '' ? '' : trimmed;
+  }
+  if (typeof raw === 'number' && Number.isFinite(raw)) {
+    return String(raw);
+  }
+  return '';
+}

--- a/dnd/vtt/assets/js/services/pusher-service.js
+++ b/dnd/vtt/assets/js/services/pusher-service.js
@@ -222,6 +222,19 @@ function handleStateChange(states) {
 
 /**
  * Handle incoming state update from Pusher.
+ *
+ * Phase 3-C: Inspect `data.type` and dispatch:
+ *   - `'ops'`           — compact delta-op broadcast. Pass `type` and
+ *                          `ops` straight through to the consumer; do
+ *                          not unpack the (absent) full-state fields.
+ *   - `'ops-overflow'`  — the server tried to broadcast ops but the
+ *                          payload exceeded the 10 KB Pusher limit.
+ *                          Pass through so the consumer can trigger a
+ *                          full GET resync.
+ *   - `'full'` / absent — the legacy full-state broadcast shape. Unpack
+ *                          placements/templates/drawings/etc. exactly
+ *                          as before. Older messages without a `type`
+ *                          field still flow through this branch.
  */
 function handleStateUpdated(data) {
   if (!data || typeof data !== 'object') {
@@ -230,11 +243,13 @@ function handleStateUpdated(data) {
   }
 
   const {
+    type,
     version,
     timestamp,
     authorId,
     authorRole,
     changedFields,
+    ops,
     placements,
     templates,
     drawings,
@@ -245,13 +260,18 @@ function handleStateUpdated(data) {
     overlay,
   } = data;
 
-  // Version check - skip if we've already applied a newer version
+  // Version check - skip if we've already applied a newer version.
+  // Applies uniformly to ops, ops-overflow, and full-state broadcasts.
   if (typeof version === 'number' && version <= lastAppliedVersion) {
     console.log('[VTT Pusher] Skipping stale update, version:', version, 'current:', lastAppliedVersion);
     return;
   }
 
-  // Self-update check - skip if this update was authored by the current user
+  // Self-update check - skip if this update was authored by the current
+  // user. The same rule applies to ops broadcasts: the author already
+  // got the new state in their save response and re-applying their own
+  // ops is redundant. The `_socketId` exclusion at the Pusher layer is
+  // the first line of defense; this is the second.
   const currentUserId = normalizeUserId(getCurrentUserIdFn());
   const updateAuthorId = normalizeUserId(authorId);
 
@@ -264,43 +284,72 @@ function handleStateUpdated(data) {
     return;
   }
 
-  console.log('[VTT Pusher] Applying update, version:', version, 'author:', authorId);
+  console.log('[VTT Pusher] Applying update, version:', version, 'author:', authorId, 'type:', type || 'full');
 
-  // Build delta update object
-  const delta = {
-    version,
-    timestamp,
-    authorId,
-    authorRole,
-    changedFields: changedFields || [],
-  };
+  // Build the delta object handed to the consumer. The shape is
+  // discriminated by `type` so the consumer can decide whether to run
+  // the op-applier or the full-state merge.
+  let delta;
+  if (type === 'ops') {
+    delta = {
+      type: 'ops',
+      version,
+      timestamp,
+      authorId,
+      authorRole,
+      ops: Array.isArray(ops) ? ops : [],
+    };
+  } else if (type === 'ops-overflow') {
+    delta = {
+      type: 'ops-overflow',
+      version,
+      timestamp,
+      authorId,
+      authorRole,
+    };
+  } else {
+    // 'full' or undefined — legacy full-state broadcast.
+    delta = {
+      type: 'full',
+      version,
+      timestamp,
+      authorId,
+      authorRole,
+      changedFields: changedFields || [],
+    };
 
-  if (placements !== undefined) {
-    delta.placements = placements;
-  }
-  if (templates !== undefined) {
-    delta.templates = templates;
-  }
-  if (drawings !== undefined) {
-    delta.drawings = drawings;
-  }
-  if (pings !== undefined) {
-    delta.pings = pings;
-  }
-  if (sceneState !== undefined) {
-    delta.sceneState = sceneState;
-  }
-  if (activeSceneId !== undefined) {
-    delta.activeSceneId = activeSceneId;
-  }
-  if (mapUrl !== undefined) {
-    delta.mapUrl = mapUrl;
-  }
-  if (overlay !== undefined) {
-    delta.overlay = overlay;
+    if (placements !== undefined) {
+      delta.placements = placements;
+    }
+    if (templates !== undefined) {
+      delta.templates = templates;
+    }
+    if (drawings !== undefined) {
+      delta.drawings = drawings;
+    }
+    if (pings !== undefined) {
+      delta.pings = pings;
+    }
+    if (sceneState !== undefined) {
+      delta.sceneState = sceneState;
+    }
+    if (activeSceneId !== undefined) {
+      delta.activeSceneId = activeSceneId;
+    }
+    if (mapUrl !== undefined) {
+      delta.mapUrl = mapUrl;
+    }
+    if (overlay !== undefined) {
+      delta.overlay = overlay;
+    }
   }
 
-  // Update last applied version
+  // Update last applied version. We bump even before the consumer
+  // applies because the consumer's own staleness/gap rules use the
+  // store's `currentBoardStateVersion` (independent of this counter)
+  // and a resync will reconcile both. Bumping here also lets the
+  // pusher-service drop any *strictly older* follow-up broadcasts
+  // that arrive while the consumer is still mid-apply.
   if (typeof version === 'number') {
     lastAppliedVersion = version;
   }

--- a/dnd/vtt/assets/js/ui/board-interactions.js
+++ b/dnd/vtt/assets/js/ui/board-interactions.js
@@ -19,6 +19,7 @@ import {
   persistCombatState,
 } from '../services/board-state-service.js';
 import { initializePusher, getSocketId, isPusherConnected } from '../services/pusher-service.js';
+import { applyBoardStateOpsLocally } from '../services/board-state-op-applier.js';
 import {
   PLAYER_VISIBLE_TOKEN_FOLDER,
   normalizeMonsterSnapshot,
@@ -403,6 +404,16 @@ export function createBoardStatePoller({
           // deliver fresh state.
           poll();
         }
+      },
+      // Phase 3-C: External callers (the Pusher subscriber, specifically)
+      // can force a one-shot poll to recover from a version-gap detected
+      // on an ops broadcast or from an `ops-overflow` marker. The
+      // existing internal staleness/grace-period guards inside `poll()`
+      // still apply, so calling this during a pending save is a safe
+      // no-op — see the `pendingResyncAfterSave` plumbing in
+      // board-interactions for the deferred case.
+      forceImmediatePoll() {
+        poll();
       },
     };
   }
@@ -1598,6 +1609,13 @@ export function mountBoardInteractions(store, routes = {}) {
   let lastPersistedBoardStateHash = null;
   let pendingBoardStateSave = null;
   let pendingCombatStateSave = null;
+  // Phase 3-C: When the Pusher ops subscriber detects a version gap or
+  // overflow marker while a save is in flight, it cannot immediately
+  // call `forceImmediatePoll()` because the poller's own
+  // pending-save guard would short-circuit. Instead, it sets this
+  // flag; the save-completion handler then triggers a fresh poll once
+  // the in-flight save resolves.
+  let pendingResyncAfterSave = false;
   // Grace period after save completes to prevent poller from overwriting with stale state
   // This handles the window between save completion and server state propagation
   let lastBoardStateSaveCompletedAt = 0;
@@ -2580,6 +2598,18 @@ export function mountBoardInteractions(store, routes = {}) {
           // Clear dirty tracking after successful save
           clearDirtyTracking();
 
+          // Phase 3-C: If a Pusher ops broadcast was deferred during
+          // this save (because of a version gap or `ops-overflow`
+          // marker), the only way to recover is a fresh GET. Fire one
+          // now that the save is fully resolved — the save response
+          // already updated `currentBoardStateVersion`, so the poll's
+          // own ETag will reflect the post-save state and any further
+          // server progress will come back as a 200.
+          if (pendingResyncAfterSave) {
+            pendingResyncAfterSave = false;
+            triggerBoardStateResync('post-save-flush');
+          }
+
           // Update version from server response.
           // The save response is the third ingestion path for state updates
           // (alongside Pusher broadcasts and the HTTP poller). Guard it with
@@ -3097,14 +3127,174 @@ export function mountBoardInteractions(store, routes = {}) {
   }
 
   /**
+   * Phase 3-C: Force a fresh GET from `api/state.php` so the client
+   * can recover from a missed Pusher ops broadcast (version gap or
+   * `ops-overflow` marker). The poller's own `forceImmediatePoll`
+   * still respects the in-flight save guard, so during a pending save
+   * we set `pendingResyncAfterSave` and the save-completion handler
+   * fires the poll once the save resolves.
+   *
+   * This is the *only* recovery path for ops broadcasts. Unlike
+   * full-state broadcasts, which are self-healing because they carry
+   * the entire scene, an ops broadcast is incremental: missing one
+   * leaves the client silently behind the server. The 30s safety-net
+   * poll would eventually catch it, but a user-visible 30s drift on a
+   * token move is exactly the lag this phase is supposed to kill.
+   */
+  function triggerBoardStateResync(reason) {
+    const hasPendingSave = Boolean(pendingBoardStateSave?.promise);
+    if (hasPendingSave) {
+      console.log('[VTT Pusher] Resync deferred until save completes, reason:', reason);
+      pendingResyncAfterSave = true;
+      return;
+    }
+    if (
+      boardStatePollerHandle &&
+      typeof boardStatePollerHandle.forceImmediatePoll === 'function'
+    ) {
+      console.log('[VTT Pusher] Forcing immediate poll, reason:', reason);
+      boardStatePollerHandle.forceImmediatePoll();
+    } else {
+      console.warn(
+        '[VTT Pusher] Resync requested but poller not available, reason:',
+        reason
+      );
+    }
+  }
+
+  /**
    * Handle state updates received from Pusher.
    * Applies delta updates with version checking.
+   *
+   * Phase 3-C: Branches on `delta.type`:
+   *   - `'ops'`           — apply each typed op via the local op applier.
+   *                          Strict `+1` version-gap detection: any
+   *                          incoming version that is not exactly
+   *                          `currentBoardStateVersion + 1` triggers a
+   *                          full GET resync instead of applying.
+   *   - `'ops-overflow'`  — server tried to broadcast ops but exceeded
+   *                          the 10 KB Pusher cap. Drop the payload and
+   *                          force a full resync.
+   *   - `'full'` / absent — legacy full-state broadcast. Existing
+   *                          merge-by-timestamp logic runs unchanged.
    */
   function handlePusherStateUpdate(delta) {
     if (!delta || typeof delta !== 'object') {
       return;
     }
 
+    // ---- Phase 3-C: ops-overflow branch -----------------------------
+    // The server fell back to a marker because the ops list would have
+    // busted Pusher's 10 KB cap. We have no payload to apply locally;
+    // the only recovery is a fresh GET. Note that we deliberately do
+    // NOT bump `currentBoardStateVersion` here — the resync will set it
+    // from the GET response, and bumping prematurely would cause any
+    // genuinely-newer ops broadcast that beats the resync to be
+    // misclassified as a small gap (current+1) and applied against the
+    // wrong base state.
+    if (delta.type === 'ops-overflow') {
+      console.warn(
+        '[VTT Pusher] ops-overflow marker received, version:',
+        delta.version,
+        '- triggering resync'
+      );
+      triggerBoardStateResync('ops-overflow');
+      return;
+    }
+
+    // ---- Phase 3-C: ops branch --------------------------------------
+    if (delta.type === 'ops') {
+      const incomingVersion = delta.version;
+
+      // Stale: drop anything we've already moved past.
+      if (
+        typeof incomingVersion !== 'number' ||
+        !Number.isFinite(incomingVersion) ||
+        incomingVersion <= currentBoardStateVersion
+      ) {
+        console.log(
+          '[VTT Pusher] Skipping stale ops broadcast, version:',
+          incomingVersion,
+          'current:',
+          currentBoardStateVersion
+        );
+        return;
+      }
+
+      // Strict +1 gap detection. The POST handler bumps the version
+      // exactly once per save (one save = one version bump regardless
+      // of how many ops were in the payload), so two consecutive
+      // saves produce versions N and N+1. Any larger gap means we
+      // missed a broadcast and our local state is now silently out
+      // of sync with the server. Recover via a full GET — applying
+      // the ops on top of the wrong base state would compound the
+      // drift.
+      if (incomingVersion !== currentBoardStateVersion + 1) {
+        console.warn(
+          '[VTT Pusher] ops version gap detected (current:',
+          currentBoardStateVersion,
+          'incoming:',
+          incomingVersion,
+          ') - triggering resync'
+        );
+        triggerBoardStateResync('version-gap');
+        return;
+      }
+
+      // If a save is in flight, the save response is about to bump
+      // currentBoardStateVersion to the post-save value, and any
+      // strict-+1 math we do here against the pre-save version is
+      // wrong. Defer to a post-save resync — the GET will reconcile
+      // both this broadcast's ops and our own save's effects.
+      const hasPendingSaveOps = Boolean(pendingBoardStateSave?.promise);
+      if (hasPendingSaveOps) {
+        console.log('[VTT Pusher] Deferring ops update due to pending save');
+        triggerBoardStateResync('ops-during-save');
+        return;
+      }
+
+      const ops = Array.isArray(delta.ops) ? delta.ops : [];
+      let appliedCount = 0;
+      try {
+        boardApi.updateState?.((draft) => {
+          if (!draft.boardState) {
+            draft.boardState = {};
+          }
+          appliedCount = applyBoardStateOpsLocally(draft.boardState, ops);
+          draft.boardState._version = incomingVersion;
+        });
+      } catch (error) {
+        console.error(
+          '[VTT Pusher] Failed to apply ops locally, falling back to resync:',
+          error
+        );
+        triggerBoardStateResync('apply-error');
+        return;
+      }
+
+      currentBoardStateVersion = incomingVersion;
+      if (pusherInterface?.setLastAppliedVersion) {
+        pusherInterface.setLastAppliedVersion(incomingVersion);
+      }
+
+      const updatedStateAfterOps = boardApi.getState?.();
+      if (updatedStateAfterOps) {
+        applyStateToBoard(updatedStateAfterOps);
+        applyCombatStateFromBoardState(updatedStateAfterOps);
+      }
+
+      console.log(
+        '[VTT Pusher] Applied',
+        appliedCount,
+        'of',
+        ops.length,
+        'ops, version:',
+        incomingVersion
+      );
+      return;
+    }
+
+    // ---- Legacy full-state path -------------------------------------
     // ALWAYS update version tracking first, regardless of other state
     // This prevents the poller from applying stale data later
     if (shouldApplyIncomingVersion(delta.version, currentBoardStateVersion)) {


### PR DESCRIPTION
## Summary

Implement client-side delta operation (ops) applier and server-side ops broadcasting to reduce Pusher message payload sizes from hundreds of KB to a few hundred bytes for typical token moves and template/drawing edits. This is Phase 3-C of the real-time state synchronization initiative.

## Key Changes

### New Files
- **`board-state-op-applier.js`** — Client-side op applier that mirrors the server's `applyBoardStateOp()` logic. Supports 8 op types:
  - `placement.move`, `placement.add`, `placement.remove`, `placement.update`
  - `template.upsert`, `template.remove`
  - `drawing.add`, `drawing.remove`
  - All ops mutate board state in place with idempotent re-application semantics
  - Malformed ops are silently ignored for forward compatibility

- **`board-state-op-applier.test.mjs`** — Comprehensive test suite (412 lines) covering:
  - Wire shape validation for each op type
  - Idempotent re-application (replaying ops re-stamps `_lastModified` only)
  - Malformed-op tolerance
  - Batch op ordering and mutation counting

### Modified Files

**`state.php`** (Server-side)
- Added feature flag `VTT_USE_DELTA_BROADCASTS` to toggle ops broadcasting
- Added `VTT_BROADCAST_MAX_BYTES` constant (9.5 KB) to enforce Pusher's 10 KB hard limit
- Detect ops-only payloads (no snapshot updates) and broadcast compact `{type: 'ops', version, ops, ...}` messages
- Fall back to `ops-overflow` marker when ops payload exceeds size limit, forcing clients to resync
- Preserve full-state broadcast path for mixed payloads and non-delta operations

**`pusher-service.js`** (Pusher subscriber)
- Inspect incoming `data.type` field to discriminate broadcast shape:
  - `'ops'` — compact delta ops broadcast
  - `'ops-overflow'` — server exceeded payload size limit
  - `'full'` / absent — legacy full-state broadcast (backward compatible)
- Pass `type` and `ops` through to consumer without unpacking full-state fields for ops broadcasts
- Maintain version checking and self-update filtering across all broadcast types

**`board-interactions.js`** (Consumer/applier orchestration)
- Add `forceImmediatePoll()` method to board state poller for recovery from version gaps
- Implement strict `+1` version-gap detection: any incoming version not exactly `currentBoardStateVersion + 1` triggers a full GET resync
- Add `pendingResyncAfterSave` flag to defer resync until in-flight save completes (prevents applying ops against stale base state)
- Implement `triggerBoardStateResync()` to coordinate resync requests with save-in-flight guards
- Branch `handlePusherStateUpdate()` on `delta.type`:
  - `'ops'` — apply ops locally via `applyBoardStateOpsLocally()`
  - `'ops-overflow'` — force immediate resync
  - `'full'` — existing merge-by-timestamp logic (unchanged)

## Notable Implementation Details

- **Idempotency**: Each op re-stamps `_lastModified` on application, ensuring timestamp-based merges downstream treat the op as newer than stale in-flight payloads
- **Version semantics**: One save = one version bump regardless of op count; strict `+1` gap detection catches missed broadcasts without false positives
- **Save-in-flight safety**: Ops broadcasts during a pending save are deferred until the save response updates `currentBoardStateVersion`, preventing ops from being applied against the wrong base state
- **Backward compatibility**: Ops broadcasts are opt-in via feature flag; full-state path remains the fallback for mixed payloads and non-delta operations
- **Pusher size limit**: 9.5 KB budget with headroom for Pusher metadata; exceeding it triggers `ops-overflow` marker and

https://claude.ai/code/session_01N3ANk4ZVdHPRpiw6SVdrdv