### PR TITLE
Add APCu caching for VTT state responses to reduce disk I/O

### DIFF
--- a/dnd/vtt/api/state.php
+++ b/dnd/vtt/api/state.php
@@ -188,8 +188,45 @@ if (!defined('VTT_STATE_API_INCLUDE_ONLY')) {
                 exit;
             }
 
-            $config = getVttBootstrapConfig();
+            // Phase 3-D: APCu memoization of the loaded + filtered state.
+            // After 3-A the safety-net poll is already near-free via 304,
+            // but there are still cases that must hit the full load path:
+            // a new player joining mid-session, several clients reconnecting
+            // at once, and the 3-C forceImmediatePoll() resync after a
+            // version gap. All three scenarios produce a burst of GETs at
+            // the same version. Caching the serialized response body keyed
+            // by (version, user) lets every GET after the first in a burst
+            // skip reading scenes.json/tokens.json/board-state.json from
+            // disk and re-running player-view filtering.
+            //
+            // The cache key includes the user because
+            // filterPlacementsForPlayerView() hides GM-only entities for
+            // non-GMs, so a single version produces two distinct response
+            // bodies depending on role.
+            //
+            // No explicit POST invalidation is needed. Every successful
+            // POST bumps `_version` monotonically inside the board-state
+            // lock, so old keys become unreachable the instant the next
+            // GET reads the new version. Orphaned entries at stale
+            // versions expire naturally via the short TTL below, which is
+            // the backstop for the narrow window between disk commit and
+            // cache-key rotation.
             $auth = getVttUserContext();
+            $apcuEnabled = function_exists('apcu_enabled') && apcu_enabled();
+            $cacheKey = null;
+            if ($apcuEnabled) {
+                $cacheUser = strtolower(trim((string) ($auth['user'] ?? '')));
+                $cacheKey = sprintf('vtt:state:v%d:%s', $currentVersion, $cacheUser);
+                $cachedBody = apcu_fetch($cacheKey, $cacheHit);
+                if ($cacheHit && is_string($cachedBody) && $cachedBody !== '') {
+                    header('ETag: ' . $currentEtag);
+                    header('Cache-Control: no-store');
+                    echo $cachedBody;
+                    exit;
+                }
+            }
+
+            $config = getVttBootstrapConfig();
             if (!($auth['isGM'] ?? false)) {
                 $config['boardState'] = filterPlacementsForPlayerView($config['boardState'] ?? []);
             }
@@ -204,9 +241,7 @@ if (!defined('VTT_STATE_API_INCLUDE_ONLY')) {
             // Include Pusher config for client-side initialization
             $pusherConfig = getVttPusherConfig();
 
-            header('ETag: ' . $currentEtag);
-            header('Cache-Control: no-store');
-            respondJson(200, [
+            $responseBody = json_encode([
                 'success' => true,
                 'data' => [
                     'scenes' => $config['scenes'],
@@ -215,6 +250,26 @@ if (!defined('VTT_STATE_API_INCLUDE_ONLY')) {
                     'pusher' => $pusherConfig,
                 ],
             ]);
+
+            // Phase 3-D: store the serialized body so cache hits can echo
+            // it directly without a second json_encode pass. TTL is short
+            // (2 seconds) because the version-keyed key rotation already
+            // handles invalidation; the TTL just garbage-collects orphaned
+            // entries at stale versions.
+            if ($apcuEnabled && $cacheKey !== null && is_string($responseBody)) {
+                apcu_store($cacheKey, $responseBody, 2);
+            }
+
+            header('ETag: ' . $currentEtag);
+            header('Cache-Control: no-store');
+            http_response_code(200);
+            echo is_string($responseBody)
+                ? $responseBody
+                : json_encode([
+                    'success' => false,
+                    'error' => 'Failed to encode board state response.',
+                ]);
+            exit;
         }
 
         if ($method === 'POST') {


### PR DESCRIPTION
## Summary
Implements APCu-based memoization of serialized VTT state responses to reduce redundant disk reads and filtering operations during burst request scenarios.

## Key Changes
- **APCu cache layer**: Caches serialized response bodies keyed by `(version, user)` to handle burst GETs at the same version (new players joining, reconnections, forced resyncs)
- **User-aware caching**: Cache key includes the user context since `filterPlacementsForPlayerView()` produces different responses for GMs vs non-GMs
- **Automatic invalidation**: No explicit POST invalidation needed—version bumps during POST operations automatically rotate cache keys, with a 2-second TTL as a garbage collection backstop
- **Response serialization refactor**: Changed from direct `respondJson()` call to explicit `json_encode()` to enable caching the serialized body, allowing cache hits to echo the response directly without re-encoding
- **Graceful degradation**: APCu caching is optional and only activates if `apcu_enabled()` returns true; requests proceed normally if APCu is unavailable

## Implementation Details
- Cache key format: `vtt:state:v{version}:{user}` (user normalized to lowercase)
- Cache hit path returns early with appropriate ETag and Cache-Control headers
- Response body is stored in APCu only after successful JSON encoding
- Fallback error response included if JSON encoding fails
- Short TTL (2 seconds) balances memory usage against the narrow window between disk commit and cache-key rotation

https://claude.ai/code/session_01G2BwNNNcxqccnBnJep7yNu