### PR TITLE
Add cache clearing utility for GM users

### DIFF
--- a/dnd/clear-cache.php
+++ b/dnd/clear-cache.php
@@ -1,0 +1,40 @@
+<?php
+// Server-side cache clearing endpoint
+// Clears PHP OPcache and realpath cache so updated files are picked up immediately.
+// Only the GM may invoke this (it's a testing/dev helper).
+
+session_start();
+header('Content-Type: application/json');
+
+if (!isset($_SESSION['logged_in']) || $_SESSION['logged_in'] !== true || ($_SESSION['user'] ?? '') !== 'GM') {
+    http_response_code(403);
+    echo json_encode(['success' => false, 'error' => 'Not authorized']);
+    exit;
+}
+
+$cleared = [];
+
+// Reset PHP OPcache if available (this is what usually causes "old file" behavior on hosts with OPcache enabled)
+if (function_exists('opcache_reset')) {
+    if (@opcache_reset()) {
+        $cleared[] = 'opcache';
+    }
+}
+
+// Reset realpath cache
+if (function_exists('clearstatcache')) {
+    clearstatcache(true);
+    $cleared[] = 'statcache';
+}
+
+// Clear APCu user cache if available
+if (function_exists('apcu_clear_cache')) {
+    @apcu_clear_cache();
+    $cleared[] = 'apcu';
+}
+
+echo json_encode([
+    'success' => true,
+    'cleared' => $cleared,
+    'timestamp' => time()
+]);

--- a/dnd/dashboard.php
+++ b/dnd/dashboard.php
@@ -963,6 +963,9 @@ $defaultInventoryTab = $is_gm ? 'frunk' : $user;
             <?php else: ?>
                 <button type="button" class="nav-btn" id="character-sheet-btn" title="Open your character sheet">Character Sheet</button>
             <?php endif; ?>
+            <?php if ($is_gm): ?>
+                <button type="button" class="nav-btn" id="clear-cache-btn" title="Clear server + browser cache and reload">Clear Cache</button>
+            <?php endif; ?>
             <button class="nav-btn logout-btn" onclick="window.location.href='logout.php'">Logout</button>
         </div>
         <h1 class="nav-title"><?php echo $is_gm ? 'GM Dashboard' : ucfirst($user) . '\'s Character Sheet'; ?></h1>
@@ -1581,6 +1584,62 @@ $defaultInventoryTab = $is_gm ? 'frunk' : $user;
             }
         }
     </script>
+    <?php if ($is_gm): ?>
+    <script>
+        // Clear Cache button: wipes server-side PHP caches, browser Cache Storage,
+        // unregisters any service workers, and reloads the page with a cache-busting query string.
+        (function () {
+            var btn = document.getElementById('clear-cache-btn');
+            if (!btn) return;
+
+            btn.addEventListener('click', async function () {
+                if (!confirm('Clear server and browser caches, then reload the page?')) return;
+
+                var originalLabel = btn.textContent;
+                btn.disabled = true;
+                btn.textContent = 'Clearing...';
+
+                // 1. Ask the server to reset PHP OPcache / stat cache.
+                try {
+                    var resp = await fetch('clear-cache.php', {
+                        method: 'POST',
+                        credentials: 'same-origin',
+                        cache: 'no-store'
+                    });
+                    var data = await resp.json().catch(function () { return {}; });
+                    console.log('Server cache clear:', data);
+                } catch (err) {
+                    console.warn('Server cache clear failed:', err);
+                }
+
+                // 2. Clear browser Cache Storage (used by service workers / PWAs).
+                if (window.caches && caches.keys) {
+                    try {
+                        var keys = await caches.keys();
+                        await Promise.all(keys.map(function (k) { return caches.delete(k); }));
+                    } catch (err) {
+                        console.warn('Cache Storage clear failed:', err);
+                    }
+                }
+
+                // 3. Unregister any service workers.
+                if (navigator.serviceWorker && navigator.serviceWorker.getRegistrations) {
+                    try {
+                        var regs = await navigator.serviceWorker.getRegistrations();
+                        await Promise.all(regs.map(function (r) { return r.unregister(); }));
+                    } catch (err) {
+                        console.warn('Service worker unregister failed:', err);
+                    }
+                }
+
+                // 4. Reload with a cache-busting query string so CSS/JS are re-fetched.
+                var url = new URL(window.location.href);
+                url.searchParams.set('_cb', Date.now().toString());
+                window.location.replace(url.toString());
+            });
+        })();
+    </script>
+    <?php endif; ?>
     <script src="js/chat-panel.js"></script>
     <script src="dice-roller/dice-roller.js"></script>
     <script src="js/theme-manager.js"></script>


### PR DESCRIPTION
## Summary
This PR adds a cache clearing utility accessible only to GM users, enabling them to clear both server-side PHP caches and browser-side caches to ensure updated files are loaded immediately.

## Key Changes
- **New endpoint (`clear-cache.php`)**: Server-side cache clearing that:
  - Validates GM authorization via session
  - Resets PHP OPcache (primary cause of stale file issues on hosts with OPcache enabled)
  - Clears realpath cache via `clearstatcache()`
  - Clears APCu user cache if available
  - Returns JSON response with cleared cache types and timestamp

- **Dashboard UI enhancement (`dashboard.php`)**:
  - Added "Clear Cache" button in navigation bar (GM-only, conditionally rendered)
  - Implemented comprehensive client-side cache clearing script that:
    - Requests server-side cache reset via POST to `clear-cache.php`
    - Clears browser Cache Storage (used by service workers/PWAs)
    - Unregisters all active service workers
    - Reloads page with cache-busting query parameter (`_cb` timestamp)
  - Includes user confirmation dialog before clearing

## Implementation Details
- Authorization is enforced at the server endpoint (403 response if not GM)
- Client-side script uses async/await with proper error handling and fallbacks for unsupported APIs
- Cache busting uses `Date.now()` as query parameter to force fresh CSS/JS downloads
- All operations are wrapped in try-catch blocks to prevent failures in one cache type from blocking others
- Button provides visual feedback (disabled state, "Clearing..." text) during operation

https://claude.ai/code/session_01M1BqXirZcc4ujmeKC9yj2e