### PR TITLE
Fix drawing persistence feedback loop from Pusher broadcasts

### DIFF
--- a/dnd/vtt/assets/js/ui/board-interactions.js
+++ b/dnd/vtt/assets/js/ui/board-interactions.js
@@ -5490,14 +5490,13 @@ export function mountBoardInteractions(store, routes = {}) {
       }
     }
 
-    // Always persist when drawings change to ensure they are saved to the server.
-    // This fixes an issue where local drawings were not being persisted because
-    // the sync pending check timing could miss the persist call.
-    persistBoardStateSnapshot({}, drawingOps);
-
-    // If sync is pending, the change came from the local drawing tool
-    // Don't update the drawing tool to preserve the undo stack
+    // Only persist when the change came from the local drawing tool.
+    // When isDrawingSyncPending() is false, the change came from an incoming
+    // Pusher broadcast — the server already has the correct state, so saving
+    // back would create a feedback loop (each client re-saves what it just
+    // received, bumping the version and triggering more broadcasts).
     if (isDrawingSyncPending()) {
+      persistBoardStateSnapshot({}, drawingOps);
       return;
     }
 


### PR DESCRIPTION
## Summary
Fixed a bug where drawing changes received from Pusher broadcasts were being persisted back to the server, creating a feedback loop that caused unnecessary version bumps and repeated broadcasts to all clients.

## Key Changes
- Moved `persistBoardStateSnapshot()` call inside the `isDrawingSyncPending()` condition so it only persists when changes originate from the local drawing tool
- Updated comments to clarify the logic: persist only for local changes, skip persistence for incoming Pusher broadcasts since the server already has the correct state
- Prevents feedback loop where each client would re-save broadcasted changes, triggering additional broadcasts

## Implementation Details
The fix leverages the existing `isDrawingSyncPending()` check which indicates whether a change came from the local drawing tool (true) or from an incoming Pusher broadcast (false). By only persisting when this flag is true, we ensure that:
- Local drawing changes are saved to the server
- Incoming broadcasts are applied locally without being re-persisted
- The undo stack is preserved for local operations

https://claude.ai/code/session_01C5F6S6WGJGREXM1F2TXyCA