### PR TITLE
Keep hidden placements in player view but strip monster data

### DIFF
--- a/dnd/vtt/assets/js/state/__tests__/player-view-filter.test.mjs
+++ b/dnd/vtt/assets/js/state/__tests__/player-view-filter.test.mjs
@@ -10,7 +10,7 @@ import {
 // restrictPlacementsToPlayerView — hidden token filtering
 // ============================================================
 
-test('hidden:true placements are stripped from player view', () => {
+test('hidden:true placements are kept but monster data is stripped', () => {
   const placements = {
     'scene-1': [
       { id: 'visible', name: 'Fighter', column: 3 },
@@ -20,11 +20,13 @@ test('hidden:true placements are stripped from player view', () => {
 
   const filtered = restrictPlacementsToPlayerView(placements);
 
-  assert.equal(filtered['scene-1'].length, 1);
+  assert.equal(filtered['scene-1'].length, 2);
   assert.equal(filtered['scene-1'][0].id, 'visible');
+  assert.equal(filtered['scene-1'][1].id, 'hidden');
+  assert.equal(filtered['scene-1'][1].hidden, true);
 });
 
-test('isHidden alternate key is recognized', () => {
+test('isHidden alternate key placements are kept', () => {
   const placements = {
     'scene-1': [
       { id: 'hidden-alt', name: 'Secret', isHidden: true },
@@ -33,10 +35,11 @@ test('isHidden alternate key is recognized', () => {
 
   const filtered = restrictPlacementsToPlayerView(placements);
 
-  assert.equal(filtered['scene-1'].length, 0);
+  assert.equal(filtered['scene-1'].length, 1);
+  assert.equal(filtered['scene-1'][0].id, 'hidden-alt');
 });
 
-test('flags.hidden nested key is recognized', () => {
+test('flags.hidden nested key placements are kept', () => {
   const placements = {
     'scene-1': [
       { id: 'hidden-flags', name: 'Ambush', flags: { hidden: true } },
@@ -45,7 +48,8 @@ test('flags.hidden nested key is recognized', () => {
 
   const filtered = restrictPlacementsToPlayerView(placements);
 
-  assert.equal(filtered['scene-1'].length, 0);
+  assert.equal(filtered['scene-1'].length, 1);
+  assert.equal(filtered['scene-1'][0].id, 'hidden-flags');
 });
 
 test('non-hidden placements are preserved', () => {
@@ -61,7 +65,7 @@ test('non-hidden placements are preserved', () => {
   assert.equal(filtered['scene-1'].length, 2);
 });
 
-test('mixed hidden and visible in same scene', () => {
+test('mixed hidden and visible in same scene are all kept', () => {
   const placements = {
     'scene-1': [
       { id: 'visible-1', name: 'Fighter' },
@@ -75,10 +79,10 @@ test('mixed hidden and visible in same scene', () => {
   const filtered = restrictPlacementsToPlayerView(placements);
   const ids = filtered['scene-1'].map((e) => e.id);
 
-  assert.deepEqual(ids, ['visible-1', 'visible-2', 'visible-3']);
+  assert.deepEqual(ids, ['visible-1', 'hidden-1', 'visible-2', 'hidden-2', 'visible-3']);
 });
 
-test('string "true" is recognized as hidden', () => {
+test('string "true" hidden placements are kept', () => {
   const placements = {
     'scene-1': [
       { id: 'str-true', hidden: 'true' },
@@ -89,7 +93,7 @@ test('string "true" is recognized as hidden', () => {
 
   const filtered = restrictPlacementsToPlayerView(placements);
 
-  assert.equal(filtered['scene-1'].length, 0);
+  assert.equal(filtered['scene-1'].length, 3);
 });
 
 test('string "false" is NOT hidden', () => {
@@ -105,7 +109,7 @@ test('string "false" is NOT hidden', () => {
   assert.equal(filtered['scene-1'].length, 2);
 });
 
-test('integer 1 is recognized as hidden', () => {
+test('integer 1 hidden placement is kept', () => {
   const placements = {
     'scene-1': [
       { id: 'int-hidden', hidden: 1 },
@@ -114,10 +118,10 @@ test('integer 1 is recognized as hidden', () => {
 
   const filtered = restrictPlacementsToPlayerView(placements);
 
-  assert.equal(filtered['scene-1'].length, 0);
+  assert.equal(filtered['scene-1'].length, 1);
 });
 
-test('multiple scenes are filtered independently', () => {
+test('multiple scenes keep all placements including hidden', () => {
   const placements = {
     'scene-1': [
       { id: 's1-visible', name: 'Fighter' },
@@ -133,11 +137,9 @@ test('multiple scenes are filtered independently', () => {
 
   const filtered = restrictPlacementsToPlayerView(placements);
 
-  assert.equal(filtered['scene-1'].length, 1);
-  assert.equal(filtered['scene-1'][0].id, 's1-visible');
-  assert.equal(filtered['scene-2'].length, 0);
+  assert.equal(filtered['scene-1'].length, 2);
+  assert.equal(filtered['scene-2'].length, 1);
   assert.equal(filtered['scene-3'].length, 1);
-  assert.equal(filtered['scene-3'][0].id, 's3-visible');
 });
 
 test('empty placements returns empty object', () => {
@@ -214,7 +216,7 @@ test('placement with no combatTeam has monster stripped', () => {
   assert.equal(token.monsterId, undefined);
 });
 
-test('hidden enemy with monster data is fully stripped (entire placement removed)', () => {
+test('hidden enemy placement is kept but monster data is stripped', () => {
   const placements = {
     'scene-1': [
       {
@@ -228,7 +230,10 @@ test('hidden enemy with monster data is fully stripped (entire placement removed
 
   const filtered = restrictPlacementsToPlayerView(placements);
 
-  assert.equal(filtered['scene-1'].length, 0);
+  assert.equal(filtered['scene-1'].length, 1);
+  assert.equal(filtered['scene-1'][0].id, 'hidden-enemy');
+  assert.equal(filtered['scene-1'][0].hidden, true);
+  assert.equal(filtered['scene-1'][0].monster, undefined);
 });
 
 // ============================================================

--- a/dnd/vtt/assets/js/state/store.js
+++ b/dnd/vtt/assets/js/state/store.js
@@ -1249,16 +1249,9 @@ export function restrictPlacementsToPlayerView(placements = {}) {
   const filtered = {};
   Object.keys(placements).forEach((sceneId) => {
     const entries = Array.isArray(placements[sceneId]) ? placements[sceneId] : [];
-    const visibleEntries = entries
-      .filter((entry) => {
-        if (!entry || typeof entry !== 'object') {
-          return false;
-        }
-        const hidden = toBoolean(entry.hidden ?? entry.isHidden ?? entry?.flags?.hidden ?? false, false);
-        return hidden !== true;
-      })
+    filtered[sceneId] = entries
+      .filter((entry) => entry && typeof entry === 'object')
       .map((entry) => stripMonsterSnapshot(entry, { allowAllyMonster: true }));
-    filtered[sceneId] = visibleEntries;
   });
 
   return filtered;

--- a/dnd/vtt/assets/js/ui/__tests__/stamina-sync.test.mjs
+++ b/dnd/vtt/assets/js/ui/__tests__/stamina-sync.test.mjs
@@ -442,7 +442,7 @@ test('restrictPlacementsToPlayerView preserves placements with HP regardless of 
     'All non-hidden placements should be visible regardless of HP');
 });
 
-test('restrictPlacementsToPlayerView strips hidden tokens but keeps visible ones with HP', () => {
+test('restrictPlacementsToPlayerView keeps hidden tokens alongside visible ones with HP', () => {
   const placements = {
     'scene-1': [
       { id: 'visible', name: 'Fighter', hp: { current: '40', max: '50' } },
@@ -451,9 +451,11 @@ test('restrictPlacementsToPlayerView strips hidden tokens but keeps visible ones
   };
 
   const filtered = restrictPlacementsToPlayerView(placements);
-  assert.equal(filtered['scene-1'].length, 1);
+  assert.equal(filtered['scene-1'].length, 2);
   assert.equal(filtered['scene-1'][0].id, 'visible');
   assert.equal(filtered['scene-1'][0].hp.current, '40');
+  assert.equal(filtered['scene-1'][1].id, 'hidden');
+  assert.equal(filtered['scene-1'][1].hidden, true);
 });
 
 // ============================================================


### PR DESCRIPTION
## Summary
Changed the player view filtering behavior to keep hidden token placements visible to players while stripping sensitive monster data, rather than completely removing hidden placements from the view.

## Key Changes
- **Modified `restrictPlacementsToPlayerView()` function**: Removed the filter that excluded hidden placements entirely. Now all placements (hidden and visible) are kept in the player view, with monster data stripped from all entries via `stripMonsterSnapshot()`.
- **Updated test expectations**: All tests now verify that hidden placements are retained in the filtered output, with assertions checking that:
  - Hidden placements remain with their `hidden` property intact
  - Monster data is stripped from hidden placements
  - All placement IDs are preserved regardless of hidden status

## Implementation Details
- The function now filters only for valid entry objects, then maps all entries through `stripMonsterSnapshot()` to remove sensitive data
- Hidden detection logic (checking `hidden`, `isHidden`, and `flags.hidden` properties) was removed from the filter step since placements are no longer filtered by visibility
- Monster data stripping still occurs for all placements, ensuring hidden enemies don't expose their stat information to players
- This allows the UI to render hidden token placeholders while keeping the actual monster stats private

https://claude.ai/code/session_01Xez6FwqrzxpMer61eH2LFA