### PR TITLE
Remove syncBoard: false from condition updates and direct persistence

### DIFF
--- a/dnd/vtt/assets/js/ui/board-interactions.js
+++ b/dnd/vtt/assets/js/ui/board-interactions.js
@@ -9195,7 +9195,7 @@ export function mountBoardInteractions(store, routes = {}) {
           }
         }
       }
-    }, { syncBoard: false });
+    });
 
     if (updated && didChange) {
       refreshTokenSettings();
@@ -13874,7 +13874,12 @@ export function mountBoardInteractions(store, routes = {}) {
       boardApi.emitStateUpdate();
     }
 
-    persistBoardStateSnapshot();
+    // Persistence is handled by updatePlacementById / updatePlacementsByIds
+    // with syncBoard: true, which generates placement.update ops and routes
+    // them through the delta-op save path. Those ops are buffered in
+    // pendingBoardStateOps and survive save coalescing, so condition changes
+    // are no longer lost when a subsequent save (e.g. a token move) aborts
+    // the in-flight request.
     return true;
   }
 
@@ -16238,7 +16243,7 @@ export function mountBoardInteractions(store, routes = {}) {
           delete target.condition;
         }
       }
-    }, { syncBoard: false });
+    });
 
     if (updated && didChange) {
       refreshTokenSettings();
@@ -16289,7 +16294,7 @@ export function mountBoardInteractions(store, routes = {}) {
           delete target.condition;
         }
       }
-    }, { syncBoard: false });
+    });
 
     if (updated && didChange) {
       refreshTokenSettings();
@@ -16368,7 +16373,7 @@ export function mountBoardInteractions(store, routes = {}) {
             delete target.condition;
           }
         }
-      }, { syncBoard: false });
+      });
 
       if (updated) {
         cleared.push({
@@ -16440,7 +16445,7 @@ export function mountBoardInteractions(store, routes = {}) {
           delete target.condition;
         }
       }
-    }, { syncBoard: false });
+    });
 
     if (updated && didChange) {
       refreshTokenSettings();


### PR DESCRIPTION
## Summary
This PR refactors how board state persistence is handled for condition updates by removing explicit `syncBoard: false` options and eliminating direct `persistBoardStateSnapshot()` calls. Instead, persistence is now delegated to the delta-op save path through `updatePlacementById`/`updatePlacementsByIds` with `syncBoard: true`.

## Key Changes
- Removed `{ syncBoard: false }` option from 5 `updatePlacementsByIds()` calls across condition-related functions
- Removed direct `persistBoardStateSnapshot()` call and replaced it with a detailed comment explaining the new persistence strategy
- Updated persistence to flow through the delta-op system, which buffers operations in `pendingBoardStateOps`

## Implementation Details
The change addresses a data loss issue where condition changes could be lost when a subsequent save operation (e.g., token move) aborted an in-flight request. By routing condition updates through the delta-op save path with proper buffering, these operations now survive save coalescing and are guaranteed to persist even if concurrent save requests are aborted.

This represents a shift from immediate, direct persistence to a more robust queued persistence model that integrates with the existing save operation pipeline.

https://claude.ai/code/session_01X9xW4gfnLEATv9dEAXHqVA