### PR TITLE
Track placement modifications and mark dirty on state changes

### DIFF
--- a/dnd/vtt/assets/js/ui/board-interactions.js
+++ b/dnd/vtt/assets/js/ui/board-interactions.js
@@ -10816,12 +10816,14 @@ export function mountBoardInteractions(store, routes = {}) {
     const mutatedIds = [];
     boardApi.updateState?.((draft) => {
       const scenePlacements = ensureScenePlacementDraft(draft, activeSceneId);
+      const nowMs = Date.now();
       scenePlacements.forEach((placement) => {
         if (!placement || typeof placement !== 'object') {
           return;
         }
         if (placement.triggeredActionReady !== true) {
           placement.triggeredActionReady = true;
+          placement._lastModified = nowMs;
           mutated = true;
           if (placement.id) {
             mutatedIds.push(placement.id);
@@ -10831,6 +10833,9 @@ export function mountBoardInteractions(store, routes = {}) {
     });
 
     if (mutated) {
+      for (const id of mutatedIds) {
+        markPlacementDirty(activeSceneId, id);
+      }
       // Phase 3-B (commit 3): every reset here is the same single-
       // field flip (`triggeredActionReady: true`) across many
       // placements. Emit one `placement.update` op per mutated id
@@ -12894,6 +12899,7 @@ export function mountBoardInteractions(store, routes = {}) {
       const current = target.triggeredActionReady !== false;
       nextReady = !current;
       target.triggeredActionReady = nextReady;
+      target._lastModified = Date.now();
       if (gmUser) {
         markPlacementAsGmAuthored(target, { isGm: gmUser });
       }
@@ -12903,6 +12909,8 @@ export function mountBoardInteractions(store, routes = {}) {
     if (!updated) {
       return false;
     }
+
+    markPlacementDirty(activeSceneId, placementId);
 
     // Phase 3-B (commit 3): the only field that changed here is
     // `triggeredActionReady`, so we can hand-build a `placement.update`


### PR DESCRIPTION
## Summary
This change adds tracking of placement modifications by recording timestamps and marking placements as dirty when their `triggeredActionReady` state is updated. This ensures proper synchronization and change detection for placement state mutations.

## Key Changes
- Added `_lastModified` timestamp tracking when `triggeredActionReady` is toggled on placements
- Mark placements as dirty via `markPlacementDirty()` when batch updating `triggeredActionReady` state
- Mark placements as dirty when individually toggling `triggeredActionReady` through the UI
- Capture current timestamp once per batch operation to ensure consistency across multiple placements

## Implementation Details
- The `_lastModified` field is set to `Date.now()` whenever a placement's `triggeredActionReady` state changes
- In batch operations, the timestamp is captured once at the start and reused for all mutated placements for consistency
- The `markPlacementDirty()` function is called for each mutated placement ID to trigger proper change detection and synchronization
- Changes apply to both batch state updates and individual user interactions

https://claude.ai/code/session_01784VoknCQ7eCX3FpgoD6xu