### PR TITLE
Fix property deletion sync in board state operations

### DIFF
--- a/dnd/vtt/api/state.php
+++ b/dnd/vtt/api/state.php
@@ -1093,7 +1093,15 @@ function applyBoardStateOp(array $state, array $op, array $context = []): array
                 if ($key === 'id') {
                     continue;
                 }
-                $entry[$key] = $value;
+                // A null value signals that the property was deleted on
+                // the source client (e.g. the last condition removed from
+                // a token). Remove the key from the entry so downstream
+                // code sees the property as absent rather than null.
+                if ($value === null) {
+                    unset($entry[$key]);
+                } else {
+                    $entry[$key] = $value;
+                }
             }
             $entry['_lastModified'] = $nowMs;
             $state['placements'][$sceneId][$idx] = $entry;

--- a/dnd/vtt/assets/js/services/board-state-op-applier.js
+++ b/dnd/vtt/assets/js/services/board-state-op-applier.js
@@ -126,10 +126,16 @@ export function applyBoardStateOpLocally(boardState, op) {
       const entry = list[i];
       if (!entry || typeof entry !== 'object') continue;
       if (entryId(entry) !== placementId) continue;
-      // Shallow merge — never overwrite the id.
+      // Shallow merge — never overwrite the id. A null value signals
+      // that the property was deleted on the source client (e.g. the
+      // last condition was removed from a token), so delete locally.
       for (const key of Object.keys(op.patch)) {
         if (key === 'id') continue;
-        entry[key] = op.patch[key];
+        if (op.patch[key] === null) {
+          delete entry[key];
+        } else {
+          entry[key] = op.patch[key];
+        }
       }
       entry._lastModified = Date.now();
       return true;

--- a/dnd/vtt/assets/js/ui/board-interactions.js
+++ b/dnd/vtt/assets/js/ui/board-interactions.js
@@ -1757,7 +1757,12 @@ export function mountBoardInteractions(store, routes = {}) {
         changed = true;
       }
       if (changed) {
-        patch[key] = afterVal;
+        // Use null (not undefined) for deleted properties so the
+        // value survives JSON.stringify and reaches the server/other
+        // clients. Without this, removing the last condition from a
+        // token produces an undefined value that is silently dropped
+        // during serialization, so the deletion never syncs.
+        patch[key] = key in after ? afterVal : null;
       }
     }
     return Object.keys(patch).length > 0 ? patch : null;


### PR DESCRIPTION
## Summary
Fixed an issue where deleting properties from board placements (e.g., removing the last condition from a token) was not syncing properly across clients. The problem was that deleted properties were being serialized as `undefined` instead of `null`, causing them to be silently dropped during JSON serialization and never reaching the server or other clients.

## Key Changes
- **board-interactions.js**: Modified patch generation to use `null` (instead of `undefined`) for deleted properties, ensuring they survive JSON serialization and reach the server/other clients
- **state.php**: Updated board state operation application to treat `null` values as deletion signals, removing the key from the entry entirely rather than storing a null value
- **board-state-op-applier.js**: Updated local state application to mirror the server behavior, deleting properties when a `null` value is received in the patch

## Implementation Details
The fix uses `null` as a sentinel value to indicate property deletion:
1. When a property is removed locally, the patch includes `null` for that key
2. The `null` value persists through JSON serialization (unlike `undefined`)
3. Both server and client code recognize `null` as a deletion signal and remove the property entirely
4. This ensures consistency across all clients and the server state

https://claude.ai/code/session_01NSxngFkhBRzQBqNzM46Mur