### PR TITLE
Fix drawing synchronization for erase/clear/undo operations

### DIFF
--- a/dnd/vtt/api/state.php
+++ b/dnd/vtt/api/state.php
@@ -789,6 +789,17 @@ if (!defined('VTT_STATE_API_INCLUDE_ONLY')) {
                 if (isset($updates['overlay'])) {
                     $broadcastData['overlay'] = $updates['overlay'];
                 }
+                // Propagate the erase/clear full-replace marker to receivers.
+                // The server applies `_replaceDrawings` by replacing each
+                // listed scene's drawing array wholesale; without this hint
+                // in the broadcast, receivers would additively merge the
+                // (often empty) `drawings` payload and never drop the
+                // drawings the author just removed. Only emitted when the
+                // save actually carried `_replaceDrawings`, so normal
+                // additive draw-add broadcasts are unchanged.
+                if (!empty($replaceDrawingScenes)) {
+                    $broadcastData['replaceDrawings'] = array_values($replaceDrawingScenes);
+                }
             }
 
             // Send the response to the client first so the sender is not

--- a/dnd/vtt/assets/js/services/pusher-service.js
+++ b/dnd/vtt/assets/js/services/pusher-service.js
@@ -253,6 +253,7 @@ function handleStateUpdated(data) {
     placements,
     templates,
     drawings,
+    replaceDrawings,
     pings,
     sceneState,
     activeSceneId,
@@ -326,6 +327,13 @@ function handleStateUpdated(data) {
     }
     if (drawings !== undefined) {
       delta.drawings = drawings;
+    }
+    // List of scene IDs whose drawings array should be fully replaced
+    // (erase/clear/undo). Forwarded so the consumer's drawings merge can
+    // drop entries absent from the broadcast for those scenes; normal
+    // additive draw broadcasts omit this field.
+    if (Array.isArray(replaceDrawings) && replaceDrawings.length > 0) {
+      delta.replaceDrawings = replaceDrawings;
     }
     if (pings !== undefined) {
       delta.pings = pings;

--- a/dnd/vtt/assets/js/ui/board-interactions.js
+++ b/dnd/vtt/assets/js/ui/board-interactions.js
@@ -3418,26 +3418,43 @@ export function mountBoardInteractions(store, routes = {}) {
         if (!draft.boardState.drawings) {
           draft.boardState.drawings = {};
         }
+        // Scenes flagged for full replacement ride the snapshot
+        // `_replaceDrawings` mechanism on save (erase/clear/undo). The
+        // broadcast forwards that list via `delta.replaceDrawings` so we
+        // know to drop drawings absent from the incoming list rather than
+        // additively merging — without this, a clear from one client
+        // would never remove drawings on other clients.
+        const replaceScenes = Array.isArray(delta.replaceDrawings)
+          ? new Set(delta.replaceDrawings)
+          : null;
         Object.entries(delta.drawings).forEach(([sceneId, drawings]) => {
-          if (Array.isArray(drawings)) {
-            const existing = draft.boardState.drawings[sceneId] || [];
-            const byId = new Map(existing.map((d) => [d.id, d]));
-            drawings.forEach((drawing) => {
-              if (drawing && drawing.id) {
-                const existingDrawing = byId.get(drawing.id);
-                if (existingDrawing) {
-                  const existingTime = existingDrawing._lastModified || 0;
-                  const incomingTime = drawing._lastModified || 0;
-                  if (incomingTime >= existingTime) {
-                    byId.set(drawing.id, drawing);
-                  }
-                } else {
+          if (!Array.isArray(drawings)) {
+            return;
+          }
+          if (replaceScenes && replaceScenes.has(sceneId)) {
+            // Trust the broadcast as authoritative for this scene.
+            // Clone entries so the store does not share references with
+            // the incoming Pusher payload.
+            draft.boardState.drawings[sceneId] = drawings.map((drawing) => ({ ...drawing }));
+            return;
+          }
+          const existing = draft.boardState.drawings[sceneId] || [];
+          const byId = new Map(existing.map((d) => [d.id, d]));
+          drawings.forEach((drawing) => {
+            if (drawing && drawing.id) {
+              const existingDrawing = byId.get(drawing.id);
+              if (existingDrawing) {
+                const existingTime = existingDrawing._lastModified || 0;
+                const incomingTime = drawing._lastModified || 0;
+                if (incomingTime >= existingTime) {
                   byId.set(drawing.id, drawing);
                 }
+              } else {
+                byId.set(drawing.id, drawing);
               }
-            });
-            draft.boardState.drawings[sceneId] = Array.from(byId.values());
-          }
+            }
+          });
+          draft.boardState.drawings[sceneId] = Array.from(byId.values());
         });
       }
 


### PR DESCRIPTION
## Summary
This PR fixes a critical synchronization issue where drawing deletions (from erase, clear, or undo operations) were not properly propagated to other connected clients. The fix implements a full-replacement mechanism for affected scenes instead of additive merging.

## Problem
When one client performed an erase, clear, or undo operation on drawings, other clients would not see those drawings removed. This occurred because the broadcast payload contained only the remaining drawings, and the receiver would additively merge them with existing drawings rather than replacing them wholesale. Without knowing which scenes had their drawings fully replaced, there was no way to distinguish between "no changes to this scene" and "all drawings in this scene were deleted."

## Solution
Implemented a three-part fix:

1. **Server-side broadcast enhancement** (`state.php`):
   - Added `replaceDrawings` field to the broadcast payload containing scene IDs that underwent full drawing replacement
   - This field is only included when the save operation actually carried `_replaceDrawings`, keeping normal additive broadcasts unchanged

2. **Pusher service update** (`pusher-service.js`):
   - Extract and forward the `replaceDrawings` list from incoming broadcasts
   - Pass it through the delta object to the state consumer

3. **Board interactions merge logic** (`board-interactions.js`):
   - Check if a scene is flagged for replacement before applying the merge
   - For flagged scenes, perform a wholesale replacement of the drawings array (with cloning to avoid reference sharing with the Pusher payload)
   - For non-flagged scenes, continue with the existing timestamp-based merge strategy
   - Refactored the merge logic for clarity with early returns

## Implementation Details
- The `replaceDrawings` field is only emitted when necessary, maintaining backward compatibility
- Drawings are cloned during replacement to prevent the store from sharing references with the incoming broadcast payload
- The timestamp-based merge strategy is preserved for normal additive drawing operations

https://claude.ai/code/session_012H8oXJzrpHsNXWX5DrYE48