### PR TITLE
feat(strixhaven): add GM-only Other NPCs section

### DIFF
--- a/dnd/dashboard.php
+++ b/dnd/dashboard.php
@@ -942,7 +942,7 @@ $defaultInventoryTab = $is_gm ? 'frunk' : $user;
                     <?php if ($is_gm): ?><a href="#" onclick="openStrixhavenSection('monster-creator')">Monster Creator</a><?php endif; ?>
                     <a href="#" onclick="openStrixhavenSection('templates')">Templates</a>
                     <a href="#" onclick="openStrixhavenSection('arcaneconstruction')" class="<?php echo ($user === 'zepha' || $is_gm) ? 'zepha-gm-allowed' : 'access-restricted'; ?>">Arcane Construction</a>
-                    <a href="#" onclick="openStrixhavenSection('coming-soon-5')">Coming Soon</a>
+                    <?php if ($is_gm): ?><a href="#" onclick="openStrixhavenSection('othernpcs')">Other NPCs</a><?php endif; ?>
                     <?php if ($is_gm): ?><!-- GM tab - only visible to GM -->
                     <a href="#" onclick="openStrixhavenSection('gm')">GM</a><?php endif; ?>
                 </div>

--- a/dnd/js/character-sheet.js
+++ b/dnd/js/character-sheet.js
@@ -2445,7 +2445,7 @@ function openRulesSection(section) {
 
 function openStrixhavenSection(section) {
     // Check if GM-only sections and user is not GM
-    if ((section === 'gm' || section === 'monster-creator') && !isGM) {
+    if ((section === 'gm' || section === 'monster-creator' || section === 'othernpcs') && !isGM) {
         // Do nothing - GM-only sections are restricted
         return false;
     }

--- a/dnd/strixhaven/othernpcs/css/othernpcs.css
+++ b/dnd/strixhaven/othernpcs/css/othernpcs.css
@@ -1,0 +1,1660 @@
+/* Other NPCs Section Styles */
+
+/* Main Layout */
+.main-container {
+    max-width: none;
+    width: 100%;
+    margin: 0;
+    padding: 12px 14px;
+    background: #f7f1e8;
+}
+
+/* Control Panel */
+.control-panel {
+    background: #fdf9f3;
+    border-radius: 6px;
+    padding: 14px 16px;
+    margin-bottom: 12px;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.05);
+    border: 1px solid #d2c2aa;
+}
+
+.search-section {
+    margin-bottom: 12px;
+}
+
+.search-input {
+    width: 100%;
+    max-width: 400px;
+    padding: 10px 12px;
+    border: 1px solid #c2b39a;
+    border-radius: 5px;
+    font-size: 15px;
+    background: #fffdf7;
+    color: #2f261b;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.search-input:focus {
+    outline: none;
+    border-color: #8b5e3c;
+    box-shadow: 0 0 0 2px rgba(139, 94, 60, 0.15);
+}
+
+.filter-section {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    align-items: center;
+}
+
+.filter-group {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.filter-group label {
+    font-weight: 600;
+    color: #2f261b;
+    margin-right: 4px;
+}
+
+.filter-btn {
+    padding: 8px 12px;
+    border: 1px solid #c2b39a;
+    background: #f4ede3;
+    border-radius: 5px;
+    cursor: pointer;
+    font-size: 14px;
+    font-weight: 500;
+    transition: all 0.2s ease;
+    color: #3d3123;
+}
+
+.filter-btn:hover {
+    border-color: #8b5e3c;
+    color: #8b5e3c;
+}
+
+.filter-btn.active {
+    background: #8b5e3c;
+    border-color: #7a4f31;
+    color: #fdfaf5;
+}
+
+.filter-select {
+    padding: 8px 10px;
+    border: 1px solid #c2b39a;
+    border-radius: 5px;
+    background: #fffdf7;
+    font-size: 14px;
+    cursor: pointer;
+    transition: border-color 0.2s ease;
+}
+
+.filter-select:focus {
+    outline: none;
+    border-color: #8b5e3c;
+}
+
+.admin-controls {
+    margin-left: auto;
+}
+
+.btn-add {
+    background: #7a4f31;
+    color: #fdfaf5;
+    border: 1px solid #6c452c;
+    padding: 9px 16px;
+    border-radius: 5px;
+    cursor: pointer;
+    font-size: 14px;
+    font-weight: 600;
+    transition: background-color 0.2s ease, transform 0.2s ease;
+}
+
+.btn-add:hover {
+    background: #8b5e3c;
+    transform: translateY(-1px);
+}
+
+.btn-import {
+    background: #8b5e3c;
+    color: #fdfaf5;
+    border: 1px solid #7a4f31;
+    padding: 9px 16px;
+    border-radius: 5px;
+    cursor: pointer;
+    font-size: 14px;
+    font-weight: 600;
+    transition: background-color 0.2s ease, transform 0.2s ease;
+    margin-left: 8px;
+}
+
+.btn-import:hover {
+    background: #9c6b45;
+    transform: translateY(-1px);
+}
+
+.btn-export {
+    background: #6f7a3a;
+    color: #fdfaf5;
+    border: 1px solid #5f692f;
+    padding: 9px 16px;
+    border-radius: 5px;
+    cursor: pointer;
+    font-size: 14px;
+    font-weight: 600;
+    transition: background-color 0.2s ease, transform 0.2s ease;
+    margin-left: 8px;
+}
+
+.btn-export:hover {
+    background: #7d8745;
+    transform: translateY(-1px);
+}
+
+.btn-cancel {
+    background: #5f5f5f;
+    color: #fdfaf5;
+    border: 1px solid #4a4a4a;
+    padding: 9px 16px;
+    border-radius: 5px;
+    cursor: pointer;
+    font-size: 14px;
+    font-weight: 600;
+    transition: background-color 0.2s ease, transform 0.2s ease;
+    margin-left: 8px;
+}
+
+.btn-cancel:hover {
+    background: #6b6b6b;
+    transform: translateY(-1px);
+}
+
+.export-selection-actions {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-top: 8px;
+    flex-wrap: wrap;
+}
+
+.export-selection-count {
+    font-size: 14px;
+    font-weight: 600;
+    color: #2f261b;
+}
+
+.btn-copy {
+    background: #435764;
+    color: #fdfaf5;
+    border: 1px solid #3a4b55;
+    padding: 8px 14px;
+    border-radius: 5px;
+    cursor: pointer;
+    font-size: 14px;
+    font-weight: 500;
+    transition: background-color 0.2s ease, transform 0.2s ease;
+}
+
+.btn-copy:hover {
+    background: #516775;
+    transform: translateY(-1px);
+}
+
+/* Students Grid */
+.npcs-container {
+    background: #fdf9f3;
+    border-radius: 6px;
+    padding: 14px;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.05);
+    border: 1px solid #d2c2aa;
+    min-height: 400px;
+}
+
+.npcs-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+    gap: 12px;
+    margin-bottom: 18px;
+}
+
+.npc-card {
+    background: #f4ede3;
+    border: 1px solid #c2b39a;
+    border-radius: 6px;
+    padding: 12px;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    position: relative;
+    overflow: hidden;
+}
+
+.export-selection-active .npc-card {
+    border-color: #bda980;
+}
+
+.npc-card.is-selected {
+    border-color: #8b5e3c;
+    box-shadow: 0 0 0 2px rgba(139, 94, 60, 0.2);
+}
+
+.export-select-indicator {
+    position: absolute;
+    top: 8px;
+    right: 8px;
+    width: 22px;
+    height: 22px;
+    border-radius: 50%;
+    border: 2px solid #8b5e3c;
+    background: #f4ede3;
+    color: white;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 12px;
+    font-weight: 700;
+    opacity: 0;
+    transform: scale(0.9);
+    transition: all 0.2s ease;
+    pointer-events: none;
+}
+
+.export-selection-active .export-select-indicator {
+    opacity: 1;
+}
+
+.npc-card.is-selected .export-select-indicator {
+    background: #8b5e3c;
+}
+
+.npc-card:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.08);
+    border-color: #8b5e3c;
+}
+
+.npc-card.expanded {
+    border-color: #8b5e3c;
+    background: #f0e7dc;
+}
+
+.npc-thumbnail {
+    width: 80px;
+    height: 80px;
+    border-radius: 6px;
+    object-fit: cover;
+    border: 2px solid #c2b39a;
+    margin: 0 auto 10px;
+    display: block;
+    transition: border-color 0.2s ease;
+}
+
+.npc-card:hover .npc-thumbnail {
+    border-color: #8b5e3c;
+}
+
+.npc-placeholder {
+    width: 80px;
+    height: 80px;
+    border-radius: 6px;
+    background: #e9decc;
+    margin: 0 auto 10px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 14px;
+    color: #5b4a3a;
+    border: 2px solid #c2b39a;
+    transition: all 0.2s ease;
+}
+
+.npc-card:hover .npc-placeholder {
+    border-color: #8b5e3c;
+    background: #f0e7dc;
+}
+
+.npc-name {
+    font-size: 18px;
+    font-weight: 600;
+    color: #2f261b;
+    text-align: center;
+    margin-bottom: 6px;
+    line-height: 1.3;
+}
+
+.npc-info {
+    text-align: center;
+    font-size: 13px;
+    color: #5b4a3a;
+    line-height: 1.35;
+}
+
+.npc-grade {
+    color: #8b5e3c;
+    font-weight: 500;
+}
+
+.npc-college {
+    color: #7a3a2a;
+    font-weight: 500;
+}
+
+.npc-favorite {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    background: #f39c12;
+    color: white;
+    border-radius: 50%;
+    width: 24px;
+    height: 24px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 12px;
+    opacity: 0.9;
+}
+
+/* No Students Message */
+.no-npcs {
+    text-align: center;
+    padding: 60px 20px;
+    color: #666;
+    font-size: 18px;
+}
+
+.no-npcs-icon {
+    font-size: 48px;
+    margin-bottom: 16px;
+    opacity: 0.5;
+}
+
+/* Pagination */
+.pagination {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 8px;
+    margin-top: 14px;
+    padding-top: 14px;
+    border-top: 1px solid #d2c2aa;
+}
+
+.pagination-btn {
+    padding: 7px 10px;
+    border: 1px solid #c2b39a;
+    background: #f4ede3;
+    border-radius: 5px;
+    cursor: pointer;
+    font-size: 14px;
+    transition: all 0.2s ease;
+    min-width: 40px;
+    text-align: center;
+}
+
+.pagination-btn:hover:not(:disabled) {
+    border-color: #8b5e3c;
+    color: #8b5e3c;
+}
+
+.pagination-btn.active {
+    background: #8b5e3c;
+    border-color: #7a4f31;
+    color: #fdfaf5;
+}
+
+.pagination-btn:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+    color: #999;
+}
+
+.pagination-info {
+    font-size: 14px;
+    color: #666;
+    margin: 0 15px;
+}
+
+/* Loading States */
+.loading {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: 60px 20px;
+    color: #666;
+}
+
+.spinner {
+    width: 40px;
+    height: 40px;
+    border: 3px solid #e1e8ed;
+    border-top: 3px solid #667eea;
+    border-radius: 50%;
+    animation: spin 1s linear infinite;
+    margin-bottom: 16px;
+}
+
+@keyframes spin {
+    0% { transform: rotate(0deg); }
+    100% { transform: rotate(360deg); }
+}
+
+@keyframes slideInRight {
+    from {
+        transform: translateX(100%);
+        opacity: 0;
+    }
+    to {
+        transform: translateX(0);
+        opacity: 1;
+    }
+}
+
+@keyframes slideOutRight {
+    from {
+        transform: translateX(0);
+        opacity: 1;
+    }
+    to {
+        transform: translateX(100%);
+        opacity: 0;
+    }
+}
+
+/* Modal Styles */
+.modal {
+    display: none;
+    position: fixed;
+    z-index: 1000;
+    left: 0;
+    top: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.5);
+    backdrop-filter: blur(3px);
+}
+
+.modal-content {
+    background: #fdf9f3;
+    margin: 2% auto;
+    border-radius: 8px;
+    width: 90%;
+    max-width: 800px;
+    max-height: 90vh;
+    overflow-y: auto;
+    border: 1px solid #c2b39a;
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.18);
+    animation: modalSlideIn 0.25s ease-out;
+}
+
+@keyframes modalSlideIn {
+    from {
+        opacity: 0;
+        transform: translateY(-50px) scale(0.95);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0) scale(1);
+    }
+}
+
+.modal-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 14px 20px;
+    border-bottom: 1px solid #d2c2aa;
+    background: #f4ede3;
+    border-radius: 8px 8px 0 0;
+}
+
+.modal-header h2 {
+    margin: 0;
+    color: #2f261b;
+    font-size: 22px;
+}
+
+.modal-controls {
+    display: flex;
+    gap: 10px;
+    align-items: center;
+}
+
+.btn-favorite {
+    background: #c07a2d;
+    color: #fdfaf5;
+    border: 1px solid #a86522;
+    padding: 7px 10px;
+    border-radius: 5px;
+    cursor: pointer;
+    font-size: 15px;
+    transition: background-color 0.2s ease, transform 0.2s ease;
+}
+
+.btn-favorite:hover {
+    background: #d18633;
+    transform: translateY(-1px);
+}
+
+.btn-favorite.active {
+    background: #d18633;
+    box-shadow: 0 0 10px rgba(193, 122, 45, 0.35);
+}
+
+.btn-expand {
+    background: #5a7080;
+    color: #fdfaf5;
+    border: 1px solid #4b5f6c;
+    padding: 7px 10px;
+    border-radius: 5px;
+    cursor: pointer;
+    font-size: 15px;
+    transition: background-color 0.2s ease, transform 0.2s ease;
+}
+
+.btn-expand:hover {
+    background: #6a8292;
+    transform: translateY(-1px);
+}
+
+.btn-danger {
+    background: #9b3b2f;
+    color: #fdfaf5;
+    border: 1px solid #833126;
+    padding: 7px 10px;
+    border-radius: 5px;
+    cursor: pointer;
+    font-size: 15px;
+    transition: background-color 0.2s ease, transform 0.2s ease;
+}
+
+.btn-danger:hover {
+    background: #a84335;
+    transform: translateY(-1px);
+}
+
+.close {
+    font-size: 26px;
+    font-weight: bold;
+    cursor: pointer;
+    color: #5b4a3a;
+    transition: color 0.2s ease;
+    margin-left: 12px;
+}
+
+.close:hover {
+    color: #9b3b2f;
+}
+
+.modal-body {
+    padding: 20px 22px;
+}
+
+.npc-details {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+}
+
+.npc-portrait-section {
+    text-align: center;
+    margin-bottom: 30px;
+}
+
+.npc-portrait {
+    width: 150px;
+    height: 150px;
+    border-radius: 12px;
+    object-fit: cover;
+    border: 3px solid #e1e8ed;
+    margin-bottom: 15px;
+}
+
+.npc-portrait-placeholder {
+    width: 150px;
+    height: 150px;
+    border-radius: 12px;
+    background: #e1e8ed;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: #777;
+    font-size: 16px;
+    border: 3px solid #e1e8ed;
+    margin-bottom: 15px;
+}
+
+.upload-portrait-btn {
+    background: #667eea;
+    color: white;
+    border: none;
+    padding: 8px 16px;
+    border-radius: 6px;
+    cursor: pointer;
+    font-size: 14px;
+    transition: all 0.3s ease;
+}
+
+.upload-portrait-btn:hover {
+    background: #5a67d8;
+}
+
+.npc-form {
+    display: grid;
+    gap: 20px;
+}
+
+.form-row {
+    display: grid;
+    grid-template-columns: 1fr 1fr 1fr 1fr;
+    gap: 20px;
+}
+
+.form-row:has(.form-group-half) {
+    grid-template-columns: 1fr 1fr 0.5fr 0.5fr;
+}
+
+.form-group-half {
+    min-width: 0;
+}
+
+.form-group {
+    display: flex;
+    flex-direction: column;
+}
+
+.form-group label {
+    font-weight: 600;
+    color: #2c3e50;
+    margin-bottom: 5px;
+}
+
+.form-group input,
+.form-group select,
+.form-group textarea {
+    padding: 10px 12px;
+    border: 2px solid #e1e8ed;
+    border-radius: 6px;
+    font-size: 14px;
+    transition: border-color 0.3s ease;
+}
+
+.form-group input:focus,
+.form-group select:focus,
+.form-group textarea:focus {
+    outline: none;
+    border-color: #667eea;
+}
+
+.form-group textarea {
+    resize: vertical;
+    min-height: 80px;
+}
+
+.readonly-field {
+    padding: 10px 12px;
+    background: #f8f9fa;
+    border: 2px solid #e1e8ed;
+    border-radius: 6px;
+    color: #666;
+    font-size: 14px;
+}
+
+.clubs-container {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    margin-top: 5px;
+}
+
+.club-tag {
+    background: #667eea;
+    color: white;
+    padding: 4px 8px;
+    border-radius: 12px;
+    font-size: 12px;
+    font-weight: 500;
+}
+
+/* Form Sections */
+.form-section {
+    margin-bottom: 30px;
+    padding: 20px;
+    background: #f8f9fa;
+    border-radius: 8px;
+    border: 1px solid #e1e8ed;
+}
+
+.form-section h3 {
+    margin: 0 0 20px 0;
+    color: #2c3e50;
+    font-size: 18px;
+    border-bottom: 2px solid #667eea;
+    padding-bottom: 8px;
+}
+
+/* GM Only Sections */
+.form-section.gm-only {
+    background: #fef9e7;
+    border: 1px solid #f39c12;
+    border-left: 4px solid #f39c12;
+}
+
+.form-section.gm-only h3 {
+    color: #d68910;
+    border-bottom-color: #f39c12;
+}
+
+/* Character Information Section */
+.form-section.character-info .form-group {
+    margin-bottom: 20px;
+}
+
+.form-section.character-info textarea {
+    min-height: 60px;
+    resize: vertical;
+    overflow: hidden;
+}
+
+/* Auto-expanding textareas */
+.form-section textarea {
+    overflow: hidden;
+    resize: none;
+    min-height: 60px;
+    transition: height 0.3s ease;
+}
+
+.form-section textarea:focus {
+    resize: vertical;
+}
+
+/* Skills Section */
+.skills-container {
+    display: flex;
+    flex-direction: column;
+    gap: 15px;
+}
+
+.selected-skills {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    min-height: 40px;
+    padding: 10px;
+    background: white;
+    border: 2px solid #e1e8ed;
+    border-radius: 6px;
+}
+
+.skill-tag {
+    background: #27ae60;
+    color: white;
+    padding: 4px 8px;
+    border-radius: 12px;
+    font-size: 12px;
+    font-weight: 500;
+    display: flex;
+    align-items: center;
+    gap: 4px;
+}
+
+.remove-skill {
+    cursor: pointer;
+    font-weight: bold;
+    opacity: 0.8;
+    transition: opacity 0.3s ease;
+}
+
+.remove-skill:hover {
+    opacity: 1;
+    background: rgba(255, 255, 255, 0.2);
+    border-radius: 50%;
+    width: 16px;
+    height: 16px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.skills-controls {
+    display: flex;
+    gap: 10px;
+    align-items: center;
+    flex-wrap: wrap;
+}
+
+.skills-dropdown {
+    min-width: 200px;
+    padding: 8px 12px;
+    border: 2px solid #e1e8ed;
+    border-radius: 6px;
+    background: white;
+    font-size: 14px;
+}
+
+.custom-skill-input {
+    min-width: 150px;
+    padding: 8px 12px;
+    border: 2px solid #e1e8ed;
+    border-radius: 6px;
+    font-size: 14px;
+}
+
+.skills-controls button {
+    padding: 8px 16px;
+    background: #667eea;
+    color: white;
+    border: none;
+    border-radius: 6px;
+    cursor: pointer;
+    font-size: 14px;
+    transition: background-color 0.3s ease;
+}
+
+.skills-controls button:hover {
+    background: #5a67d8;
+}
+
+/* Relationships Section */
+.relationships-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 15px;
+}
+
+.relationship-item {
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+}
+
+.relationship-item label {
+    font-weight: 600;
+    color: #667eea;
+    font-size: 14px;
+}
+
+.relationship-item input {
+    padding: 8px 12px;
+    border: 2px solid #e1e8ed;
+    border-radius: 6px;
+    font-size: 14px;
+    transition: border-color 0.3s ease;
+}
+
+.relationship-item input:focus {
+    outline: none;
+    border-color: #667eea;
+}
+
+/* PC Relationships Section */
+.pc-relationships-list {
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+}
+
+.pc-relationship {
+    border: 1px solid #e1e8ed;
+    border-radius: 8px;
+    padding: 15px;
+    background: white;
+}
+
+.pc-relationship-header {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin-bottom: 8px;
+}
+
+.pc-relationship-header label {
+    font-weight: 600;
+    color: #667eea;
+    font-size: 16px;
+    min-width: 60px;
+}
+
+.relationship-points {
+    width: 80px;
+    padding: 6px 10px;
+    border: 2px solid #e1e8ed;
+    border-radius: 6px;
+    font-size: 14px;
+    text-align: center;
+    transition: border-color 0.3s ease;
+}
+
+.relationship-points:focus {
+    outline: none;
+    border-color: #667eea;
+}
+
+.readonly-points {
+    background: #f8f9fa;
+    border: 2px solid #e1e8ed;
+    border-radius: 6px;
+    padding: 6px 10px;
+    font-size: 14px;
+    color: #666;
+    min-width: 60px;
+    text-align: center;
+    display: inline-block;
+}
+
+.pc-relationship textarea {
+    width: 100%;
+    padding: 8px 12px;
+    border: 2px solid #e1e8ed;
+    border-radius: 6px;
+    font-size: 14px;
+    resize: vertical;
+    transition: border-color 0.3s ease;
+}
+
+.pc-relationship textarea:focus {
+    outline: none;
+    border-color: #667eea;
+}
+
+/* Responsive Design */
+@media (max-width: 1024px) {
+    .form-row {
+        grid-template-columns: 1fr 1fr;
+    }
+    
+    .form-row:has(.form-group-half) {
+        grid-template-columns: 1fr 1fr;
+    }
+}
+
+@media (max-width: 768px) {
+    .filter-section {
+        flex-direction: column;
+        align-items: stretch;
+        gap: 15px;
+    }
+    
+    .filter-group {
+        flex-wrap: wrap;
+        justify-content: center;
+    }
+    
+    .admin-controls {
+        margin-left: 0;
+        text-align: center;
+    }
+    
+    .npcs-grid {
+        grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+        gap: 15px;
+    }
+    
+    .npc-details {
+        text-align: center;
+    }
+    
+    .form-row {
+        grid-template-columns: 1fr;
+    }
+    
+    .form-row:has(.form-group-half) {
+        grid-template-columns: 1fr;
+    }
+    
+    .modal-content {
+        margin: 5% auto;
+        width: 95%;
+    }
+    
+    .modal-header {
+        padding: 15px 20px;
+    }
+    
+    .modal-body {
+        padding: 20px;
+    }
+}
+
+/* Image Gallery Styles */
+.image-gallery {
+    position: relative;
+    display: inline-block;
+}
+
+.image-container {
+    position: relative;
+    display: inline-block;
+}
+
+.gallery-image {
+    display: block;
+    max-width: 300px;
+    max-height: 300px;
+    border-radius: 8px;
+    object-fit: cover;
+    border: 2px solid #e1e8ed;
+    transition: all 0.3s ease;
+    cursor: pointer;
+}
+
+.gallery-image:hover {
+    border-color: #667eea;
+    transform: scale(1.02);
+}
+
+.gallery-nav {
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+    background: rgba(0, 0, 0, 0.7);
+    color: white;
+    border: none;
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    cursor: pointer;
+    font-size: 18px;
+    font-weight: bold;
+    transition: all 0.3s ease;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 3;
+}
+
+.gallery-nav:hover {
+    background: rgba(0, 0, 0, 0.9);
+    transform: translateY(-50%) scale(1.1);
+}
+
+.gallery-nav.prev {
+    left: -20px;
+}
+
+.gallery-nav.next {
+    right: -20px;
+}
+
+.gallery-indicator {
+    position: absolute;
+    bottom: 10px;
+    left: 50%;
+    transform: translateX(-50%);
+    background: rgba(0, 0, 0, 0.7);
+    color: white;
+    padding: 4px 8px;
+    border-radius: 12px;
+    font-size: 12px;
+    z-index: 3;
+}
+
+.delete-image-btn {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    background: #e74c3c;
+    color: white;
+    border: none;
+    width: 24px;
+    height: 24px;
+    border-radius: 50%;
+    cursor: pointer;
+    font-size: 14px;
+    font-weight: bold;
+    transition: all 0.3s ease;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 3;
+}
+
+.delete-image-btn:hover {
+    background: #c0392b;
+    transform: scale(1.1);
+}
+
+/* Image Popup Window - Draggable and Resizable */
+.image-popup {
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    width: 600px;
+    height: 450px;
+    background: white;
+    border-radius: 8px;
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
+    z-index: 2000;
+    resize: both;
+    overflow: hidden;
+    min-width: 200px;
+    min-height: 150px;
+    display: none;
+}
+
+.image-popup-header {
+    background: #f8f9fa;
+    padding: 10px 15px;
+    border-bottom: 1px solid #e1e8ed;
+    cursor: move;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    user-select: none;
+}
+
+.image-popup-title {
+    font-weight: 600;
+    color: #2c3e50;
+    font-size: 14px;
+}
+
+.image-popup-close {
+    background: #e74c3c;
+    color: white;
+    border: none;
+    width: 20px;
+    height: 20px;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 12px;
+    font-weight: bold;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: background 0.2s ease;
+}
+
+.image-popup-close:hover {
+    background: #c0392b;
+}
+
+.image-popup-content {
+    padding: 10px;
+    height: calc(100% - 50px);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.image-popup-content img {
+    max-width: 100%;
+    max-height: 100%;
+    object-fit: contain;
+    border-radius: 4px;
+}
+
+@media (max-width: 480px) {
+    .main-container {
+        padding: 10px;
+    }
+    
+    .control-panel,
+    .npcs-container {
+        padding: 15px;
+    }
+    
+    .npcs-grid {
+        grid-template-columns: 1fr;
+    }
+    
+    .npc-card {
+        padding: 12px;
+    }
+    
+    .pagination {
+        flex-wrap: wrap;
+        gap: 5px;
+    }
+    
+    .pagination-btn {
+        padding: 6px 10px;
+        font-size: 12px;
+        min-width: 35px;
+    }
+    
+    .gallery-nav {
+        width: 35px;
+        height: 35px;
+        font-size: 16px;
+    }
+    
+    .gallery-nav.prev {
+        left: -15px;
+    }
+    
+    .gallery-nav.next {
+        right: -15px;
+    }
+    
+    .gallery-image {
+        max-width: 250px;
+    }
+}
+
+/* Rich Text Editor Containers */
+.rich-text-container {
+    border: 2px solid #e1e8ed;
+    border-radius: 8px;
+    min-height: 100px;
+    background: white;
+    transition: border-color 0.3s ease, box-shadow 0.3s ease;
+}
+
+.rich-text-container.small {
+    min-height: 60px;
+}
+
+.rich-text-container.medium {
+    min-height: 120px;
+}
+
+.rich-text-container.large {
+    min-height: 180px;
+}
+
+.rich-text-container:focus-within {
+    border-color: #667eea;
+    box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+}
+
+/* Rich text editor specific styles */
+.rich-text-container .rich-text-editor {
+    min-height: inherit;
+    border: none;
+    border-radius: 6px;
+}
+
+/* Enhanced Rich Text Toolbar Styling - Copied from GM section */
+.rich-text-container .rich-text-toolbar {
+    display: flex !important;
+    align-items: center !important;
+    padding: 8px 12px !important;
+    background: #f8f9fa !important;
+    border-bottom: 1px solid #e9ecef !important;
+    gap: 5px !important;
+    flex-wrap: wrap !important;
+    min-height: 48px !important;
+    flex-shrink: 0 !important;
+    border-radius: 6px 6px 0 0;
+}
+
+.toolbar-btn {
+    background: white !important;
+    border: 1px solid #ddd !important;
+    border-radius: 4px !important;
+    padding: 6px 10px !important;
+    cursor: pointer !important;
+    font-size: 14px !important;
+    font-weight: bold !important;
+    color: #495057 !important;
+    transition: all 0.2s ease !important;
+    min-width: 32px !important;
+    height: 32px !important;
+    display: flex !important;
+    align-items: center !important;
+    justify-content: center !important;
+    line-height: 1 !important;
+    position: relative !important;
+    z-index: 1 !important;
+}
+
+.toolbar-btn:hover {
+    background: #e9ecef !important;
+    border-color: #adb5bd !important;
+    transform: translateY(-1px) !important;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.1) !important;
+}
+
+.toolbar-btn.active {
+    background: #007bff !important;
+    color: white !important;
+    border-color: #007bff !important;
+    box-shadow: 0 2px 4px rgba(0,123,255,0.3) !important;
+}
+
+.toolbar-btn:focus {
+    outline: none !important;
+    box-shadow: 0 0 0 2px rgba(0, 123, 255, 0.25) !important;
+}
+
+.toolbar-separator {
+    width: 1px !important;
+    height: 24px !important;
+    background: #dee2e6 !important;
+    margin: 0 5px !important;
+    flex-shrink: 0 !important;
+}
+
+/* Responsive adjustments */
+@media (max-width: 768px) {
+    .rich-text-container .rich-text-toolbar {
+        padding: 6px 8px !important;
+        gap: 3px !important;
+    }
+    
+    .toolbar-btn {
+        padding: 4px 6px !important;
+        font-size: 12px !important;
+        min-width: 28px !important;
+        height: 28px !important;
+    }
+}
+
+@media (max-width: 480px) {
+    .rich-text-container .rich-text-toolbar {
+        padding: 6px 8px;
+        gap: 3px;
+    }
+    
+    .toolbar-btn {
+        padding: 4px 6px;
+        font-size: 12px;
+        min-width: 28px;
+        height: 28px;
+    }
+}
+
+/* Version Footer */
+.version-footer {
+    position: fixed;
+    bottom: 0;
+    right: 0;
+    background: rgba(0, 0, 0, 0.8);
+    color: white;
+    padding: 5px 10px;
+    border-radius: 5px 0 0 0;
+    font-size: 12px;
+    z-index: 1000;
+    display: flex;
+    gap: 15px;
+    align-items: center;
+}
+
+.version-info {
+    font-weight: bold;
+    color: #4a9eff;
+}
+
+.version-updated {
+    opacity: 0.8;
+    font-size: 11px;
+}
+
+/* ===================== */
+/* Conflict Engine Styles */
+/* ===================== */
+
+.conflict-engine-section h3 {
+    color: #5b4a3a;
+    border-bottom-color: #c07a2d;
+}
+
+.ce-icon {
+    font-size: 16px;
+    margin-right: 4px;
+}
+
+.ce-block {
+    margin-bottom: 20px;
+    background: #fffdf7;
+    border-radius: 8px;
+    border: 1px solid #e8dcc8;
+    overflow: hidden;
+}
+
+.ce-block-header {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 10px 14px;
+    background: #faf5ec;
+    border-bottom: 1px solid #e8dcc8;
+}
+
+.ce-badge {
+    width: 28px;
+    height: 28px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: 700;
+    font-size: 14px;
+    color: white;
+    flex-shrink: 0;
+}
+
+.ce-badge-want { background: #2e7d32; }
+.ce-badge-obstacle { background: #6d4c41; }
+.ce-badge-action { background: #1565c0; }
+.ce-badge-consequence { background: #e65100; }
+
+.ce-block-title {
+    font-weight: 600;
+    font-size: 15px;
+    color: #3d3123;
+}
+
+.ce-want-tag-select {
+    margin-left: auto;
+    padding: 4px 8px;
+    border: 1px solid #c2b39a;
+    border-radius: 4px;
+    font-size: 13px;
+    background: white;
+}
+
+.ce-want-tag {
+    background: #2e7d32;
+    color: white;
+    padding: 2px 10px;
+    border-radius: 12px;
+    font-size: 12px;
+    font-weight: 600;
+}
+
+.ce-block-body {
+    padding: 12px 14px;
+}
+
+.ce-block-body .rich-text-container {
+    border: none;
+    min-height: 60px;
+    background: transparent;
+}
+
+/* ===================== */
+/* Tension Web Styles    */
+/* ===================== */
+
+.tension-web-section h3 {
+    color: #c07a2d;
+    border-bottom-color: #c07a2d;
+}
+
+.tension-web-list {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    margin-bottom: 16px;
+}
+
+.tension-web-entry {
+    background: #fffdf7;
+    border-left: 4px solid #c07a2d;
+    border-radius: 0 8px 8px 0;
+    padding: 12px 16px;
+    border-top: 1px solid #e8dcc8;
+    border-right: 1px solid #e8dcc8;
+    border-bottom: 1px solid #e8dcc8;
+}
+
+.tension-web-entry-header {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 6px;
+}
+
+.tension-web-name {
+    font-size: 15px;
+    color: #2f261b;
+}
+
+.tension-web-role {
+    font-size: 13px;
+    color: #8b7355;
+    font-style: italic;
+}
+
+.tension-web-description {
+    font-size: 14px;
+    color: #5b4a3a;
+    line-height: 1.5;
+}
+
+.btn-remove-tension {
+    margin-left: auto;
+    background: none;
+    border: none;
+    color: #9b3b2f;
+    font-size: 18px;
+    cursor: pointer;
+    padding: 0 4px;
+    line-height: 1;
+    opacity: 0.6;
+    transition: opacity 0.2s;
+}
+
+.btn-remove-tension:hover {
+    opacity: 1;
+}
+
+.tension-web-empty {
+    color: #8b7355;
+    font-style: italic;
+    text-align: center;
+    padding: 16px;
+}
+
+.tension-web-add {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.tension-web-add-row {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+}
+
+.tw-input {
+    padding: 8px 12px;
+    border: 1px solid #c2b39a;
+    border-radius: 6px;
+    font-size: 14px;
+    background: #fffdf7;
+    transition: border-color 0.2s;
+}
+
+.tw-input:focus {
+    outline: none;
+    border-color: #8b5e3c;
+}
+
+.tw-name-input {
+    flex: 1;
+    max-width: 200px;
+}
+
+.tw-role-input {
+    flex: 1;
+    max-width: 250px;
+}
+
+.tw-desc-input {
+    flex: 1;
+}
+
+.btn-add-tension {
+    background: #c07a2d;
+    color: white;
+    border: 1px solid #a86522;
+    padding: 8px 16px;
+    border-radius: 6px;
+    cursor: pointer;
+    font-size: 14px;
+    font-weight: 600;
+    transition: background-color 0.2s;
+    white-space: nowrap;
+}
+
+.btn-add-tension:hover {
+    background: #d18633;
+}
+
+/* ===================== */
+/* Pressure Point Styles */
+/* ===================== */
+
+.pressure-point-section h3 {
+    color: #c07a2d;
+    border-bottom-color: #c07a2d;
+}
+
+/* ===================== */
+/* Trajectory Styles     */
+/* ===================== */
+
+.trajectory-section h3 {
+    color: #c07a2d;
+    border-bottom-color: #c07a2d;
+}
+
+/* ===================== */
+/* Director's Notes      */
+/* ===================== */
+
+.directors-notes-section h3 {
+    color: #9b3b2f;
+    border-bottom-color: #9b3b2f;
+}
+
+.directors-notes-toggle {
+    cursor: pointer;
+    user-select: none;
+    transition: color 0.2s;
+}
+
+.directors-notes-toggle:hover {
+    color: #c04a3d;
+}
+
+.toggle-arrow {
+    font-size: 12px;
+    margin-left: 6px;
+    display: inline-block;
+    transition: transform 0.2s;
+}
+
+.directors-notes-content {
+    padding-top: 12px;
+}
+
+/* Debug Info Styles */
+.debug-info {
+    font-size: 12px;
+    font-family: monospace;
+    margin: 10px 0;
+}
+
+.debug-info strong {
+    color: #856404;
+}

--- a/dnd/strixhaven/othernpcs/data-utils.php
+++ b/dnd/strixhaven/othernpcs/data-utils.php
@@ -1,0 +1,111 @@
+<?php
+require_once __DIR__ . '/../includes/json-file-helper.php';
+
+function getNpcDataFilePath() {
+    return __DIR__ . '/othernpcs.json';
+}
+
+function getNpcLockFilePath() {
+    return __DIR__ . '/othernpcs.lock';
+}
+
+function getDefaultNpcDataset() {
+    return [
+        'npcs' => [],
+        'metadata' => [
+            'last_updated' => date('Y-m-d H:i:s'),
+            'total_npcs' => 0,
+        ],
+    ];
+}
+
+function getBlankNpcRecord() {
+    return [
+        'npc_id' => 'npc_' . time() . '_' . uniqid(),
+        'name' => 'New NPC',
+        'images' => [],
+        'race' => '',
+        'college' => '',
+        'favorites' => [],
+        'conflict_engine' => [
+            'want' => '',
+            'want_tag' => '',
+            'obstacle' => '',
+            'action' => '',
+            'consequence' => '',
+        ],
+        'tension_web' => [],
+        'pressure_point' => '',
+        'trajectory' => '',
+        'directors_notes' => '',
+        'details' => [
+            'backstory' => '',
+            'core_want' => '',
+            'core_fear' => '',
+            'other' => '',
+        ],
+    ];
+}
+
+function updateNpcMetadata(array &$data) {
+    if (!isset($data['metadata']) || !is_array($data['metadata'])) {
+        $data['metadata'] = [];
+    }
+    $data['metadata']['last_updated'] = date('Y-m-d H:i:s');
+    $data['metadata']['total_npcs'] = isset($data['npcs']) && is_array($data['npcs'])
+        ? count($data['npcs'])
+        : 0;
+}
+
+function loadNpcData() {
+    return loadJsonFileWithBackup(getNpcDataFilePath(), [
+        'default' => function () {
+            return getDefaultNpcDataset();
+        },
+        'backup_prefix' => 'othernpcs',
+    ]);
+}
+
+function modifyNpcData(callable $modifier) {
+    return modifyJsonFileWithLock(
+        getNpcDataFilePath(),
+        function (&$data) use ($modifier) {
+            if (!isset($data['npcs']) || !is_array($data['npcs'])) {
+                $data['npcs'] = [];
+            }
+            return $modifier($data);
+        },
+        [
+            'default' => function () {
+                return getDefaultNpcDataset();
+            },
+            'backup_prefix' => 'othernpcs',
+            'lock_file' => getNpcLockFilePath(),
+            'before_save' => function (&$data) {
+                updateNpcMetadata($data);
+            },
+        ]
+    );
+}
+
+function saveNpcData(array $newData) {
+    $result = modifyJsonFileWithLock(
+        getNpcDataFilePath(),
+        function (&$data) use ($newData) {
+            $data = $newData;
+            return ['result' => true];
+        },
+        [
+            'default' => function () {
+                return getDefaultNpcDataset();
+            },
+            'backup_prefix' => 'othernpcs',
+            'lock_file' => getNpcLockFilePath(),
+            'before_save' => function (&$data) {
+                updateNpcMetadata($data);
+            },
+        ]
+    );
+
+    return $result['success'];
+}

--- a/dnd/strixhaven/othernpcs/index.php
+++ b/dnd/strixhaven/othernpcs/index.php
@@ -1,0 +1,548 @@
+<?php
+session_start();
+
+// Check if user is logged in
+if (!isset($_SESSION['logged_in']) || $_SESSION['logged_in'] !== true) {
+    header('Location: ../../index.php');
+    exit;
+}
+
+$user = $_SESSION['user'];
+$is_gm = ($user === 'GM');
+
+// GM-only gate. Non-GM users cannot access this section at all.
+if (!$is_gm) {
+    if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+        header('Content-Type: application/json');
+        echo json_encode(['success' => false, 'error' => 'Access restricted: GM only']);
+        exit;
+    }
+    http_response_code(403);
+    ?><!DOCTYPE html>
+    <html lang="en">
+    <head>
+        <meta charset="UTF-8">
+        <title>Access Restricted</title>
+        <style>
+            body { font-family: 'Segoe UI', sans-serif; background: #1a1a2e; color: #eee; display: flex; align-items: center; justify-content: center; height: 100vh; margin: 0; }
+            .box { background: #2a2a4e; padding: 40px 60px; border-radius: 12px; box-shadow: 0 4px 20px rgba(0,0,0,0.4); text-align: center; }
+            h1 { color: #ff6b6b; margin: 0 0 12px; }
+            p { color: #aab; margin: 0 0 20px; }
+            a { color: #667eea; text-decoration: none; }
+            a:hover { text-decoration: underline; }
+        </style>
+    </head>
+    <body>
+        <div class="box">
+            <h1>Access Restricted</h1>
+            <p>The Other NPCs section is only available to the GM.</p>
+            <a href="../../dashboard.php">Return to Dashboard</a>
+        </div>
+    </body>
+    </html><?php
+    exit;
+}
+
+// Include version system
+define('VERSION_SYSTEM_INTERNAL', true);
+require_once '../../version.php';
+
+// Include character integration for character details functionality
+require_once '../gm/includes/character-integration.php';
+require_once __DIR__ . '/data-utils.php';
+
+$npcs_endpoint = $_SERVER['PHP_SELF'] ?? ($_SERVER['SCRIPT_NAME'] ?? '/dnd/strixhaven/othernpcs/index.php');
+
+// Handle AJAX requests
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['action'])) {
+    header('Content-Type: application/json');
+
+    if ($_POST['action'] === 'load_npcs') {
+        $data = loadNpcData();
+        $sort_by = isset($_POST['sort_by']) ? $_POST['sort_by'] : 'name';
+        $filter_college = isset($_POST['filter_college']) ? $_POST['filter_college'] : '';
+        $show_favorites = isset($_POST['show_favorites']) ? $_POST['show_favorites'] === 'true' : false;
+        $search_term = isset($_POST['search_term']) ? trim($_POST['search_term']) : '';
+
+        $npcs = isset($data['npcs']) && is_array($data['npcs']) ? $data['npcs'] : [];
+
+        if ($show_favorites) {
+            $npcs = array_filter($npcs, function($npc) use ($user) {
+                return isset($npc['favorites'][$user]) && $npc['favorites'][$user];
+            });
+        }
+
+        if ($filter_college) {
+            $npcs = array_filter($npcs, function($npc) use ($filter_college) {
+                return isset($npc['college']) && $npc['college'] === $filter_college;
+            });
+        }
+
+        if ($search_term) {
+            $npcs = array_filter($npcs, function($npc) use ($search_term) {
+                return stripos($npc['name'], $search_term) !== false;
+            });
+        }
+
+        usort($npcs, function($a, $b) use ($sort_by) {
+            switch ($sort_by) {
+                case 'college':
+                    $ac = isset($a['college']) ? $a['college'] : '';
+                    $bc = isset($b['college']) ? $b['college'] : '';
+                    if ($ac === $bc) {
+                        return strcasecmp($a['name'], $b['name']);
+                    }
+                    return strcasecmp($ac, $bc);
+
+                case 'race':
+                    $ar = isset($a['race']) ? $a['race'] : '';
+                    $br = isset($b['race']) ? $b['race'] : '';
+                    if ($ar === $br) {
+                        return strcasecmp($a['name'], $b['name']);
+                    }
+                    return strcasecmp($ar, $br);
+
+                case 'name':
+                default:
+                    return strcasecmp($a['name'], $b['name']);
+            }
+        });
+
+        require_once '../includes/thumbnail-utils.php';
+        foreach ($npcs as &$n) {
+            if (isset($n['images']) && is_array($n['images'])) {
+                $n['thumbnails'] = array();
+                foreach ($n['images'] as $img) {
+                    $thumbPath = getThumbnailPath($img);
+                    $n['thumbnails'][$img] = file_exists($thumbPath) ? $thumbPath : null;
+                }
+            }
+        }
+        unset($n);
+
+        echo json_encode(array(
+            'success' => true,
+            'npcs' => array_values($npcs)
+        ));
+
+    } elseif ($_POST['action'] === 'save_npc') {
+        $npc_id = isset($_POST['npc_id']) ? $_POST['npc_id'] : '';
+        $field = isset($_POST['field']) ? $_POST['field'] : '';
+        $value = isset($_POST['value']) ? $_POST['value'] : '';
+
+        if ($npc_id && $field) {
+            $result = modifyNpcData(function (&$data) use ($npc_id, $field, $value) {
+                foreach ($data['npcs'] as &$npc) {
+                    if ($npc['npc_id'] === $npc_id) {
+                        if (strpos($field, 'conflict_engine.') === 0) {
+                            $ceField = substr($field, 16);
+                            if (!isset($npc['conflict_engine']) || !is_array($npc['conflict_engine'])) {
+                                $npc['conflict_engine'] = array();
+                            }
+                            $npc['conflict_engine'][$ceField] = $value;
+                        } elseif ($field === 'tension_web') {
+                            $decoded = json_decode($value, true);
+                            if (!is_array($decoded)) {
+                                return ['save' => false, 'error' => 'Invalid tension web data'];
+                            }
+                            $npc['tension_web'] = $decoded;
+                        } elseif ($field === 'pressure_point' || $field === 'trajectory' || $field === 'directors_notes') {
+                            $npc[$field] = $value;
+                        } elseif (strpos($field, 'details.') === 0) {
+                            $detailField = substr($field, 8);
+                            if (!isset($npc['details']) || !is_array($npc['details'])) {
+                                $npc['details'] = array();
+                            }
+                            $npc['details'][$detailField] = $value;
+                        } else {
+                            $npc[$field] = $value;
+                        }
+
+                        return ['result' => true];
+                    }
+                }
+
+                return ['save' => false, 'error' => 'NPC not found'];
+            });
+
+            if ($result['success']) {
+                echo json_encode(array('success' => true));
+            } else {
+                $error = isset($result['error']) ? $result['error'] : 'Failed to save data';
+                echo json_encode(array('success' => false, 'error' => $error));
+            }
+        } else {
+            echo json_encode(array('success' => false, 'error' => 'Invalid parameters'));
+        }
+
+    } elseif ($_POST['action'] === 'add_npc') {
+        $new_npc = getBlankNpcRecord();
+        $result = modifyNpcData(function (&$data) use (&$new_npc) {
+            $data['npcs'][] = $new_npc;
+            return ['result' => $new_npc];
+        });
+
+        if ($result['success']) {
+            echo json_encode(array('success' => true, 'npc' => $new_npc));
+        } else {
+            $error = isset($result['error']) ? $result['error'] : 'Failed to add NPC';
+            echo json_encode(array('success' => false, 'error' => $error));
+        }
+
+    } elseif ($_POST['action'] === 'delete_npc') {
+        $npc_id = isset($_POST['npc_id']) ? $_POST['npc_id'] : '';
+
+        if ($npc_id) {
+            $imagesToDelete = array();
+            $result = modifyNpcData(function (&$data) use ($npc_id, &$imagesToDelete) {
+                foreach ($data['npcs'] as $index => $npc) {
+                    if ($npc['npc_id'] === $npc_id) {
+                        if (isset($npc['images']) && is_array($npc['images'])) {
+                            foreach ($npc['images'] as $image_path) {
+                                if (!empty($image_path)) {
+                                    $imagesToDelete[] = $image_path;
+                                }
+                            }
+                        }
+                        array_splice($data['npcs'], $index, 1);
+                        return ['result' => true];
+                    }
+                }
+
+                return ['save' => false, 'error' => 'NPC not found'];
+            });
+
+            if ($result['success']) {
+                foreach ($imagesToDelete as $image_path) {
+                    if (!empty($image_path) && file_exists($image_path)) {
+                        unlink($image_path);
+                    }
+                }
+                echo json_encode(array('success' => true));
+            } else {
+                $error = isset($result['error']) ? $result['error'] : 'Failed to delete NPC';
+                echo json_encode(array('success' => false, 'error' => $error));
+            }
+        } else {
+            echo json_encode(array('success' => false, 'error' => 'Invalid NPC ID'));
+        }
+
+    } elseif ($_POST['action'] === 'toggle_favorite') {
+        $npc_id = isset($_POST['npc_id']) ? $_POST['npc_id'] : '';
+
+        if ($npc_id) {
+            $result = modifyNpcData(function (&$data) use ($npc_id, $user) {
+                foreach ($data['npcs'] as &$npc) {
+                    if ($npc['npc_id'] === $npc_id) {
+                        if (!isset($npc['favorites']) || !is_array($npc['favorites'])) {
+                            $npc['favorites'] = array();
+                        }
+                        $current_status = isset($npc['favorites'][$user]) ? (bool)$npc['favorites'][$user] : false;
+                        $npc['favorites'][$user] = !$current_status;
+                        return ['result' => $npc['favorites'][$user]];
+                    }
+                }
+                return ['save' => false, 'error' => 'NPC not found'];
+            });
+
+            if ($result['success']) {
+                echo json_encode(array('success' => true, 'is_favorite' => (bool)$result['result']));
+            } else {
+                $error = isset($result['error']) ? $result['error'] : 'Failed to update favorite status';
+                echo json_encode(array('success' => false, 'error' => $error));
+            }
+        } else {
+            echo json_encode(array('success' => false, 'error' => 'Invalid NPC ID'));
+        }
+
+    } elseif ($_POST['action'] === 'upload_portrait') {
+        $npc_id = isset($_POST['npc_id']) ? $_POST['npc_id'] : '';
+
+        if (!$npc_id) {
+            echo json_encode(array('success' => false, 'error' => 'Invalid NPC ID'));
+            exit;
+        }
+
+        if (!isset($_FILES['portrait']) || $_FILES['portrait']['error'] !== UPLOAD_ERR_OK) {
+            echo json_encode(array('success' => false, 'error' => 'No file uploaded or upload error'));
+            exit;
+        }
+
+        $file = $_FILES['portrait'];
+
+        $allowed_types = array('image/jpeg', 'image/jpg', 'image/png', 'image/gif', 'image/webp');
+        $file_type = mime_content_type($file['tmp_name']);
+
+        if (!in_array($file_type, $allowed_types) && !in_array($file['type'], $allowed_types)) {
+            echo json_encode(array('success' => false, 'error' => 'Invalid file type. Please upload JPEG, PNG, GIF, or WebP images only.'));
+            exit;
+        }
+
+        if ($file['size'] > 5 * 1024 * 1024) {
+            echo json_encode(array('success' => false, 'error' => 'File too large. Maximum size is 5MB.'));
+            exit;
+        }
+
+        $portraits_dir = 'portraits';
+        if (!is_dir($portraits_dir)) {
+            mkdir($portraits_dir, 0755, true);
+        }
+
+        $file_extension = pathinfo($file['name'], PATHINFO_EXTENSION);
+        if (empty($file_extension)) {
+            $mime_extensions = array(
+                'image/jpeg' => 'jpg',
+                'image/jpg' => 'jpg',
+                'image/png' => 'png',
+                'image/gif' => 'gif',
+                'image/webp' => 'webp'
+            );
+            $file_extension = isset($mime_extensions[$file_type]) ? $mime_extensions[$file_type] : 'jpg';
+        }
+
+        $filename = $npc_id . '_portrait_' . time() . '.' . $file_extension;
+        $filepath = $portraits_dir . '/' . $filename;
+
+        if (move_uploaded_file($file['tmp_name'], $filepath)) {
+            require_once '../includes/thumbnail-utils.php';
+            generateThumbnail($filepath, 'thumbnails', 320);
+
+            $result = modifyNpcData(function (&$data) use ($npc_id, $filepath) {
+                foreach ($data['npcs'] as &$npc) {
+                    if ($npc['npc_id'] === $npc_id) {
+                        if (!isset($npc['images']) || !is_array($npc['images'])) {
+                            $npc['images'] = array();
+                        }
+                        $npc['images'][] = $filepath;
+                        return ['result' => true];
+                    }
+                }
+                return ['save' => false, 'error' => 'NPC not found'];
+            });
+
+            if ($result['success']) {
+                echo json_encode(array(
+                    'success' => true,
+                    'image_path' => $filepath,
+                    'message' => 'Image uploaded successfully'
+                ));
+            } else {
+                if (file_exists($filepath)) {
+                    unlink($filepath);
+                }
+                $error = isset($result['error']) ? $result['error'] : 'Failed to update NPC data';
+                echo json_encode(array('success' => false, 'error' => $error));
+            }
+        } else {
+            echo json_encode(array('success' => false, 'error' => 'Failed to save uploaded file'));
+        }
+
+    } elseif ($_POST['action'] === 'delete_image') {
+        $npc_id = isset($_POST['npc_id']) ? $_POST['npc_id'] : '';
+        $image_path = isset($_POST['image_path']) ? $_POST['image_path'] : '';
+
+        if ($npc_id && $image_path) {
+            $shouldDeleteFile = false;
+            $result = modifyNpcData(function (&$data) use ($npc_id, $image_path, &$shouldDeleteFile) {
+                foreach ($data['npcs'] as &$npc) {
+                    if ($npc['npc_id'] === $npc_id) {
+                        if (isset($npc['images'])) {
+                            $image_index = array_search($image_path, $npc['images']);
+                            if ($image_index !== false) {
+                                array_splice($npc['images'], $image_index, 1);
+                                $shouldDeleteFile = true;
+                                return ['result' => true];
+                            }
+                        }
+                        return ['save' => false, 'error' => 'Image not found'];
+                    }
+                }
+                return ['save' => false, 'error' => 'NPC not found'];
+            });
+
+            if ($result['success']) {
+                if ($shouldDeleteFile && file_exists($image_path)) {
+                    unlink($image_path);
+                    require_once '../includes/thumbnail-utils.php';
+                    $thumbPath = getThumbnailPath($image_path);
+                    if (file_exists($thumbPath)) {
+                        unlink($thumbPath);
+                    }
+                }
+                echo json_encode(array('success' => true));
+            } else {
+                $error = isset($result['error']) ? $result['error'] : 'Failed to delete image';
+                echo json_encode(array('success' => false, 'error' => $error));
+            }
+        } else {
+            echo json_encode(array('success' => false, 'error' => 'Invalid parameters'));
+        }
+
+    } elseif ($_POST['action'] === 'save_image_adjust') {
+        $npc_id = isset($_POST['npc_id']) ? $_POST['npc_id'] : '';
+        $image_path = isset($_POST['image_path']) ? $_POST['image_path'] : '';
+        $adjustment = isset($_POST['adjustment']) ? $_POST['adjustment'] : '';
+
+        if ($npc_id && $image_path && $adjustment) {
+            $adj_data = json_decode($adjustment, true);
+            if (!is_array($adj_data)) {
+                echo json_encode(array('success' => false, 'error' => 'Invalid adjustment data'));
+                exit;
+            }
+
+            $result = modifyNpcData(function (&$data) use ($npc_id, $image_path, $adj_data) {
+                foreach ($data['npcs'] as &$npc) {
+                    if ($npc['npc_id'] === $npc_id) {
+                        if (!isset($npc['image_adjustments']) || !is_array($npc['image_adjustments'])) {
+                            $npc['image_adjustments'] = array();
+                        }
+                        $npc['image_adjustments'][$image_path] = $adj_data;
+                        return ['result' => true];
+                    }
+                }
+                return ['save' => false, 'error' => 'NPC not found'];
+            });
+
+            if ($result['success']) {
+                echo json_encode(array('success' => true));
+            } else {
+                $error = isset($result['error']) ? $result['error'] : 'Failed to save adjustment';
+                echo json_encode(array('success' => false, 'error' => $error));
+            }
+        } else {
+            echo json_encode(array('success' => false, 'error' => 'Invalid parameters'));
+        }
+    }
+
+    exit;
+}
+
+// Load initial data for page
+$npcData = loadNpcData();
+
+// Include navigation bar
+require_once '../../includes/strix-nav.php';
+?>
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Strixhaven Other NPCs - <?php echo htmlspecialchars($user); ?></title>
+    <link rel="stylesheet" href="../../css/style.css">
+    <link rel="stylesheet" href="css/othernpcs.css">
+    <link rel="stylesheet" href="../includes/image-adjuster.css">
+</head>
+<body>
+    <?php renderStrixNav(''); ?>
+    <!-- Top Navigation Bar -->
+    <div class="top-nav">
+        <div class="nav-buttons">
+            <button class="nav-btn" onclick="window.close()">Close Other NPCs</button>
+            <button class="nav-btn logout-btn" onclick="window.location.href='../../logout.php'">Logout</button>
+        </div>
+        <h1 class="nav-title">Strixhaven Other NPCs - GM View</h1>
+    </div>
+
+    <div class="main-container">
+        <!-- Control Panel -->
+        <div class="control-panel">
+            <div class="search-section">
+                <input type="text" id="search-input" placeholder="Search NPCs by name..." class="search-input">
+            </div>
+
+            <div class="filter-section">
+                <div class="filter-group">
+                    <label>Sort by:</label>
+                    <button class="filter-btn active" data-sort="name">Name</button>
+                    <button class="filter-btn" data-sort="race">Race</button>
+                    <button class="filter-btn" data-sort="college">College</button>
+                </div>
+
+                <div class="filter-group">
+                    <label>Filter:</label>
+                    <select id="filter-college" class="filter-select">
+                        <option value="">All Colleges</option>
+                        <option value="Silverquill">Silverquill</option>
+                        <option value="Prismari">Prismari</option>
+                        <option value="Witherbloom">Witherbloom</option>
+                        <option value="Lorehold">Lorehold</option>
+                        <option value="Quandrix">Quandrix</option>
+                    </select>
+
+                    <button class="filter-btn" id="favorites-toggle">★ Favorites</button>
+                </div>
+
+                <div class="admin-controls">
+                    <button class="btn-add" id="add-npc-btn">+ Add NPC</button>
+                </div>
+            </div>
+        </div>
+
+        <!-- NPCs Grid -->
+        <div class="npcs-container">
+            <div id="npcs-grid" class="npcs-grid">
+                <!-- NPCs will be loaded here via JavaScript -->
+            </div>
+        </div>
+
+        <!-- Loading indicator -->
+        <div id="loading" class="loading" style="display: none;">
+            <div class="spinner"></div>
+            <p>Loading NPCs...</p>
+        </div>
+    </div>
+
+    <!-- NPC Detail Modal -->
+    <div id="npc-modal" class="modal">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h2 id="modal-npc-name">NPC Details</h2>
+                <div class="modal-controls">
+                    <button class="btn-favorite" id="modal-favorite-btn" title="Toggle Favorite">★</button>
+                    <button class="btn-danger" id="modal-delete-btn" title="Delete NPC">🗑</button>
+                    <span class="close" onclick="closeNpcModal()">&times;</span>
+                </div>
+            </div>
+            <div class="modal-body">
+                <div class="npc-details">
+                    <!-- NPC details will be populated here -->
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <script>
+        // Globals used by npcs.js
+        const isGM = true;
+        const currentUser = '<?php echo htmlspecialchars($user, ENT_QUOTES); ?>';
+        const NPCS_ENDPOINT = <?php echo json_encode($npcs_endpoint); ?>;
+        let currentSort = 'name';
+        let currentFilters = {
+            college: '',
+            favorites: false,
+            search: ''
+        };
+        let selectedNpc = null;
+
+        document.addEventListener('DOMContentLoaded', function() {
+            setupEventListeners();
+            loadNpcs();
+        });
+    </script>
+    <!-- Character Autocomplete Container -->
+    <div id="character-autocomplete" class="character-autocomplete" style="display: none;"></div>
+
+    <!-- Version Footer -->
+    <div class="version-footer">
+        <span class="version-info"><?php echo Version::displayVersion(); ?></span>
+        <span class="version-updated">Updated: <?php echo Version::getLastUpdated(); ?></span>
+    </div>
+
+    <script src="../gm/js/rich-text-editor.js"></script>
+    <script src="../gm/js/character-lookup.js"></script>
+    <script src="../includes/image-adjuster.js"></script>
+    <script src="js/othernpcs.js"></script>
+</body>
+</html>

--- a/dnd/strixhaven/othernpcs/js/othernpcs.js
+++ b/dnd/strixhaven/othernpcs/js/othernpcs.js
@@ -1,0 +1,1053 @@
+// Other NPCs Management JavaScript (GM-only)
+
+const npcsEndpoint = (typeof NPCS_ENDPOINT !== 'undefined' && NPCS_ENDPOINT)
+    ? NPCS_ENDPOINT
+    : 'index.php';
+
+let modalRichTextEditors = new Map();
+
+function initializeCharacterLookup() {
+    if (window.characterLookup && !window.characterLookup.isReady()) {
+        window.characterLookup.init().then(() => {
+            console.log('Character lookup initialized for NPCs section');
+        }).catch(error => {
+            console.warn('Character lookup initialization failed:', error);
+        });
+    }
+}
+
+function setupModalRichTextEditors(container, npcData) {
+    if (typeof RichTextEditor === 'undefined') {
+        console.warn('RichTextEditor not available');
+        return;
+    }
+
+    cleanupModalRichTextEditors();
+
+    const containers = container.querySelectorAll('.rich-text-container');
+    containers.forEach(richContainer => {
+        const field = richContainer.getAttribute('data-field');
+        const placeholder = richContainer.getAttribute('data-placeholder') || 'Enter text...';
+
+        if (field) {
+            const editor = new RichTextEditor(richContainer, {
+                placeholder: placeholder + ' Type [[character name]] to link to characters'
+            });
+
+            editor.init();
+
+            const fieldValue = getNestedFieldValue(npcData, field);
+            if (fieldValue) {
+                editor.setContent(fieldValue);
+            }
+
+            editor.onChange((content) => {
+                saveNpcField(npcData.npc_id, field, content);
+            });
+
+            if (window.characterLookup && window.characterLookup.isReady()) {
+                const editorElement = editor.getEditor();
+                if (editorElement) {
+                    window.characterLookup.setupEditorListeners(editorElement);
+                }
+            } else {
+                setTimeout(() => {
+                    if (window.characterLookup && window.characterLookup.isReady()) {
+                        const editorElement = editor.getEditor();
+                        if (editorElement) {
+                            window.characterLookup.setupEditorListeners(editorElement);
+                        }
+                    }
+                }, 500);
+            }
+
+            modalRichTextEditors.set(field, editor);
+        }
+    });
+}
+
+function cleanupModalRichTextEditors() {
+    modalRichTextEditors.forEach((editor) => {
+        if (editor && editor.destroy) {
+            editor.destroy();
+        }
+    });
+    modalRichTextEditors.clear();
+}
+
+function getNestedFieldValue(npcData, field) {
+    const parts = field.split('.');
+    let value = npcData;
+
+    for (const part of parts) {
+        if (value && typeof value === 'object' && part in value) {
+            value = value[part];
+        } else {
+            return '';
+        }
+    }
+
+    return value || '';
+}
+
+function setupEventListeners() {
+    setTimeout(initializeCharacterLookup, 500);
+
+    const searchInput = document.getElementById('search-input');
+    if (searchInput) {
+        searchInput.addEventListener('input', debounce(function() {
+            currentFilters.search = this.value.trim();
+            loadNpcs();
+        }, 300));
+    }
+
+    document.querySelectorAll('[data-sort]').forEach(btn => {
+        btn.addEventListener('click', function() {
+            const sortType = this.getAttribute('data-sort');
+            document.querySelectorAll('[data-sort]').forEach(b => b.classList.remove('active'));
+            this.classList.add('active');
+            currentSort = sortType;
+            loadNpcs();
+        });
+    });
+
+    const collegeFilter = document.getElementById('filter-college');
+    if (collegeFilter) {
+        collegeFilter.addEventListener('change', function() {
+            currentFilters.college = this.value;
+            loadNpcs();
+        });
+    }
+
+    const favoritesToggle = document.getElementById('favorites-toggle');
+    if (favoritesToggle) {
+        favoritesToggle.addEventListener('click', function() {
+            currentFilters.favorites = !currentFilters.favorites;
+            this.classList.toggle('active', currentFilters.favorites);
+            loadNpcs();
+        });
+    }
+
+    const addNpcBtn = document.getElementById('add-npc-btn');
+    if (addNpcBtn) {
+        addNpcBtn.addEventListener('click', addNpc);
+    }
+
+    const modalDeleteBtn = document.getElementById('modal-delete-btn');
+    if (modalDeleteBtn) {
+        modalDeleteBtn.addEventListener('click', deleteNpc);
+    }
+
+    const modalFavoriteBtn = document.getElementById('modal-favorite-btn');
+    if (modalFavoriteBtn) {
+        modalFavoriteBtn.addEventListener('click', toggleNpcFavorite);
+    }
+
+    const modal = document.getElementById('npc-modal');
+    if (modal) {
+        let backgroundPointerDown = false;
+        modal.addEventListener('mousedown', function(e) {
+            backgroundPointerDown = e.target === modal;
+        });
+        modal.addEventListener('mouseup', function(e) {
+            if (backgroundPointerDown && e.target === modal) {
+                closeNpcModal();
+            }
+            backgroundPointerDown = false;
+        });
+    }
+}
+
+function loadNpcs() {
+    showLoading(true);
+
+    const formData = new FormData();
+    formData.append('action', 'load_npcs');
+    formData.append('sort_by', currentSort);
+    formData.append('filter_college', currentFilters.college);
+    formData.append('show_favorites', currentFilters.favorites.toString());
+    formData.append('search_term', currentFilters.search);
+
+    fetch(npcsEndpoint, {
+        method: 'POST',
+        body: formData
+    })
+    .then(response => response.json())
+    .then(data => {
+        showLoading(false);
+        if (data.success) {
+            displayNpcs(data.npcs);
+            window.allNpcs = data.npcs;
+        } else {
+            console.error('Failed to load NPCs:', data.error);
+            showError('Failed to load NPCs');
+        }
+    })
+    .catch(error => {
+        showLoading(false);
+        console.error('Error loading NPCs:', error);
+        showError('Error loading NPCs');
+    });
+}
+
+function displayNpcs(npcs) {
+    const grid = document.getElementById('npcs-grid');
+
+    if (npcs.length === 0) {
+        grid.innerHTML = `
+            <div class="no-npcs">
+                <div class="no-npcs-icon">👥</div>
+                <p>No NPCs found matching your criteria.</p>
+            </div>
+        `;
+        return;
+    }
+
+    grid.innerHTML = npcs.map(npc => createNpcCard(npc)).join('');
+
+    grid.querySelectorAll('.npc-card').forEach(card => {
+        card.addEventListener('click', function() {
+            const npcId = this.getAttribute('data-npc-id');
+            const npc = npcs.find(n => n.npc_id === npcId);
+            if (npc) {
+                openNpcModal(npc);
+            }
+        });
+    });
+}
+
+function createNpcCard(npc) {
+    const isFavorite = npc.favorites && npc.favorites[currentUser];
+    const favoriteIcon = isFavorite ? '<div class="npc-favorite">★</div>' : '';
+
+    let thumbnailImage = '';
+    if (npc.images && npc.images.length > 0) {
+        thumbnailImage = npc.images[0];
+    } else if (npc.image_path) {
+        thumbnailImage = npc.image_path;
+    }
+
+    let imageHtml;
+    if (thumbnailImage) {
+        const thumbSrc = npc.thumbnails && npc.thumbnails[thumbnailImage];
+        const cardSrc = thumbSrc || escapeHtml(thumbnailImage);
+
+        const adj = npc.image_adjustments && npc.image_adjustments[thumbnailImage];
+        const adjustedHtml = adj && typeof ImageAdjuster !== 'undefined' ?
+            ImageAdjuster.createAdjustedImageHtml(
+                cardSrc,
+                escapeHtml(npc.name), adj, '', '', 'loading="lazy"'
+            ) : null;
+        imageHtml = adjustedHtml ||
+            `<img src="${cardSrc}" alt="${escapeHtml(npc.name)}" class="npc-thumbnail" loading="lazy">`;
+    } else {
+        imageHtml = `<div class="npc-placeholder">No Photo</div>`;
+    }
+
+    return `
+        <div class="npc-card" data-npc-id="${escapeHtml(npc.npc_id)}">
+            ${favoriteIcon}
+            ${imageHtml}
+            <div class="npc-name">${escapeHtml(npc.name)}</div>
+            <div class="npc-info">
+                <div class="npc-race">${escapeHtml(npc.race || 'Unknown Race')}</div>
+                <div class="npc-college">${escapeHtml(npc.college || 'No College')}</div>
+            </div>
+        </div>
+    `;
+}
+
+function openNpcModal(npc) {
+    selectedNpc = npc;
+
+    const modal = document.getElementById('npc-modal');
+    const modalName = document.getElementById('modal-npc-name');
+    const modalBody = modal.querySelector('.npc-details');
+
+    modalName.textContent = npc.name;
+
+    const favoriteBtn = document.getElementById('modal-favorite-btn');
+    if (favoriteBtn) {
+        const isFavorite = npc.favorites && npc.favorites[currentUser];
+        favoriteBtn.classList.toggle('active', isFavorite);
+        favoriteBtn.title = isFavorite ? 'Remove from Favorites' : 'Add to Favorites';
+    }
+
+    modalBody.innerHTML = createNpcDetailForm(npc);
+
+    modalBody.querySelectorAll('input, select, textarea').forEach(input => {
+        input.addEventListener('change', function() {
+            const field = this.getAttribute('data-field');
+            const value = this.value;
+            saveNpcField(npc.npc_id, field, value);
+        });
+    });
+
+    setupModalRichTextEditors(modalBody, npc);
+
+    modal.style.display = 'block';
+}
+
+function createNpcDetailForm(npc) {
+    const conflictEngine = npc.conflict_engine || {};
+    const tensionWeb = npc.tension_web || [];
+
+    let images = [];
+    if (npc.images && npc.images.length > 0) {
+        images = npc.images;
+    } else if (npc.image_path) {
+        images = [npc.image_path];
+    }
+
+    const imageHtml = images.length > 0 ?
+        createImageGallery(images, npc.npc_id, 'npc', npc.image_adjustments) :
+        `<div class="npc-portrait-placeholder">No Photo</div>`;
+
+    const uploadButton = `<button class="upload-portrait-btn" onclick="uploadNpcPortrait('${npc.npc_id}')">Upload Photo</button>`;
+
+    const tensionWebHtml = tensionWeb.map((entry, index) => `
+        <div class="tension-web-entry" data-index="${index}">
+            <div class="tension-web-entry-header">
+                <strong class="tension-web-name">${escapeHtml(entry.name || '')}</strong>
+                <span class="tension-web-role">(${escapeHtml(entry.role || '')})</span>
+                <button class="btn-remove-tension" onclick="removeTensionWebEntry('${npc.npc_id}', ${index})" title="Remove entry">&times;</button>
+            </div>
+            <div class="tension-web-description">${entry.description || ''}</div>
+        </div>
+    `).join('');
+
+    const wantTagOptions = ['Legacy', 'Recognition', 'Freedom', 'Power', 'Knowledge', 'Connection', 'Survival', 'Justice', 'Creation', 'Redemption'];
+    const currentWantTag = conflictEngine.want_tag || '';
+
+    return `
+        <div class="npc-form student-form">
+            <!-- Portrait Section -->
+            <div class="npc-portrait-section student-portrait-section">
+                ${imageHtml}
+                ${uploadButton}
+            </div>
+
+            <!-- Basic Information: name, race, college only -->
+            <div class="form-section">
+                <h3>Basic Information</h3>
+                <div class="form-row">
+                    <div class="form-group">
+                        <label>Name:</label>
+                        <input type="text" value="${escapeHtml(npc.name)}" data-field="name">
+                    </div>
+                    <div class="form-group">
+                        <label>Race:</label>
+                        <input type="text" value="${escapeHtml(npc.race || '')}" data-field="race" placeholder="Enter race">
+                    </div>
+                    <div class="form-group">
+                        <label>College:</label>
+                        <select data-field="college">
+                            <option value="">No College</option>
+                            <option value="Silverquill" ${npc.college === 'Silverquill' ? 'selected' : ''}>Silverquill</option>
+                            <option value="Prismari" ${npc.college === 'Prismari' ? 'selected' : ''}>Prismari</option>
+                            <option value="Witherbloom" ${npc.college === 'Witherbloom' ? 'selected' : ''}>Witherbloom</option>
+                            <option value="Lorehold" ${npc.college === 'Lorehold' ? 'selected' : ''}>Lorehold</option>
+                            <option value="Quandrix" ${npc.college === 'Quandrix' ? 'selected' : ''}>Quandrix</option>
+                        </select>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Conflict Engine Section -->
+            <div class="form-section gm-only conflict-engine-section">
+                <h3><span class="ce-icon">&#9881;</span> Conflict Engine</h3>
+
+                <div class="ce-block ce-want">
+                    <div class="ce-block-header">
+                        <span class="ce-badge ce-badge-want">W</span>
+                        <span class="ce-block-title">Want</span>
+                        <select class="ce-want-tag-select" data-field="conflict_engine.want_tag">
+                            <option value="">No tag</option>
+                            ${wantTagOptions.map(tag => `<option value="${tag}" ${currentWantTag === tag ? 'selected' : ''}>${tag}</option>`).join('')}
+                        </select>
+                        ${currentWantTag ? `<span class="ce-want-tag">${escapeHtml(currentWantTag)}</span>` : ''}
+                    </div>
+                    <div class="ce-block-body">
+                        <div class="rich-text-container" data-field="conflict_engine.want" data-placeholder="What does this character want most?"></div>
+                    </div>
+                </div>
+
+                <div class="ce-block ce-obstacle">
+                    <div class="ce-block-header">
+                        <span class="ce-badge ce-badge-obstacle">O</span>
+                        <span class="ce-block-title">Obstacle</span>
+                    </div>
+                    <div class="ce-block-body">
+                        <div class="rich-text-container" data-field="conflict_engine.obstacle" data-placeholder="What stands in the way of what they want?"></div>
+                    </div>
+                </div>
+
+                <div class="ce-block ce-action">
+                    <div class="ce-block-header">
+                        <span class="ce-badge ce-badge-action">A</span>
+                        <span class="ce-block-title">Action</span>
+                    </div>
+                    <div class="ce-block-body">
+                        <div class="rich-text-container" data-field="conflict_engine.action" data-placeholder="What is this character actively doing about it?"></div>
+                    </div>
+                </div>
+
+                <div class="ce-block ce-consequence">
+                    <div class="ce-block-header">
+                        <span class="ce-badge ce-badge-consequence">C</span>
+                        <span class="ce-block-title">Consequence</span>
+                    </div>
+                    <div class="ce-block-body">
+                        <div class="rich-text-container" data-field="conflict_engine.consequence" data-placeholder="What happens if they fail or succeed? What's at stake?"></div>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Tension Web Section -->
+            <div class="form-section gm-only tension-web-section">
+                <h3>Tension Web</h3>
+                <div class="tension-web-list" id="tension-web-${npc.npc_id}">
+                    ${tensionWebHtml || '<p class="tension-web-empty">No tension web entries yet.</p>'}
+                </div>
+                <div class="tension-web-add">
+                    <div class="tension-web-add-row">
+                        <input type="text" id="tw-name-${npc.npc_id}" placeholder="Name..." class="tw-input tw-name-input">
+                        <input type="text" id="tw-role-${npc.npc_id}" placeholder="Role (e.g. mentor, rival)..." class="tw-input tw-role-input">
+                    </div>
+                    <div class="tension-web-add-row">
+                        <input type="text" id="tw-desc-${npc.npc_id}" placeholder="Describe the tension/friction..." class="tw-input tw-desc-input">
+                        <button class="btn-add-tension" onclick="addTensionWebEntry('${npc.npc_id}')">+ Add</button>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Pressure Point Section -->
+            <div class="form-section gm-only pressure-point-section">
+                <h3>Pressure Point</h3>
+                <div class="rich-text-container" data-field="pressure_point" data-placeholder="When [trigger], they [behavior]... What pushes this character's buttons?"></div>
+            </div>
+
+            <!-- Trajectory Section -->
+            <div class="form-section gm-only trajectory-section">
+                <h3>Trajectory</h3>
+                <div class="rich-text-container" data-field="trajectory" data-placeholder="Without intervention, what happens to this character? (single sentence arc)"></div>
+            </div>
+
+            <!-- Director's Notes Section (collapsed by default) -->
+            <div class="form-section gm-only directors-notes-section">
+                <h3 class="directors-notes-toggle" onclick="toggleDirectorsNotes(this)">Director's Notes <span class="toggle-arrow">&#9660;</span></h3>
+                <div class="directors-notes-content" style="display: none;">
+                    <div class="rich-text-container large" data-field="directors_notes" data-placeholder="Origin, background, and other GM notes..."></div>
+                </div>
+            </div>
+        </div>
+    `;
+}
+
+function closeNpcModal() {
+    cleanupModalRichTextEditors();
+    const modal = document.getElementById('npc-modal');
+    modal.style.display = 'none';
+    selectedNpc = null;
+}
+
+function toggleDirectorsNotes(header) {
+    const content = header.nextElementSibling;
+    const arrow = header.querySelector('.toggle-arrow');
+    if (content.style.display === 'none') {
+        content.style.display = 'block';
+        arrow.innerHTML = '&#9650;';
+        const containers = content.querySelectorAll('.rich-text-container');
+        containers.forEach(container => {
+            if (!container.querySelector('.rich-text-editor') && typeof RichTextEditor !== 'undefined') {
+                const field = container.getAttribute('data-field');
+                const placeholder = container.getAttribute('data-placeholder') || 'Enter text...';
+                const editor = new RichTextEditor(container, {
+                    placeholder: placeholder + ' Type [[character name]] to link to characters'
+                });
+                editor.init();
+                if (selectedNpc && field) {
+                    const value = selectedNpc[field] || '';
+                    if (value) editor.setContent(value);
+                }
+                editor.onChange((editorContent) => {
+                    if (selectedNpc) {
+                        saveNpcField(selectedNpc.npc_id, field, editorContent);
+                    }
+                });
+                modalRichTextEditors.set(field, editor);
+            }
+        });
+    } else {
+        content.style.display = 'none';
+        arrow.innerHTML = '&#9660;';
+    }
+}
+
+function addTensionWebEntry(npcId) {
+    const nameInput = document.getElementById(`tw-name-${npcId}`);
+    const roleInput = document.getElementById(`tw-role-${npcId}`);
+    const descInput = document.getElementById(`tw-desc-${npcId}`);
+
+    const name = nameInput.value.trim();
+    const role = roleInput.value.trim();
+    const description = descInput.value.trim();
+
+    if (!name) {
+        nameInput.focus();
+        return;
+    }
+
+    const npc = window.allNpcs ? window.allNpcs.find(n => n.npc_id === npcId) : selectedNpc;
+    if (!npc) return;
+
+    if (!npc.tension_web) npc.tension_web = [];
+    npc.tension_web.push({ name, role, description });
+
+    saveNpcField(npcId, 'tension_web', JSON.stringify(npc.tension_web));
+
+    nameInput.value = '';
+    roleInput.value = '';
+    descInput.value = '';
+
+    renderTensionWebList(npcId, npc.tension_web);
+}
+
+function removeTensionWebEntry(npcId, index) {
+    const npc = window.allNpcs ? window.allNpcs.find(n => n.npc_id === npcId) : selectedNpc;
+    if (!npc || !npc.tension_web) return;
+
+    npc.tension_web.splice(index, 1);
+    saveNpcField(npcId, 'tension_web', JSON.stringify(npc.tension_web));
+    renderTensionWebList(npcId, npc.tension_web);
+}
+
+function renderTensionWebList(npcId, entries) {
+    const list = document.getElementById(`tension-web-${npcId}`);
+    if (!list) return;
+
+    if (!entries || entries.length === 0) {
+        list.innerHTML = '<p class="tension-web-empty">No tension web entries yet.</p>';
+        return;
+    }
+
+    list.innerHTML = entries.map((entry, index) => `
+        <div class="tension-web-entry" data-index="${index}">
+            <div class="tension-web-entry-header">
+                <strong class="tension-web-name">${escapeHtml(entry.name || '')}</strong>
+                <span class="tension-web-role">(${escapeHtml(entry.role || '')})</span>
+                <button class="btn-remove-tension" onclick="removeTensionWebEntry('${npcId}', ${index})" title="Remove entry">&times;</button>
+            </div>
+            <div class="tension-web-description">${escapeHtml(entry.description || '')}</div>
+        </div>
+    `).join('');
+}
+
+function saveNpcField(npcId, field, value) {
+    const formData = new FormData();
+    formData.append('action', 'save_npc');
+    formData.append('npc_id', npcId);
+    formData.append('field', field);
+    formData.append('value', Array.isArray(value) ? JSON.stringify(value) : value);
+
+    fetch(npcsEndpoint, {
+        method: 'POST',
+        body: formData
+    })
+    .then(response => response.json())
+    .then(data => {
+        if (!data.success) {
+            console.error('Failed to save field:', data.error);
+            showError('Failed to save changes');
+        } else if (selectedNpc && selectedNpc.npc_id === npcId) {
+            // keep local selectedNpc in sync for simple top-level fields
+            if (field.indexOf('.') === -1 && field !== 'tension_web') {
+                selectedNpc[field] = value;
+            }
+        }
+    })
+    .catch(error => {
+        console.error('Error saving field:', error);
+        showError('Error saving changes');
+    });
+}
+
+function addNpc() {
+    const formData = new FormData();
+    formData.append('action', 'add_npc');
+
+    fetch(npcsEndpoint, {
+        method: 'POST',
+        body: formData
+    })
+    .then(response => response.json())
+    .then(data => {
+        if (data.success) {
+            loadNpcs();
+            showSuccess('NPC added successfully');
+        } else {
+            showError('Failed to add NPC');
+        }
+    })
+    .catch(error => {
+        console.error('Error adding NPC:', error);
+        showError('Error adding NPC');
+    });
+}
+
+function toggleNpcFavorite() {
+    if (!selectedNpc) return;
+
+    const formData = new FormData();
+    formData.append('action', 'toggle_favorite');
+    formData.append('npc_id', selectedNpc.npc_id);
+
+    fetch(npcsEndpoint, {
+        method: 'POST',
+        body: formData
+    })
+    .then(response => response.json())
+    .then(data => {
+        if (data.success) {
+            if (!selectedNpc.favorites) {
+                selectedNpc.favorites = {};
+            }
+            selectedNpc.favorites[currentUser] = data.is_favorite;
+
+            const favoriteBtn = document.getElementById('modal-favorite-btn');
+            if (favoriteBtn) {
+                favoriteBtn.classList.toggle('active', data.is_favorite);
+                favoriteBtn.title = data.is_favorite ? 'Remove from Favorites' : 'Add to Favorites';
+            }
+
+            loadNpcs();
+        } else {
+            showError('Failed to update favorite status');
+        }
+    })
+    .catch(error => {
+        console.error('Error toggling favorite:', error);
+        showError('Error updating favorite');
+    });
+}
+
+function deleteNpc() {
+    if (!selectedNpc) return;
+
+    if (!confirm(`Are you sure you want to delete ${selectedNpc.name}? This action cannot be undone.`)) {
+        return;
+    }
+
+    const formData = new FormData();
+    formData.append('action', 'delete_npc');
+    formData.append('npc_id', selectedNpc.npc_id);
+
+    fetch(npcsEndpoint, {
+        method: 'POST',
+        body: formData
+    })
+    .then(response => response.json())
+    .then(data => {
+        if (data.success) {
+            closeNpcModal();
+            loadNpcs();
+            showSuccess('NPC deleted successfully');
+        } else {
+            showError('Failed to delete NPC');
+        }
+    })
+    .catch(error => {
+        console.error('Error deleting NPC:', error);
+        showError('Error deleting NPC');
+    });
+}
+
+function uploadNpcPortrait(npcId) {
+    const input = document.createElement('input');
+    input.type = 'file';
+    input.accept = 'image/*,.webp';
+    input.onchange = function(event) {
+        const file = event.target.files[0];
+        if (!file) return;
+
+        if (file.size > 5 * 1024 * 1024) {
+            showError('Image file must be smaller than 5MB');
+            return;
+        }
+
+        const allowedTypes = ['image/jpeg', 'image/jpg', 'image/png', 'image/gif', 'image/webp'];
+        if (!allowedTypes.includes(file.type)) {
+            showError('Please select a valid image file (JPEG, PNG, GIF, or WebP)');
+            return;
+        }
+
+        const formData = new FormData();
+        formData.append('action', 'upload_portrait');
+        formData.append('npc_id', npcId);
+        formData.append('portrait', file);
+
+        fetch(npcsEndpoint, {
+            method: 'POST',
+            body: formData
+        })
+        .then(response => response.json())
+        .then(data => {
+            if (data.success) {
+                if (selectedNpc && selectedNpc.npc_id === npcId) {
+                    if (!selectedNpc.images) {
+                        selectedNpc.images = [];
+                    }
+                    selectedNpc.images.push(data.image_path);
+
+                    const modalBody = document.querySelector('#npc-modal .npc-details');
+                    if (modalBody) {
+                        modalBody.innerHTML = createNpcDetailForm(selectedNpc);
+                        setupFormEventListeners(modalBody);
+                        setupModalRichTextEditors(modalBody, selectedNpc);
+                    }
+                }
+                loadNpcs();
+            } else {
+                alert('Failed to upload image: ' + (data.error || 'Unknown error'));
+            }
+        })
+        .catch(error => {
+            console.error('Error uploading image:', error);
+            alert('Error uploading image');
+        });
+    };
+    input.click();
+}
+
+function setupFormEventListeners(container) {
+    container.querySelectorAll('input, select').forEach(input => {
+        input.addEventListener('change', function() {
+            const field = this.getAttribute('data-field');
+            const value = this.value;
+            if (selectedNpc) {
+                saveNpcField(selectedNpc.npc_id, field, value);
+            }
+        });
+    });
+}
+
+// Image Gallery Functions
+function createImageGallery(images, itemId, itemType, imageAdjustments) {
+    if (!images || images.length === 0) {
+        return `<div class="${itemType}-portrait-placeholder">No Photo</div>`;
+    }
+
+    const currentImageIndex = 0;
+    const hasMultipleImages = images.length > 1;
+    const currentImage = images[currentImageIndex];
+    const adj = imageAdjustments && imageAdjustments[currentImage];
+
+    let imageElement;
+    const adjustedHtml = adj && typeof ImageAdjuster !== 'undefined' ?
+        ImageAdjuster.createAdjustedImageHtml(
+            escapeHtml(currentImage),
+            itemType + ' image', adj, '',
+            "openImagePopup('" + escapeHtml(currentImage) + "')"
+        ) : null;
+
+    if (adjustedHtml) {
+        imageElement = adjustedHtml;
+    } else {
+        imageElement = `<img src="${escapeHtml(currentImage)}"
+                     alt="${itemType} image"
+                     class="${itemType}-portrait gallery-image"
+                     onclick="openImagePopup('${escapeHtml(currentImage)}')"
+                     data-current-index="${currentImageIndex}">`;
+    }
+
+    return `
+        <div class="image-gallery" data-item-id="${itemId}" data-item-type="${itemType}">
+            <div class="image-container">
+                ${imageElement}
+
+                ${hasMultipleImages ? `
+                    <button class="gallery-nav prev" onclick="navigateGallery('${itemId}', -1)">‹</button>
+                    <button class="gallery-nav next" onclick="navigateGallery('${itemId}', 1)">›</button>
+                    <div class="gallery-indicator">${currentImageIndex + 1} / ${images.length}</div>
+                ` : ''}
+
+                <button class="delete-image-btn" onclick="deleteImage('${itemId}', '${escapeHtml(currentImage)}', '${itemType}')">×</button>
+            </div>
+            <button class="adjust-image-btn" onclick="openImageAdjuster('${itemId}', '${escapeHtml(currentImage)}', '${itemType}')">Adjust Image</button>
+        </div>
+    `;
+}
+
+function navigateGallery(itemId, direction) {
+    if (!selectedNpc || selectedNpc.npc_id !== itemId) return;
+
+    const images = selectedNpc.images || [];
+    if (images.length <= 1) return;
+
+    const galleryEl = document.querySelector(`[data-item-id="${itemId}"]`);
+    if (!galleryEl) return;
+
+    const imgEl = galleryEl.querySelector('.image-container img, .image-container .adjusted-image-wrapper img');
+    const currentIndex = imgEl ? parseInt(imgEl.getAttribute('data-current-index') || '0') : 0;
+
+    let newIndex = currentIndex + direction;
+    if (newIndex < 0) newIndex = images.length - 1;
+    if (newIndex >= images.length) newIndex = 0;
+
+    const newImage = images[newIndex];
+    const adj = selectedNpc.image_adjustments && selectedNpc.image_adjustments[newImage];
+    const container = galleryEl.querySelector('.image-container');
+
+    let newImageHtml;
+    const adjustedHtml = adj && typeof ImageAdjuster !== 'undefined' ?
+        ImageAdjuster.createAdjustedImageHtml(
+            escapeHtml(newImage),
+            'npc image', adj, '',
+            "openImagePopup('" + escapeHtml(newImage) + "')"
+        ) : null;
+
+    if (adjustedHtml) {
+        newImageHtml = adjustedHtml;
+    } else {
+        newImageHtml = `<img src="${escapeHtml(newImage)}"
+             alt="npc image"
+             class="npc-portrait gallery-image"
+             onclick="openImagePopup('${escapeHtml(newImage)}')"
+             data-current-index="${newIndex}">`;
+    }
+
+    container.innerHTML = `
+        ${newImageHtml}
+        <button class="gallery-nav prev" onclick="navigateGallery('${itemId}', -1)">&#8249;</button>
+        <button class="gallery-nav next" onclick="navigateGallery('${itemId}', 1)">&#8250;</button>
+        <div class="gallery-indicator">${newIndex + 1} / ${images.length}</div>
+        <button class="delete-image-btn" onclick="deleteImage('${itemId}', '${escapeHtml(newImage)}', 'npc')">×</button>
+    `;
+
+    const adjustBtn = galleryEl.querySelector('.adjust-image-btn');
+    if (adjustBtn) {
+        adjustBtn.setAttribute('onclick', `openImageAdjuster('${itemId}', '${escapeHtml(newImage)}', 'npc')`);
+    }
+
+    const newImgEl = container.querySelector('img');
+    if (newImgEl) newImgEl.setAttribute('data-current-index', newIndex);
+}
+
+function openImagePopup(imagePath) {
+    let popup = document.getElementById('image-popup');
+    if (!popup) {
+        popup = createImagePopup();
+    }
+    const popupImage = popup.querySelector('.image-popup-content img');
+    popupImage.src = imagePath;
+    popup.style.display = 'block';
+}
+
+function closeImagePopup() {
+    const popup = document.getElementById('image-popup');
+    if (popup) {
+        popup.style.display = 'none';
+    }
+}
+
+function createImagePopup() {
+    const popup = document.createElement('div');
+    popup.id = 'image-popup';
+    popup.className = 'image-popup';
+    popup.innerHTML = `
+        <div class="image-popup-header">
+            <div class="image-popup-title">NPC Image</div>
+            <button class="image-popup-close" onclick="closeImagePopup()">×</button>
+        </div>
+        <div class="image-popup-content">
+            <img src="" alt="NPC image">
+        </div>
+    `;
+    document.body.appendChild(popup);
+    makeDraggable(popup);
+    return popup;
+}
+
+function makeDraggable(popup) {
+    const header = popup.querySelector('.image-popup-header');
+    let isDragging = false;
+    let currentX, currentY, initialX, initialY;
+    let xOffset = 0, yOffset = 0;
+
+    header.addEventListener('mousedown', dragStart);
+    document.addEventListener('mouseup', dragEnd);
+    document.addEventListener('mousemove', drag);
+
+    function dragStart(e) {
+        if (e.target.classList.contains('image-popup-close')) return;
+        initialX = e.clientX - xOffset;
+        initialY = e.clientY - yOffset;
+        if (e.target === header || header.contains(e.target)) {
+            isDragging = true;
+        }
+    }
+
+    function drag(e) {
+        if (isDragging) {
+            e.preventDefault();
+            currentX = e.clientX - initialX;
+            currentY = e.clientY - initialY;
+            xOffset = currentX;
+            yOffset = currentY;
+            popup.style.transform = `translate(${currentX}px, ${currentY}px)`;
+        }
+    }
+
+    function dragEnd() {
+        initialX = currentX;
+        initialY = currentY;
+        isDragging = false;
+    }
+}
+
+function deleteImage(itemId, imagePath) {
+    if (!confirm('Are you sure you want to delete this image?')) {
+        return;
+    }
+
+    const formData = new FormData();
+    formData.append('action', 'delete_image');
+    formData.append('npc_id', itemId);
+    formData.append('image_path', imagePath);
+
+    fetch(npcsEndpoint, {
+        method: 'POST',
+        body: formData
+    })
+    .then(response => response.json())
+    .then(data => {
+        if (data.success) {
+            if (selectedNpc && selectedNpc.npc_id === itemId) {
+                if (selectedNpc.images) {
+                    const imageIndex = selectedNpc.images.indexOf(imagePath);
+                    if (imageIndex !== -1) {
+                        selectedNpc.images.splice(imageIndex, 1);
+                    }
+                }
+
+                const modalBody = document.querySelector('#npc-modal .npc-details');
+                if (modalBody) {
+                    modalBody.innerHTML = createNpcDetailForm(selectedNpc);
+                    setupFormEventListeners(modalBody);
+                    setupModalRichTextEditors(modalBody, selectedNpc);
+                }
+            }
+            loadNpcs();
+        } else {
+            alert('Failed to delete image: ' + (data.error || 'Unknown error'));
+        }
+    })
+    .catch(error => {
+        console.error('Error deleting image:', error);
+        alert('Error deleting image');
+    });
+}
+
+function openImageAdjuster(itemId, imagePath, itemType) {
+    if (typeof ImageAdjuster === 'undefined') return;
+
+    const npc = selectedNpc && selectedNpc.npc_id === itemId ? selectedNpc : null;
+    const existingAdj = npc && npc.image_adjustments ? npc.image_adjustments[imagePath] : null;
+
+    ImageAdjuster.open(imagePath, itemId, itemType, npcsEndpoint, existingAdj, function(imgPath, adjustment) {
+        if (selectedNpc && selectedNpc.npc_id === itemId) {
+            if (!selectedNpc.image_adjustments) {
+                selectedNpc.image_adjustments = {};
+            }
+            selectedNpc.image_adjustments[imgPath] = adjustment;
+
+            const modalBody = document.querySelector('#npc-modal .npc-details');
+            if (modalBody) {
+                modalBody.innerHTML = createNpcDetailForm(selectedNpc);
+                setupFormEventListeners(modalBody);
+                setupModalRichTextEditors(modalBody, selectedNpc);
+            }
+        }
+        loadNpcs();
+    });
+}
+
+// Utility functions
+function showLoading(show) {
+    const loading = document.getElementById('loading');
+    const grid = document.getElementById('npcs-grid');
+
+    if (show) {
+        loading.style.display = 'flex';
+        grid.style.opacity = '0.5';
+    } else {
+        loading.style.display = 'none';
+        grid.style.opacity = '1';
+    }
+}
+
+function showError(message) {
+    const toast = document.createElement('div');
+    toast.className = 'toast toast-error';
+    toast.textContent = message;
+    toast.style.cssText = `
+        position: fixed;
+        top: 20px;
+        right: 20px;
+        background: #e74c3c;
+        color: white;
+        padding: 12px 20px;
+        border-radius: 6px;
+        z-index: 10000;
+        box-shadow: 0 4px 12px rgba(0,0,0,0.3);
+    `;
+    document.body.appendChild(toast);
+    setTimeout(() => {
+        if (toast.parentNode) toast.parentNode.removeChild(toast);
+    }, 4000);
+}
+
+function showSuccess(message) {
+    const toast = document.createElement('div');
+    toast.className = 'toast toast-success';
+    toast.textContent = message;
+    toast.style.cssText = `
+        position: fixed;
+        top: 20px;
+        right: 20px;
+        background: #27ae60;
+        color: white;
+        padding: 12px 20px;
+        border-radius: 6px;
+        z-index: 10000;
+        box-shadow: 0 4px 12px rgba(0,0,0,0.3);
+    `;
+    document.body.appendChild(toast);
+    setTimeout(() => {
+        if (toast.parentNode) toast.parentNode.removeChild(toast);
+    }, 3000);
+}
+
+function escapeHtml(text) {
+    if (text === null || text === undefined) return '';
+    const map = {
+        '&': '&amp;',
+        '<': '&lt;',
+        '>': '&gt;',
+        '"': '&quot;',
+        "'": '&#039;'
+    };
+    return text.toString().replace(/[&<>"']/g, function(m) { return map[m]; });
+}
+
+function debounce(func, wait) {
+    let timeout;
+    return function executedFunction(...args) {
+        const later = () => {
+            clearTimeout(timeout);
+            func.apply(this, args);
+        };
+        clearTimeout(timeout);
+        timeout = setTimeout(later, wait);
+    };
+}


### PR DESCRIPTION
Replaces the second "Coming Soon" entry in the Strixhaven dropdown with an "Other NPCs" section modeled on Students but slimmed down. The top card/form only captures name, race, and college; skills and PC relationships are removed. Access is GM-only: non-GM users don't see the menu link and the page itself returns a 403 access-restricted view (with JSON error on POST).