### PR TITLE
Add gitignore entries for Other NPCs data files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,11 @@ pnpm-lock.yaml
 # Location data
 /dnd/strixhaven/locations/locations.json
 
+# Other NPCs data
+/dnd/strixhaven/othernpcs/othernpcs.json
+/dnd/strixhaven/othernpcs/othernpcs.lock
+/dnd/strixhaven/othernpcs/othernpcs_backup_*.json
+
 # Inventory data
 /dnd/strixhaven/data/inventory.json
 


### PR DESCRIPTION
## Summary
Updated `.gitignore` to exclude generated and backup files related to the Other NPCs data module.

## Changes
- Added gitignore entries for the `othernpcs` directory to exclude:
  - `othernpcs.json` - Generated Other NPCs data file
  - `othernpcs.lock` - Lock file for data consistency
  - `othernpcs_backup_*.json` - Backup files with timestamp patterns

This follows the existing pattern used for other data modules (locations, inventory) and prevents generated/local data files from being committed to the repository.

https://claude.ai/code/session_011uxDu8HAVmy6kBR8YzQ3gU