### PR TITLE
Add Levels v2 step 1: constants, scene-state fields, and ops

### DIFF
--- a/dnd/vtt/api/state.php
+++ b/dnd/vtt/api/state.php
@@ -385,7 +385,16 @@ if (!defined('VTT_STATE_API_INCLUDE_ONLY')) {
                 // timestamp-merge (which cannot delete) by sending a
                 // `placement.remove` op directly.
                 if (!empty($ops)) {
-                    $opContext = ['isGm' => $isGm];
+                    // Levels v2: include the caller's normalized profile id so
+                    // permission-gated ops (claim.set, user-level.set) can
+                    // verify a non-GM is only writing their own state.
+                    $callerUserId = isset($auth['user']) && is_string($auth['user'])
+                        ? strtolower(trim($auth['user']))
+                        : '';
+                    $opContext = [
+                        'isGm' => $isGm,
+                        'userId' => $callerUserId,
+                    ];
                     foreach ($ops as $op) {
                         $nextState = applyBoardStateOp($nextState, $op, $opContext);
                     }
@@ -1330,9 +1339,242 @@ function applyBoardStateOp(array $state, array $op, array $context = []): array
         return $state;
     }
 
+    // Levels v2: per-scene claim of a token to a user.
+    if ($type === 'claim.set') {
+        $sceneId = isset($op['sceneId']) && is_string($op['sceneId']) ? trim($op['sceneId']) : '';
+        if ($sceneId === '') {
+            return $state;
+        }
+        $placementId = extractBoardStateOpPlacementId($op);
+        if ($placementId === '') {
+            return $state;
+        }
+        $targetUserId = isset($op['userId']) && is_string($op['userId'])
+            ? strtolower(trim($op['userId']))
+            : '';
+        if ($targetUserId === '') {
+            return $state;
+        }
+        // Non-GM may only claim a token for themselves.
+        $callerUserId = isset($context['userId']) && is_string($context['userId'])
+            ? strtolower(trim($context['userId']))
+            : '';
+        if (!$isGm && $targetUserId !== $callerUserId) {
+            return $state;
+        }
+        // Validate that the placement actually exists in the scene.
+        if (!boardStatePlacementExists($state, $sceneId, $placementId)) {
+            return $state;
+        }
+        $state = ensureBoardStateSceneEntry($state, $sceneId);
+        if (!isset($state['sceneState'][$sceneId]['claimedTokens']) || !is_array($state['sceneState'][$sceneId]['claimedTokens'])) {
+            $state['sceneState'][$sceneId]['claimedTokens'] = [];
+        }
+        $state['sceneState'][$sceneId]['claimedTokens'][$placementId] = $targetUserId;
+        return $state;
+    }
+
+    if ($type === 'claim.clear') {
+        $sceneId = isset($op['sceneId']) && is_string($op['sceneId']) ? trim($op['sceneId']) : '';
+        if ($sceneId === '') {
+            return $state;
+        }
+        $placementId = extractBoardStateOpPlacementId($op);
+        if ($placementId === '') {
+            return $state;
+        }
+        if (!isset($state['sceneState'][$sceneId]['claimedTokens']) || !is_array($state['sceneState'][$sceneId]['claimedTokens'])) {
+            return $state;
+        }
+        $existingClaim = $state['sceneState'][$sceneId]['claimedTokens'][$placementId] ?? null;
+        if ($existingClaim === null) {
+            return $state;
+        }
+        // Non-GM may only clear their own claim. They may take ownership of a
+        // claim by sending claim.set instead.
+        $callerUserId = isset($context['userId']) && is_string($context['userId'])
+            ? strtolower(trim($context['userId']))
+            : '';
+        if (!$isGm && $existingClaim !== $callerUserId) {
+            return $state;
+        }
+        unset($state['sceneState'][$sceneId]['claimedTokens'][$placementId]);
+        return $state;
+    }
+
+    if ($type === 'user-level.set') {
+        $sceneId = isset($op['sceneId']) && is_string($op['sceneId']) ? trim($op['sceneId']) : '';
+        if ($sceneId === '') {
+            return $state;
+        }
+        $targetUserId = isset($op['userId']) && is_string($op['userId'])
+            ? strtolower(trim($op['userId']))
+            : '';
+        if ($targetUserId === '') {
+            return $state;
+        }
+        $levelId = isset($op['levelId']) && is_string($op['levelId']) ? trim($op['levelId']) : '';
+        if ($levelId === '') {
+            return $state;
+        }
+        // Non-GM may only write their own active-level state.
+        $callerUserId = isset($context['userId']) && is_string($context['userId'])
+            ? strtolower(trim($context['userId']))
+            : '';
+        if (!$isGm && $targetUserId !== $callerUserId) {
+            return $state;
+        }
+        // Validate that the target level exists in the scene's stored levels
+        // or is the virtual base level. The base level constant matches
+        // BASE_MAP_LEVEL_ID on the client.
+        if (!boardStateLevelIdIsValid($state, $sceneId, $levelId)) {
+            return $state;
+        }
+        $sourceRaw = $op['source'] ?? '';
+        $source = is_string($sourceRaw) ? strtolower(trim($sourceRaw)) : '';
+        if ($source !== 'manual' && $source !== 'activate' && $source !== 'claim') {
+            $source = 'manual';
+        }
+        $entry = [
+            'levelId' => $levelId,
+            'source' => $source,
+            'updatedAt' => (int) round(microtime(true) * 1000),
+        ];
+        $tokenIdRaw = $op['tokenId'] ?? null;
+        if (is_string($tokenIdRaw)) {
+            $tokenId = trim($tokenIdRaw);
+            if ($tokenId !== '') {
+                $entry['tokenId'] = $tokenId;
+            }
+        }
+        $state = ensureBoardStateSceneEntry($state, $sceneId);
+        if (!isset($state['sceneState'][$sceneId]['userLevelState']) || !is_array($state['sceneState'][$sceneId]['userLevelState'])) {
+            $state['sceneState'][$sceneId]['userLevelState'] = [];
+        }
+        $state['sceneState'][$sceneId]['userLevelState'][$targetUserId] = $entry;
+        return $state;
+    }
+
+    if ($type === 'user-level.activate') {
+        // GM-only batch write: pull every supplied user to a single level.
+        if (!$isGm) {
+            return $state;
+        }
+        $sceneId = isset($op['sceneId']) && is_string($op['sceneId']) ? trim($op['sceneId']) : '';
+        if ($sceneId === '') {
+            return $state;
+        }
+        $levelId = isset($op['levelId']) && is_string($op['levelId']) ? trim($op['levelId']) : '';
+        if ($levelId === '') {
+            return $state;
+        }
+        if (!boardStateLevelIdIsValid($state, $sceneId, $levelId)) {
+            return $state;
+        }
+        if (!isset($op['userIds']) || !is_array($op['userIds'])) {
+            return $state;
+        }
+        $userIds = [];
+        foreach ($op['userIds'] as $userIdRaw) {
+            if (!is_string($userIdRaw)) {
+                continue;
+            }
+            $userId = strtolower(trim($userIdRaw));
+            if ($userId === '' || in_array($userId, $userIds, true)) {
+                continue;
+            }
+            $userIds[] = $userId;
+        }
+        if (empty($userIds)) {
+            return $state;
+        }
+        $state = ensureBoardStateSceneEntry($state, $sceneId);
+        if (!isset($state['sceneState'][$sceneId]['userLevelState']) || !is_array($state['sceneState'][$sceneId]['userLevelState'])) {
+            $state['sceneState'][$sceneId]['userLevelState'] = [];
+        }
+        $updatedAt = (int) round(microtime(true) * 1000);
+        foreach ($userIds as $userId) {
+            $state['sceneState'][$sceneId]['userLevelState'][$userId] = [
+                'levelId' => $levelId,
+                'source' => 'activate',
+                'updatedAt' => $updatedAt,
+            ];
+        }
+        return $state;
+    }
+
     // Unknown op types are silently ignored so older servers can
     // tolerate payloads from newer clients.
     return $state;
+}
+
+/**
+ * Levels v2: ensure a scene state entry exists in $state so claim/user-level
+ * ops can write into it without first requiring a snapshot save to seed the
+ * scene.
+ *
+ * @param array<string,mixed> $state
+ * @return array<string,mixed>
+ */
+function ensureBoardStateSceneEntry(array $state, string $sceneId): array
+{
+    if (!isset($state['sceneState']) || !is_array($state['sceneState'])) {
+        $state['sceneState'] = [];
+    }
+    if (!isset($state['sceneState'][$sceneId]) || !is_array($state['sceneState'][$sceneId])) {
+        $state['sceneState'][$sceneId] = [];
+    }
+    return $state;
+}
+
+/**
+ * Levels v2: check whether a placement with the given id exists in the
+ * scene's placements list. Used to validate claim ops before applying.
+ *
+ * @param array<string,mixed> $state
+ */
+function boardStatePlacementExists(array $state, string $sceneId, string $placementId): bool
+{
+    if (!isset($state['placements'][$sceneId]) || !is_array($state['placements'][$sceneId])) {
+        return false;
+    }
+    foreach ($state['placements'][$sceneId] as $entry) {
+        if (!is_array($entry)) {
+            continue;
+        }
+        $entryId = extractBoardEntryIdentifier($entry);
+        if ($entryId === $placementId) {
+            return true;
+        }
+    }
+    return false;
+}
+
+/**
+ * Levels v2: a level id is valid for a scene if it is the base level
+ * sentinel ("level-0") or matches an id in the scene's stored mapLevels.
+ *
+ * @param array<string,mixed> $state
+ */
+function boardStateLevelIdIsValid(array $state, string $sceneId, string $levelId): bool
+{
+    if ($levelId === 'level-0') {
+        return true;
+    }
+    $levels = $state['sceneState'][$sceneId]['mapLevels']['levels'] ?? null;
+    if (!is_array($levels)) {
+        return false;
+    }
+    foreach ($levels as $level) {
+        if (!is_array($level)) {
+            continue;
+        }
+        $idRaw = $level['id'] ?? null;
+        if (is_string($idRaw) && trim($idRaw) === $levelId) {
+            return true;
+        }
+    }
+    return false;
 }
 
 /**
@@ -1824,10 +2066,118 @@ function normalizeSceneStatePayload(array $rawSceneState, bool $includeMapLevelD
             }
         }
 
+        // Levels v2: per-scene claim and active-level state. Preserved here so
+        // saves do not silently drop them. The op-apply path is the only
+        // legitimate writer; snapshot saves should ship the canonical state
+        // exactly as the client holds it.
+        if (array_key_exists('claimedTokens', $config)) {
+            $entry['claimedTokens'] = normalizeClaimedTokensPayload($config['claimedTokens']);
+        }
+
+        if (array_key_exists('userLevelState', $config)) {
+            $entry['userLevelState'] = normalizeUserLevelStatePayload($config['userLevelState']);
+        }
+
         $normalized[$key] = $entry;
     }
 
     return $normalized;
+}
+
+/**
+ * Levels v2: normalize the per-scene `claimedTokens` map. Keys are placement
+ * ids; values are normalized profile ids (lowercased).
+ *
+ * @param mixed $raw
+ * @return array<string,string>
+ */
+function normalizeClaimedTokensPayload($raw): array
+{
+    if (!is_array($raw)) {
+        return [];
+    }
+    $out = [];
+    foreach ($raw as $placementId => $userId) {
+        if (!is_string($placementId)) {
+            continue;
+        }
+        $placementKey = trim($placementId);
+        if ($placementKey === '') {
+            continue;
+        }
+        if (!is_string($userId)) {
+            continue;
+        }
+        $userKey = strtolower(trim($userId));
+        if ($userKey === '') {
+            continue;
+        }
+        $out[$placementKey] = $userKey;
+    }
+    return $out;
+}
+
+/**
+ * Levels v2: normalize the per-scene `userLevelState` map. Keys are
+ * normalized profile ids; values are objects with `levelId`, `source`,
+ * optional `tokenId`, and `updatedAt`.
+ *
+ * @param mixed $raw
+ * @return array<string,array<string,mixed>>
+ */
+function normalizeUserLevelStatePayload($raw): array
+{
+    if (!is_array($raw)) {
+        return [];
+    }
+    $out = [];
+    foreach ($raw as $userId => $entry) {
+        if (!is_string($userId)) {
+            continue;
+        }
+        $userKey = strtolower(trim($userId));
+        if ($userKey === '') {
+            continue;
+        }
+        if (!is_array($entry)) {
+            continue;
+        }
+        $levelIdRaw = $entry['levelId'] ?? null;
+        if (!is_string($levelIdRaw)) {
+            continue;
+        }
+        $levelId = trim($levelIdRaw);
+        if ($levelId === '') {
+            continue;
+        }
+        $sourceRaw = $entry['source'] ?? '';
+        $source = is_string($sourceRaw) ? strtolower(trim($sourceRaw)) : '';
+        if ($source !== 'manual' && $source !== 'activate' && $source !== 'claim') {
+            $source = 'manual';
+        }
+        $updatedAtRaw = $entry['updatedAt'] ?? 0;
+        $updatedAt = 0;
+        if (is_int($updatedAtRaw) || is_float($updatedAtRaw)) {
+            $updatedAt = max(0, (int) $updatedAtRaw);
+        } elseif (is_string($updatedAtRaw) && is_numeric($updatedAtRaw)) {
+            $updatedAt = max(0, (int) $updatedAtRaw);
+        }
+
+        $record = [
+            'levelId' => $levelId,
+            'source' => $source,
+            'updatedAt' => $updatedAt,
+        ];
+        $tokenIdRaw = $entry['tokenId'] ?? null;
+        if (is_string($tokenIdRaw)) {
+            $tokenId = trim($tokenIdRaw);
+            if ($tokenId !== '') {
+                $record['tokenId'] = $tokenId;
+            }
+        }
+        $out[$userKey] = $record;
+    }
+    return $out;
 }
 
 function createEmptyMapLevelsState(): array

--- a/dnd/vtt/assets/js/services/__tests__/board-state-op-applier-levels-v2.test.mjs
+++ b/dnd/vtt/assets/js/services/__tests__/board-state-op-applier-levels-v2.test.mjs
@@ -1,0 +1,191 @@
+import { describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { applyBoardStateOpLocally } from '../board-state-op-applier.js';
+
+// Levels v2 (Step 1): client-side op applier handlers for the new
+// claim and user-level op types. Mirrors the server's `applyBoardStateOp`
+// in `dnd/vtt/api/state.php`. These tests lock in the wire shape and
+// scene-state mutation semantics; permission rules are enforced
+// server-side and tested separately.
+
+function seedBoardState() {
+  return {
+    placements: {
+      'scene-1': [
+        { id: 'hero', column: 1, row: 2 },
+        { id: 'goblin', column: 5, row: 5 },
+      ],
+    },
+    sceneState: {
+      'scene-1': {
+        mapLevels: { levels: [{ id: 'map-level-a' }], activeLevelId: null },
+      },
+    },
+  };
+}
+
+describe('Board State Op Applier — claim.set / claim.clear', () => {
+  test('sets a claim and writes the user id under the placement', () => {
+    const state = seedBoardState();
+    const mutated = applyBoardStateOpLocally(state, {
+      type: 'claim.set',
+      sceneId: 'scene-1',
+      placementId: 'hero',
+      userId: 'Indigo',
+    });
+    assert.equal(mutated, true);
+    assert.equal(state.sceneState['scene-1'].claimedTokens.hero, 'indigo');
+  });
+
+  test('replacing an existing claim updates the user', () => {
+    const state = seedBoardState();
+    state.sceneState['scene-1'].claimedTokens = { hero: 'sharon' };
+    const mutated = applyBoardStateOpLocally(state, {
+      type: 'claim.set',
+      sceneId: 'scene-1',
+      placementId: 'hero',
+      userId: 'frunk',
+    });
+    assert.equal(mutated, true);
+    assert.equal(state.sceneState['scene-1'].claimedTokens.hero, 'frunk');
+  });
+
+  test('claim.set with same user is a no-op', () => {
+    const state = seedBoardState();
+    state.sceneState['scene-1'].claimedTokens = { hero: 'indigo' };
+    const mutated = applyBoardStateOpLocally(state, {
+      type: 'claim.set',
+      sceneId: 'scene-1',
+      placementId: 'hero',
+      userId: 'indigo',
+    });
+    assert.equal(mutated, false);
+  });
+
+  test('claim.clear removes the claim', () => {
+    const state = seedBoardState();
+    state.sceneState['scene-1'].claimedTokens = { hero: 'indigo' };
+    const mutated = applyBoardStateOpLocally(state, {
+      type: 'claim.clear',
+      sceneId: 'scene-1',
+      placementId: 'hero',
+    });
+    assert.equal(mutated, true);
+    assert.equal('hero' in state.sceneState['scene-1'].claimedTokens, false);
+  });
+
+  test('claim.clear on an unclaimed placement is a no-op', () => {
+    const state = seedBoardState();
+    const mutated = applyBoardStateOpLocally(state, {
+      type: 'claim.clear',
+      sceneId: 'scene-1',
+      placementId: 'hero',
+    });
+    assert.equal(mutated, false);
+  });
+
+  test('rejects malformed claim.set ops', () => {
+    const state = seedBoardState();
+    assert.equal(
+      applyBoardStateOpLocally(state, { type: 'claim.set', sceneId: 'scene-1' }),
+      false
+    );
+    assert.equal(
+      applyBoardStateOpLocally(state, {
+        type: 'claim.set',
+        sceneId: 'scene-1',
+        placementId: 'hero',
+      }),
+      false
+    );
+    assert.equal(state.sceneState['scene-1'].claimedTokens, undefined);
+  });
+});
+
+describe('Board State Op Applier — user-level.set', () => {
+  test('writes a per-user level entry with manual default source', () => {
+    const state = seedBoardState();
+    const mutated = applyBoardStateOpLocally(state, {
+      type: 'user-level.set',
+      sceneId: 'scene-1',
+      userId: 'indigo',
+      levelId: 'level-0',
+    });
+    assert.equal(mutated, true);
+    const entry = state.sceneState['scene-1'].userLevelState.indigo;
+    assert.equal(entry.levelId, 'level-0');
+    assert.equal(entry.source, 'manual');
+    assert.ok(typeof entry.updatedAt === 'number' && entry.updatedAt > 0);
+  });
+
+  test('respects an explicit source and tokenId when provided', () => {
+    const state = seedBoardState();
+    applyBoardStateOpLocally(state, {
+      type: 'user-level.set',
+      sceneId: 'scene-1',
+      userId: 'sharon',
+      levelId: 'map-level-a',
+      source: 'claim',
+      tokenId: 'hero',
+    });
+    const entry = state.sceneState['scene-1'].userLevelState.sharon;
+    assert.equal(entry.source, 'claim');
+    assert.equal(entry.tokenId, 'hero');
+  });
+
+  test('coerces an unknown source string to manual', () => {
+    const state = seedBoardState();
+    applyBoardStateOpLocally(state, {
+      type: 'user-level.set',
+      sceneId: 'scene-1',
+      userId: 'frunk',
+      levelId: 'level-0',
+      source: 'bogus',
+    });
+    assert.equal(state.sceneState['scene-1'].userLevelState.frunk.source, 'manual');
+  });
+});
+
+describe('Board State Op Applier — user-level.activate', () => {
+  test('writes the same level for every supplied user with source=activate', () => {
+    const state = seedBoardState();
+    const mutated = applyBoardStateOpLocally(state, {
+      type: 'user-level.activate',
+      sceneId: 'scene-1',
+      levelId: 'map-level-a',
+      userIds: ['indigo', 'Sharon', 'frunk'],
+    });
+    assert.equal(mutated, true);
+    const entries = state.sceneState['scene-1'].userLevelState;
+    assert.equal(entries.indigo.levelId, 'map-level-a');
+    assert.equal(entries.indigo.source, 'activate');
+    assert.equal(entries.sharon.source, 'activate');
+    assert.equal(entries.frunk.source, 'activate');
+  });
+
+  test('returns false when userIds is empty or missing', () => {
+    const state = seedBoardState();
+    assert.equal(
+      applyBoardStateOpLocally(state, {
+        type: 'user-level.activate',
+        sceneId: 'scene-1',
+        levelId: 'map-level-a',
+        userIds: [],
+      }),
+      false
+    );
+  });
+
+  test('creates the sceneState entry if missing', () => {
+    const state = { placements: {}, sceneState: {} };
+    const mutated = applyBoardStateOpLocally(state, {
+      type: 'user-level.activate',
+      sceneId: 'scene-7',
+      levelId: 'level-0',
+      userIds: ['indigo'],
+    });
+    assert.equal(mutated, true);
+    assert.equal(state.sceneState['scene-7'].userLevelState.indigo.levelId, 'level-0');
+  });
+});

--- a/dnd/vtt/assets/js/services/board-state-op-applier.js
+++ b/dnd/vtt/assets/js/services/board-state-op-applier.js
@@ -12,14 +12,18 @@
  * become a single committed state transition.
  *
  * Op shapes:
- *   { type: 'placement.move',   sceneId, placementId, x, y }
- *   { type: 'placement.add',    sceneId, placement: { id, ... } }
- *   { type: 'placement.remove', sceneId, placementId }
- *   { type: 'placement.update', sceneId, placementId, patch: { ... } }
- *   { type: 'template.upsert',  sceneId, template: { id, ... } }
- *   { type: 'template.remove',  sceneId, templateId }
- *   { type: 'drawing.add',      sceneId, drawing:  { id, ... } }
- *   { type: 'drawing.remove',   sceneId, drawingId }
+ *   { type: 'placement.move',     sceneId, placementId, x, y }
+ *   { type: 'placement.add',      sceneId, placement: { id, ... } }
+ *   { type: 'placement.remove',   sceneId, placementId }
+ *   { type: 'placement.update',   sceneId, placementId, patch: { ... } }
+ *   { type: 'template.upsert',    sceneId, template: { id, ... } }
+ *   { type: 'template.remove',    sceneId, templateId }
+ *   { type: 'drawing.add',        sceneId, drawing:  { id, ... } }
+ *   { type: 'drawing.remove',     sceneId, drawingId }
+ *   { type: 'claim.set',          sceneId, placementId, userId }
+ *   { type: 'claim.clear',        sceneId, placementId }
+ *   { type: 'user-level.set',     sceneId, userId, levelId, source?, tokenId? }
+ *   { type: 'user-level.activate',sceneId, levelId, userIds: [...] }
  *
  * Unknown or malformed ops are silently ignored — the function returns
  * the boardState unchanged for that op. This matches the server's
@@ -217,6 +221,79 @@ export function applyBoardStateOpLocally(boardState, op) {
     return true;
   }
 
+  // Levels v2: per-scene claim of a token to a user.
+  if (type === 'claim.set') {
+    const placementId = extractOpEntityId(op, 'placementId');
+    if (!placementId) return false;
+    const userId = normalizeProfileIdField(op.userId);
+    if (!userId) return false;
+    const sceneState = ensureSceneStateEntry(boardState, sceneId);
+    if (!sceneState.claimedTokens || typeof sceneState.claimedTokens !== 'object') {
+      sceneState.claimedTokens = {};
+    }
+    if (sceneState.claimedTokens[placementId] === userId) {
+      return false;
+    }
+    sceneState.claimedTokens[placementId] = userId;
+    return true;
+  }
+
+  if (type === 'claim.clear') {
+    const placementId = extractOpEntityId(op, 'placementId');
+    if (!placementId) return false;
+    const sceneState = boardState?.sceneState?.[sceneId];
+    if (!sceneState || typeof sceneState !== 'object') return false;
+    const claims = sceneState.claimedTokens;
+    if (!claims || typeof claims !== 'object') return false;
+    if (!(placementId in claims)) return false;
+    delete claims[placementId];
+    return true;
+  }
+
+  if (type === 'user-level.set') {
+    const userId = normalizeProfileIdField(op.userId);
+    if (!userId) return false;
+    const levelId = typeof op.levelId === 'string' ? op.levelId.trim() : '';
+    if (!levelId) return false;
+    const sceneState = ensureSceneStateEntry(boardState, sceneId);
+    if (!sceneState.userLevelState || typeof sceneState.userLevelState !== 'object') {
+      sceneState.userLevelState = {};
+    }
+    const entry = buildUserLevelEntry({
+      levelId,
+      source: op.source,
+      tokenId: op.tokenId,
+    });
+    sceneState.userLevelState[userId] = entry;
+    return true;
+  }
+
+  if (type === 'user-level.activate') {
+    const levelId = typeof op.levelId === 'string' ? op.levelId.trim() : '';
+    if (!levelId) return false;
+    const userIds = Array.isArray(op.userIds)
+      ? op.userIds
+          .map((id) => normalizeProfileIdField(id))
+          .filter((id) => id)
+      : [];
+    if (userIds.length === 0) return false;
+    const sceneState = ensureSceneStateEntry(boardState, sceneId);
+    if (!sceneState.userLevelState || typeof sceneState.userLevelState !== 'object') {
+      sceneState.userLevelState = {};
+    }
+    let mutated = false;
+    const updatedAt = Date.now();
+    userIds.forEach((userId) => {
+      sceneState.userLevelState[userId] = {
+        levelId,
+        source: 'activate',
+        updatedAt,
+      };
+      mutated = true;
+    });
+    return mutated;
+  }
+
   // Unknown op type — ignored so the client tolerates payloads from
   // newer servers without crashing.
   return false;
@@ -275,4 +352,37 @@ function entryId(entry) {
     return String(raw);
   }
   return '';
+}
+
+function normalizeProfileIdField(value) {
+  if (typeof value !== 'string') return '';
+  const trimmed = value.trim().toLowerCase();
+  return trimmed;
+}
+
+function ensureSceneStateEntry(boardState, sceneId) {
+  if (!boardState.sceneState || typeof boardState.sceneState !== 'object') {
+    boardState.sceneState = {};
+  }
+  const existing = boardState.sceneState[sceneId];
+  if (!existing || typeof existing !== 'object') {
+    boardState.sceneState[sceneId] = {};
+  }
+  return boardState.sceneState[sceneId];
+}
+
+const USER_LEVEL_OP_SOURCES = new Set(['manual', 'activate', 'claim']);
+
+function buildUserLevelEntry({ levelId, source, tokenId }) {
+  const sourceRaw = typeof source === 'string' ? source.trim().toLowerCase() : '';
+  const normalizedSource = USER_LEVEL_OP_SOURCES.has(sourceRaw) ? sourceRaw : 'manual';
+  const entry = {
+    levelId,
+    source: normalizedSource,
+    updatedAt: Date.now(),
+  };
+  if (typeof tokenId === 'string' && tokenId.trim()) {
+    entry.tokenId = tokenId.trim();
+  }
+  return entry;
 }

--- a/dnd/vtt/assets/js/services/board-state-service.js
+++ b/dnd/vtt/assets/js/services/board-state-service.js
@@ -1,6 +1,10 @@
 import { queueSave } from '../state/persistence.js';
 import { normalizeGridState } from '../state/normalize/grid.js';
-import { normalizeMapLevelsState } from '../state/normalize/map-levels.js';
+import {
+  normalizeClaimedTokensMap,
+  normalizeMapLevelsState,
+  normalizeUserLevelStateMap,
+} from '../state/normalize/map-levels.js';
 
 const SAVE_KEY = 'board-state';
 const COMBAT_SAVE_KEY_PREFIX = 'combat-state';
@@ -122,6 +126,33 @@ function boardStateOpDedupKey(op) {
       return null;
     }
     return `drawing.remove:${sceneId}:${drawingId}`;
+  }
+  // Levels v2 ops. Per-(scene, placement) keys for claim ops and per-(scene,
+  // user) keys for user-level ops so rapid repeats coalesce; the activate op
+  // is broadcast-style so it has no per-user key (later wins on the scene).
+  if (op.type === 'claim.set') {
+    const placementId = typeof op.placementId === 'string' ? op.placementId.trim() : '';
+    if (!placementId) {
+      return null;
+    }
+    return `claim.set:${sceneId}:${placementId}`;
+  }
+  if (op.type === 'claim.clear') {
+    const placementId = typeof op.placementId === 'string' ? op.placementId.trim() : '';
+    if (!placementId) {
+      return null;
+    }
+    return `claim.clear:${sceneId}:${placementId}`;
+  }
+  if (op.type === 'user-level.set') {
+    const userId = typeof op.userId === 'string' ? op.userId.trim().toLowerCase() : '';
+    if (!userId) {
+      return null;
+    }
+    return `user-level.set:${sceneId}:${userId}`;
+  }
+  if (op.type === 'user-level.activate') {
+    return `user-level.activate:${sceneId}`;
   }
   return null;
 }
@@ -393,7 +424,11 @@ function buildPayload(boardState = {}) {
         const combat = formatCombatState(value.combat ?? value.combatState ?? null);
         const overlay = formatOverlayState(value.overlay ?? null);
         const mapLevels = normalizeMapLevelsState(value.mapLevels ?? null, { sceneGrid: grid });
-        const entry = { grid, overlay, mapLevels };
+        // Levels v2: preserve per-scene claim and active-level state so
+        // snapshot saves do not silently drop the new fields.
+        const claimedTokens = normalizeClaimedTokensMap(value.claimedTokens ?? null);
+        const userLevelState = normalizeUserLevelStateMap(value.userLevelState ?? null);
+        const entry = { grid, overlay, mapLevels, claimedTokens, userLevelState };
         if (combat) {
           entry.combat = combat;
         }

--- a/dnd/vtt/assets/js/state/__tests__/map-levels-v2-normalization.test.mjs
+++ b/dnd/vtt/assets/js/state/__tests__/map-levels-v2-normalization.test.mjs
@@ -1,0 +1,168 @@
+import { describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  BASE_MAP_LEVEL_ID,
+  buildLevelViewModel,
+  levelIdExistsInViewModel,
+  normalizeClaimedTokensMap,
+  normalizeUserLevelStateEntry,
+  normalizeUserLevelStateMap,
+  resolvePlacementLevelId,
+} from '../normalize/map-levels.js';
+import { normalizeSceneBoardState } from '../normalize/scene-board-state.js';
+
+// Levels v2 (Step 1): exercises the new constant, view-model helper, and
+// per-scene normalization for claim and user-level state. The plan in
+// `dnd/vtt/LEVELS_V2_PLAN.md` keeps Level 0 virtual (derived from the
+// scene's base map URL) and stores Level 1+ in the existing levels array.
+
+describe('Levels v2 — base level constant and placement resolution', () => {
+  test('BASE_MAP_LEVEL_ID is the canonical level-0 id', () => {
+    assert.equal(BASE_MAP_LEVEL_ID, 'level-0');
+  });
+
+  test('resolvePlacementLevelId returns Level 0 when missing/null/blank', () => {
+    assert.equal(resolvePlacementLevelId({}), 'level-0');
+    assert.equal(resolvePlacementLevelId({ levelId: null }), 'level-0');
+    assert.equal(resolvePlacementLevelId({ levelId: '' }), 'level-0');
+    assert.equal(resolvePlacementLevelId({ levelId: '   ' }), 'level-0');
+  });
+
+  test('resolvePlacementLevelId trims and returns a stored level id', () => {
+    assert.equal(resolvePlacementLevelId({ levelId: '  map-level-a  ' }), 'map-level-a');
+  });
+});
+
+describe('Levels v2 — buildLevelViewModel', () => {
+  test('places a virtual Level 0 entry first with the scene base map url', () => {
+    const view = buildLevelViewModel({
+      baseMapUrl: '/maps/base.png',
+      mapLevels: { levels: [{ id: 'a', name: 'Upper', zIndex: 1 }] },
+      sceneGrid: { size: 80 },
+    });
+    assert.equal(view.length, 2);
+    assert.equal(view[0].id, 'level-0');
+    assert.equal(view[0].mapUrl, '/maps/base.png');
+    assert.equal(view[0].isBaseLevel, true);
+    assert.equal(view[0].grid.size, 80);
+    assert.equal(view[1].id, 'a');
+    assert.equal(view[1].isBaseLevel, false);
+  });
+
+  test('sorts stored levels by zIndex ascending', () => {
+    const view = buildLevelViewModel({
+      baseMapUrl: '/m.png',
+      mapLevels: {
+        levels: [
+          { id: 'top', zIndex: 5 },
+          { id: 'mid', zIndex: 2 },
+          { id: 'low', zIndex: 0 },
+        ],
+      },
+    });
+    assert.deepEqual(
+      view.map((entry) => entry.id),
+      ['level-0', 'low', 'mid', 'top']
+    );
+  });
+
+  test('handles missing baseMapUrl by setting null', () => {
+    const view = buildLevelViewModel({ baseMapUrl: null, mapLevels: { levels: [] } });
+    assert.equal(view.length, 1);
+    assert.equal(view[0].mapUrl, null);
+  });
+
+  test('levelIdExistsInViewModel matches level-0 and stored ids', () => {
+    const view = buildLevelViewModel({
+      baseMapUrl: '/m.png',
+      mapLevels: { levels: [{ id: 'a' }] },
+    });
+    assert.equal(levelIdExistsInViewModel('level-0', view), true);
+    assert.equal(levelIdExistsInViewModel('a', view), true);
+    assert.equal(levelIdExistsInViewModel('missing', view), false);
+    assert.equal(levelIdExistsInViewModel('', view), false);
+  });
+});
+
+describe('Levels v2 — normalizeUserLevelStateEntry', () => {
+  test('rejects entries without a levelId', () => {
+    assert.equal(normalizeUserLevelStateEntry({}), null);
+    assert.equal(normalizeUserLevelStateEntry({ levelId: '' }), null);
+  });
+
+  test('coerces an unknown source to manual and clamps updatedAt', () => {
+    const entry = normalizeUserLevelStateEntry({
+      levelId: '  level-0  ',
+      source: 'BoGuS',
+      updatedAt: '12345',
+    });
+    assert.equal(entry.levelId, 'level-0');
+    assert.equal(entry.source, 'manual');
+    assert.equal(entry.updatedAt, 12345);
+  });
+
+  test('preserves a tokenId when present', () => {
+    const entry = normalizeUserLevelStateEntry({
+      levelId: 'a',
+      source: 'claim',
+      tokenId: ' placement-1 ',
+    });
+    assert.equal(entry.tokenId, 'placement-1');
+  });
+});
+
+describe('Levels v2 — normalizeUserLevelStateMap and normalizeClaimedTokensMap', () => {
+  test('normalizes profile id keys to lowercase and drops invalid entries', () => {
+    const result = normalizeUserLevelStateMap({
+      Indigo: { levelId: 'level-0' },
+      '': { levelId: 'a' },
+      sharon: 'not-an-object',
+      bogus: { levelId: '' },
+    });
+    assert.deepEqual(Object.keys(result).sort(), ['indigo']);
+    assert.equal(result.indigo.levelId, 'level-0');
+  });
+
+  test('normalizes claim map keys (placement ids) and values (profile ids)', () => {
+    const result = normalizeClaimedTokensMap({
+      'placement-1': 'Indigo',
+      '': 'sharon',
+      'placement-2': '',
+      'placement-3': 'FRUNK',
+    });
+    assert.deepEqual(result, {
+      'placement-1': 'indigo',
+      'placement-3': 'frunk',
+    });
+  });
+});
+
+describe('Levels v2 — scene-board-state normalization preserves new fields', () => {
+  test('claimedTokens and userLevelState round-trip through the scene normalizer', () => {
+    const normalized = normalizeSceneBoardState({
+      'scene-1': {
+        grid: { size: 64 },
+        claimedTokens: { 'placement-1': 'Indigo' },
+        userLevelState: {
+          Indigo: { levelId: 'level-0', source: 'claim', tokenId: 'placement-1', updatedAt: 100 },
+        },
+      },
+    });
+    assert.deepEqual(normalized['scene-1'].claimedTokens, { 'placement-1': 'indigo' });
+    assert.deepEqual(normalized['scene-1'].userLevelState.indigo, {
+      levelId: 'level-0',
+      source: 'claim',
+      updatedAt: 100,
+      tokenId: 'placement-1',
+    });
+  });
+
+  test('absent fields default to empty maps', () => {
+    const normalized = normalizeSceneBoardState({
+      'scene-1': { grid: { size: 64 } },
+    });
+    assert.deepEqual(normalized['scene-1'].claimedTokens, {});
+    assert.deepEqual(normalized['scene-1'].userLevelState, {});
+  });
+});

--- a/dnd/vtt/assets/js/state/normalize/map-levels.js
+++ b/dnd/vtt/assets/js/state/normalize/map-levels.js
@@ -4,6 +4,12 @@ import { roundToPrecision, toBoolean, toNonNegativeInt } from './helpers.js';
 export const MAP_LEVEL_MAX_LEVELS = 5;
 export const MAP_LEVEL_ID_PREFIX = 'map-level-';
 
+// Levels v2: the first uploaded scene map is treated as Level 0. It is not
+// persisted in `mapLevels.levels` (which still stores Level 1+ only); it is
+// derived from the scene's base map URL when building the level view model.
+// Placements without an explicit `levelId` resolve to this id.
+export const BASE_MAP_LEVEL_ID = 'level-0';
+
 const mapLevelSeed = Date.now();
 let mapLevelSequence = 0;
 
@@ -161,6 +167,178 @@ function normalizeDefaultPlayerLevel(levels) {
       firstVisible.defaultForPlayers = true;
     }
   }
+}
+
+/**
+ * Levels v2 helper: resolve a placement's stored level id. Missing, blank,
+ * or null values map to BASE_MAP_LEVEL_ID. This is intentionally separate
+ * from `resolveActiveLevelId` because the user's active level must never be
+ * used as a fallback for a token that lacks `levelId` — that would let
+ * old tokens "follow" users between levels.
+ */
+export function resolvePlacementLevelId(placement) {
+  if (!placement || typeof placement !== 'object') {
+    return BASE_MAP_LEVEL_ID;
+  }
+  const raw = placement.levelId;
+  if (typeof raw !== 'string') {
+    return BASE_MAP_LEVEL_ID;
+  }
+  const trimmed = raw.trim();
+  return trimmed || BASE_MAP_LEVEL_ID;
+}
+
+/**
+ * Levels v2 helper: build the per-scene level view model. Returns an
+ * ordered list with the virtual Level 0 entry first (derived from the
+ * scene's base map URL) followed by stored Level 1+ entries sorted by
+ * zIndex. Used by the renderer, the level selector, and visibility code
+ * so they can treat Level 0 like any other level.
+ */
+export function buildLevelViewModel({ baseMapUrl = null, mapLevels = null, sceneGrid = null } = {}) {
+  const trimmedBase = typeof baseMapUrl === 'string' ? baseMapUrl.trim() : '';
+  const baseEntry = {
+    id: BASE_MAP_LEVEL_ID,
+    name: 'Level 0',
+    mapUrl: trimmedBase || null,
+    visible: true,
+    opacity: 1,
+    zIndex: -1,
+    grid: sceneGrid && typeof sceneGrid === 'object' ? sceneGrid : null,
+    cutouts: [],
+    blocksLowerLevelInteraction: false,
+    blocksLowerLevelVision: false,
+    defaultForPlayers: false,
+    isBaseLevel: true,
+  };
+
+  const storedLevels = Array.isArray(mapLevels?.levels) ? mapLevels.levels : [];
+  const storedSorted = storedLevels
+    .filter((level) => level && typeof level === 'object' && level.id)
+    .slice()
+    .sort((a, b) => {
+      const aZ = Number.isFinite(a?.zIndex) ? a.zIndex : 0;
+      const bZ = Number.isFinite(b?.zIndex) ? b.zIndex : 0;
+      return aZ - bZ;
+    })
+    .map((level, index) => ({
+      ...level,
+      // Display labels for stored levels start at "Level 1".
+      displayLabel: typeof level.name === 'string' && level.name.trim()
+        ? level.name
+        : `Level ${index + 1}`,
+      isBaseLevel: false,
+    }));
+
+  return [baseEntry, ...storedSorted];
+}
+
+/**
+ * Levels v2 helper: validate a level id against a built view model.
+ * Returns the id if it exists in the view model, otherwise null.
+ */
+export function levelIdExistsInViewModel(levelId, viewModel = []) {
+  if (typeof levelId !== 'string') {
+    return false;
+  }
+  const trimmed = levelId.trim();
+  if (!trimmed) {
+    return false;
+  }
+  if (!Array.isArray(viewModel)) {
+    return false;
+  }
+  return viewModel.some((entry) => entry && entry.id === trimmed);
+}
+
+const USER_LEVEL_STATE_SOURCES = new Set(['manual', 'activate', 'claim']);
+
+/**
+ * Levels v2: normalize a single user's active-level entry. Returns null
+ * when the input cannot be coerced into a valid record so the caller can
+ * drop it from the map.
+ */
+export function normalizeUserLevelStateEntry(raw) {
+  if (!raw || typeof raw !== 'object') {
+    return null;
+  }
+  const levelIdSource = typeof raw.levelId === 'string' ? raw.levelId.trim() : '';
+  if (!levelIdSource) {
+    return null;
+  }
+  const sourceSource = typeof raw.source === 'string' ? raw.source.trim().toLowerCase() : '';
+  const source = USER_LEVEL_STATE_SOURCES.has(sourceSource) ? sourceSource : 'manual';
+  const tokenIdSource = typeof raw.tokenId === 'string' ? raw.tokenId.trim() : '';
+  const updatedAtRaw = Number(raw.updatedAt);
+  const updatedAt = Number.isFinite(updatedAtRaw) ? Math.max(0, Math.trunc(updatedAtRaw)) : 0;
+
+  const entry = {
+    levelId: levelIdSource,
+    source,
+    updatedAt,
+  };
+  if (tokenIdSource) {
+    entry.tokenId = tokenIdSource;
+  }
+  return entry;
+}
+
+/**
+ * Levels v2: normalize the full per-user active-level map for a scene.
+ * Keys are normalized profile ids; values are entry records as produced by
+ * `normalizeUserLevelStateEntry`. Invalid entries are dropped silently.
+ */
+export function normalizeUserLevelStateMap(raw) {
+  if (!raw || typeof raw !== 'object') {
+    return {};
+  }
+  const out = {};
+  Object.keys(raw).forEach((key) => {
+    if (typeof key !== 'string') {
+      return;
+    }
+    const normalizedKey = key.trim().toLowerCase();
+    if (!normalizedKey) {
+      return;
+    }
+    const entry = normalizeUserLevelStateEntry(raw[key]);
+    if (!entry) {
+      return;
+    }
+    out[normalizedKey] = entry;
+  });
+  return out;
+}
+
+/**
+ * Levels v2: normalize the per-scene `claimedTokens` map. Keys are
+ * placement ids, values are normalized profile ids. Invalid entries are
+ * dropped silently.
+ */
+export function normalizeClaimedTokensMap(raw) {
+  if (!raw || typeof raw !== 'object') {
+    return {};
+  }
+  const out = {};
+  Object.keys(raw).forEach((key) => {
+    if (typeof key !== 'string') {
+      return;
+    }
+    const placementId = key.trim();
+    if (!placementId) {
+      return;
+    }
+    const value = raw[key];
+    if (typeof value !== 'string') {
+      return;
+    }
+    const userId = value.trim().toLowerCase();
+    if (!userId) {
+      return;
+    }
+    out[placementId] = userId;
+  });
+  return out;
 }
 
 function resolveActiveLevelId(preferredId, levels = []) {

--- a/dnd/vtt/assets/js/state/normalize/scene-board-state.js
+++ b/dnd/vtt/assets/js/state/normalize/scene-board-state.js
@@ -2,7 +2,11 @@ import { normalizeGridState } from './grid.js';
 import { normalizeCombatStateEntry } from './combat.js';
 import { normalizeOverlayEntry } from './overlay.js';
 import { normalizeFogOfWarEntry } from './fog.js';
-import { normalizeMapLevelsState } from './map-levels.js';
+import {
+  normalizeClaimedTokensMap,
+  normalizeMapLevelsState,
+  normalizeUserLevelStateMap,
+} from './map-levels.js';
 
 export function normalizeSceneBoardState(raw = {}) {
   if (!raw || typeof raw !== 'object') {
@@ -26,7 +30,9 @@ export function normalizeSceneBoardState(raw = {}) {
     const overlay = normalizeOverlayEntry(value.overlay ?? null);
     const mapLevels = normalizeMapLevelsState(value.mapLevels ?? null, { sceneGrid: grid });
     const fogOfWar = normalizeFogOfWarEntry(value.fogOfWar ?? null);
-    const entry = { grid, mapLevels };
+    const claimedTokens = normalizeClaimedTokensMap(value.claimedTokens ?? null);
+    const userLevelState = normalizeUserLevelStateMap(value.userLevelState ?? null);
+    const entry = { grid, mapLevels, claimedTokens, userLevelState };
 
     if (combat) {
       entry.combat = combat;


### PR DESCRIPTION
Implements step 1 of the Levels v2 build order from LEVELS_V2_PLAN.md: the foundation needed before per-user active level, Activate, claims, visibility rules, and falling can land.

- Added BASE_MAP_LEVEL_ID = "level-0" and a virtual Level 0 view-model helper. Stored mapLevels.levels still hold Level 1+ only; Level 0 is derived from the scene base map URL when the renderer/UI need it.
- Added resolvePlacementLevelId so placements with missing/null/blank levelId resolve to Level 0 without using the user's active level as a fallback (which would have moved old tokens between levels as users browsed).
- Per-scene claimedTokens and userLevelState are now normalized, preserved through scene normalization, and shipped on snapshot saves.
- New ops claim.set, claim.clear, user-level.set, user-level.activate are mirrored on the client op applier and the server state.php. Permissions: non-GM may only claim/clear their own claim and write their own active level; user-level.activate is GM-only. Server-side validation rejects ops targeting a non-existent placement or a level id that is not the level-0 sentinel and is missing from the scene's stored levels.
- Op dedupe keys cover the new types so rapid repeats coalesce.

Tests: 26 new tests across map-levels-v2-normalization and board-state-op-applier-levels-v2; full suite remains green (408 tests).