### PR TITLE
Add Levels v2 step 2: per-user active level and viewer indicator

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -30,7 +30,10 @@
       "mcp__playwright__browser_console_messages",
       "mcp__playwright__browser_handle_dialog",
       "Bash(npm test *)",
-      "Read(//tmp/**)"
+      "Read(//tmp/**)",
+      "Read(//c/c/Users/tasta/OneDrive/Documents/GitHub/gmscreen/.claude/worktrees/**)",
+      "Bash(node -e \"import\\('./dnd/vtt/assets/js/state/normalize/map-levels.js'\\).then\\(m => console.log\\(Object.keys\\(m\\).filter\\(k => k.startsWith\\('resolve'\\) || k.startsWith\\('build'\\) || k.startsWith\\('BASE'\\)\\)\\)\\)\")",
+      "Bash(node --check dnd/vtt/assets/js/ui/board-interactions.js)"
     ],
     "deny": []
   }

--- a/dnd/vtt/assets/css/board.css
+++ b/dnd/vtt/assets/css/board.css
@@ -144,6 +144,33 @@
   white-space: nowrap;
 }
 
+.vtt-board__level-indicator {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  margin: 0;
+  padding: 0.15rem 0.5rem;
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  border-radius: calc(var(--vtt-radius) * 0.55);
+  background: rgba(15, 23, 42, 0.28);
+  color: var(--vtt-text-primary);
+  font-size: 0.78rem;
+  line-height: 1.2;
+}
+
+.vtt-board__level-indicator[hidden] {
+  display: none !important;
+}
+
+.vtt-board__level-indicator-label {
+  color: var(--vtt-text-muted);
+  font-weight: 600;
+}
+
+.vtt-board__level-indicator-value {
+  font-weight: 700;
+}
+
 .vtt-board__tracker {
   display: flex;
   align-items: flex-start;

--- a/dnd/vtt/assets/js/state/__tests__/map-levels-v2-normalization.test.mjs
+++ b/dnd/vtt/assets/js/state/__tests__/map-levels-v2-normalization.test.mjs
@@ -8,6 +8,7 @@ import {
   normalizeClaimedTokensMap,
   normalizeUserLevelStateEntry,
   normalizeUserLevelStateMap,
+  resolveActiveLevelIdForUser,
   resolvePlacementLevelId,
 } from '../normalize/map-levels.js';
 import { normalizeSceneBoardState } from '../normalize/scene-board-state.js';
@@ -166,3 +167,104 @@ describe('Levels v2 — scene-board-state normalization preserves new fields', (
     assert.deepEqual(normalized['scene-1'].userLevelState, {});
   });
 });
+
+describe('Levels v2 — resolveActiveLevelIdForUser', () => {
+  test('returns BASE_MAP_LEVEL_ID when no scene state is provided', () => {
+    assert.equal(
+      resolveActiveLevelIdForUser({ userId: 'gm' }),
+      BASE_MAP_LEVEL_ID,
+    );
+  });
+
+  test('returns BASE_MAP_LEVEL_ID when the user has no entry', () => {
+    const sceneState = { userLevelState: {} };
+    assert.equal(
+      resolveActiveLevelIdForUser({ sceneState, userId: 'sharon' }),
+      BASE_MAP_LEVEL_ID,
+    );
+  });
+
+  test('returns the stored level id from userLevelState (lowercased userId match)', () => {
+    const sceneState = {
+      userLevelState: { gm: { levelId: 'map-level-a', source: 'manual', updatedAt: 1 } },
+    };
+    assert.equal(
+      resolveActiveLevelIdForUser({ sceneState, userId: 'GM' }),
+      'map-level-a',
+    );
+  });
+
+  test('rejects an unknown level id when validLevelIds is provided', () => {
+    const sceneState = {
+      userLevelState: { gm: { levelId: 'gone', source: 'manual', updatedAt: 1 } },
+    };
+    assert.equal(
+      resolveActiveLevelIdForUser({
+        sceneState,
+        userId: 'gm',
+        validLevelIds: ['level-0', 'map-level-a'],
+      }),
+      BASE_MAP_LEVEL_ID,
+    );
+  });
+
+  test('falls back to the most recent claimed token level', () => {
+    const sceneState = {
+      claimedTokens: { 't1': 'indigo', 't2': 'indigo' },
+      userLevelState: {},
+    };
+    const placements = [
+      { id: 't1', levelId: 'map-level-a', _lastModified: 100 },
+      { id: 't2', levelId: 'map-level-b', _lastModified: 500 },
+    ];
+    assert.equal(
+      resolveActiveLevelIdForUser({
+        sceneState,
+        userId: 'indigo',
+        placements,
+        validLevelIds: ['level-0', 'map-level-a', 'map-level-b'],
+      }),
+      'map-level-b',
+    );
+  });
+
+  test('userLevelState takes priority over claimed token level', () => {
+    const sceneState = {
+      claimedTokens: { 't1': 'indigo' },
+      userLevelState: {
+        indigo: { levelId: 'map-level-x', source: 'manual', updatedAt: 200 },
+      },
+    };
+    const placements = [
+      { id: 't1', levelId: 'map-level-a', _lastModified: 999 },
+    ];
+    assert.equal(
+      resolveActiveLevelIdForUser({
+        sceneState,
+        userId: 'indigo',
+        placements,
+        validLevelIds: ['level-0', 'map-level-a', 'map-level-x'],
+      }),
+      'map-level-x',
+    );
+  });
+
+  test('claim fallback skips other users tokens', () => {
+    const sceneState = {
+      claimedTokens: { 't1': 'sharon' },
+      userLevelState: {},
+    };
+    const placements = [
+      { id: 't1', levelId: 'map-level-a', _lastModified: 1 },
+    ];
+    assert.equal(
+      resolveActiveLevelIdForUser({
+        sceneState,
+        userId: 'indigo',
+        placements,
+      }),
+      BASE_MAP_LEVEL_ID,
+    );
+  });
+});
+

--- a/dnd/vtt/assets/js/state/normalize/map-levels.js
+++ b/dnd/vtt/assets/js/state/normalize/map-levels.js
@@ -311,6 +311,84 @@ export function normalizeUserLevelStateMap(raw) {
 }
 
 /**
+ * Levels v2 helper: resolve a user's active level id for a scene,
+ * following the priority chain in §4.2 of LEVELS_V2_PLAN.md:
+ *   1. Valid `userLevelState[userId].levelId`
+ *   2. Most recently modified claimed token's level (when claims drive
+ *      view-follow). Requires `placements` to look up token levels.
+ *   3. `BASE_MAP_LEVEL_ID`.
+ *
+ * The signature accepts a per-scene `sceneState` entry plus the user id.
+ * `placements` is the per-scene placement list (boardState.placements[sceneId]).
+ * `validLevelIds`, when provided, restricts resolution to known level ids
+ * (including `BASE_MAP_LEVEL_ID`). Unknown/invalid stored ids fall through
+ * to claim/base resolution. When `validLevelIds` is null/empty the
+ * stored id is returned as-is unless it is missing, in which case we
+ * still fall through.
+ *
+ * The resolver is intentionally separate from
+ * `resolvePlacementLevelId(placement)`: a placement's stored level must
+ * not be replaced by the user's active level (see §4.1).
+ */
+export function resolveActiveLevelIdForUser({
+  sceneState = null,
+  userId = null,
+  placements = null,
+  validLevelIds = null,
+} = {}) {
+  const userKey = typeof userId === 'string' ? userId.trim().toLowerCase() : '';
+  const validSet = Array.isArray(validLevelIds)
+    ? new Set(validLevelIds.filter((id) => typeof id === 'string' && id))
+    : null;
+  const isValidLevelId = (levelId) => {
+    if (typeof levelId !== 'string' || !levelId) {
+      return false;
+    }
+    if (!validSet || validSet.size === 0) {
+      return true;
+    }
+    return validSet.has(levelId);
+  };
+
+  if (userKey && sceneState && typeof sceneState === 'object') {
+    const userLevelState = sceneState.userLevelState;
+    if (userLevelState && typeof userLevelState === 'object') {
+      const entry = userLevelState[userKey];
+      if (entry && typeof entry === 'object') {
+        const levelId = typeof entry.levelId === 'string' ? entry.levelId.trim() : '';
+        if (levelId && isValidLevelId(levelId)) {
+          return levelId;
+        }
+      }
+    }
+
+    const claims = sceneState.claimedTokens;
+    if (claims && typeof claims === 'object' && Array.isArray(placements)) {
+      let bestLevelId = null;
+      let bestModified = -Infinity;
+      for (const placement of placements) {
+        if (!placement || typeof placement !== 'object') continue;
+        const placementId = typeof placement.id === 'string' ? placement.id : '';
+        if (!placementId) continue;
+        if (claims[placementId] !== userKey) continue;
+        const modified = Number(placement._lastModified);
+        const score = Number.isFinite(modified) ? modified : 0;
+        if (score < bestModified) continue;
+        const placementLevelId = resolvePlacementLevelId(placement);
+        if (!isValidLevelId(placementLevelId)) continue;
+        bestLevelId = placementLevelId;
+        bestModified = score;
+      }
+      if (bestLevelId) {
+        return bestLevelId;
+      }
+    }
+  }
+
+  return BASE_MAP_LEVEL_ID;
+}
+
+/**
  * Levels v2: normalize the per-scene `claimedTokens` map. Keys are
  * placement ids, values are normalized profile ids. Invalid entries are
  * dropped silently.

--- a/dnd/vtt/assets/js/ui/__tests__/map-level-renderer.test.mjs
+++ b/dnd/vtt/assets/js/ui/__tests__/map-level-renderer.test.mjs
@@ -307,6 +307,38 @@ describe('map level renderer', () => {
     assert.equal(renderer.element.querySelector('[data-map-level-id="upper"]'), null);
   });
 
+  test('honors an explicit activeLevelId override on sync (Levels v2)', () => {
+    // Levels v2: per-user viewer level is plumbed through `sync` so the
+    // rendered `dataset.activeMapLevelId` reflects the current user's
+    // `userLevelState` entry instead of the legacy
+    // `mapLevels.activeLevelId` from scene state. `level-0` is a valid
+    // override even though it isn't part of `mapLevels.levels`.
+    const { renderer } = createRendererHarness();
+
+    renderer.sync(
+      {
+        activeLevelId: 'upper',
+        levels: [
+          { id: 'upper', mapUrl: '/maps/upper.png', zIndex: 1 },
+        ],
+      },
+      { activeLevelId: 'level-0' }
+    );
+
+    assert.equal(renderer.element.dataset.activeMapLevelId, 'level-0');
+  });
+
+  test('falls back to mapLevels.activeLevelId when no override is supplied', () => {
+    const { renderer } = createRendererHarness();
+
+    renderer.sync({
+      activeLevelId: 'upper',
+      levels: [{ id: 'upper', mapUrl: '/maps/upper.png', zIndex: 1 }],
+    });
+
+    assert.equal(renderer.element.dataset.activeMapLevelId, 'upper');
+  });
+
   test('reset clears rendered levels and hides the stack', () => {
     const { renderer } = createRendererHarness();
 

--- a/dnd/vtt/assets/js/ui/__tests__/token-levels.test.mjs
+++ b/dnd/vtt/assets/js/ui/__tests__/token-levels.test.mjs
@@ -90,6 +90,44 @@ describe('token level helpers', () => {
     assert.deepEqual(controls.levels.map((level) => level.id), ['ground', 'upper', 'roof']);
   });
 
+  test('navigation control state honors an explicit currentLevelId override', () => {
+    // Levels v2: GM browsing supplies its per-user level via the
+    // `currentLevelId` option so the nav reflects `userLevelState[gmId]`
+    // instead of the legacy scene-global active id.
+    const mapLevels = {
+      activeLevelId: 'upper',
+      levels: [
+        { id: 'ground', name: 'Ground', zIndex: 0 },
+        { id: 'upper', name: 'Upper', zIndex: 1 },
+        { id: 'roof', name: 'Roof', zIndex: 2 },
+      ],
+    };
+
+    const controls = getMapLevelNavigationControlState(mapLevels, {
+      currentLevelId: 'ground',
+    });
+    assert.equal(controls.currentLevel?.id, 'ground');
+    assert.equal(controls.canMoveDown, false);
+    assert.equal(controls.canMoveUp, true);
+  });
+
+  test('navigation control state ignores an unknown currentLevelId override', () => {
+    const mapLevels = {
+      activeLevelId: 'upper',
+      levels: [
+        { id: 'ground', name: 'Ground', zIndex: 0 },
+        { id: 'upper', name: 'Upper', zIndex: 1 },
+      ],
+    };
+
+    const controls = getMapLevelNavigationControlState(mapLevels, {
+      currentLevelId: 'level-0',
+    });
+    // Falls back to the scene's legacy active id when the override is
+    // not one of the stored Level 1+ entries.
+    assert.equal(controls.currentLevel?.id, 'upper');
+  });
+
   test('resolves scene-scoped map level state from board state', () => {
     const mapLevels = resolveSceneTokenLevelState({
       boardState: {

--- a/dnd/vtt/assets/js/ui/board-interactions.js
+++ b/dnd/vtt/assets/js/ui/board-interactions.js
@@ -26,7 +26,12 @@ import {
   normalizeGridOffset,
   normalizeGridState,
 } from '../state/normalize/grid.js';
-import { normalizeMapLevelsState } from '../state/normalize/map-levels.js';
+import {
+  BASE_MAP_LEVEL_ID,
+  buildLevelViewModel,
+  normalizeMapLevelsState,
+  resolveActiveLevelIdForUser,
+} from '../state/normalize/map-levels.js';
 import { initializePusher, getSocketId, isPusherConnected } from '../services/pusher-service.js';
 import { createBoardStatePoller } from '../services/board-state-poller.js';
 import { applyBoardStateOpsLocally } from '../services/board-state-op-applier.js';
@@ -490,6 +495,8 @@ export function mountBoardInteractions(store, routes = {}) {
   const mapLevelNavName = document.querySelector('[data-map-level-nav-name]');
   const mapLevelNavDown = document.querySelector('[data-action="view-map-level-down"]');
   const mapLevelNavUp = document.querySelector('[data-action="view-map-level-up"]');
+  const mapLevelIndicator = document.querySelector('[data-map-level-indicator]');
+  const mapLevelIndicatorValue = document.querySelector('[data-map-level-indicator-value]');
   const appMain = document.getElementById('vtt-main');
   const combatTrackerRoot = document.querySelector('[data-combat-tracker]');
   const combatTrackerWaiting = combatTrackerRoot?.querySelector('[data-combat-tracker-waiting]');
@@ -1604,7 +1611,17 @@ export function mountBoardInteractions(store, routes = {}) {
         : {};
       const sceneGrid = sceneEntry.grid ?? null;
       const mapLevels = normalizeMapLevelsState(sceneEntry.mapLevels ?? null, { sceneGrid });
-      const activeLevelId = getActiveMapLevelId(sceneEntry.mapLevels ?? null, sceneGrid);
+      // Levels v2: cutout edit affordances follow the GM's per-user
+      // viewer level. Fall back to the legacy `activeLevelId` for older
+      // scenes that have not yet been touched in v2.
+      const viewerLevelId = getViewerLevelIdForCurrentUser(
+        boardApi.getState?.() ?? {},
+        sceneId,
+      );
+      const legacyActiveLevelId = getActiveMapLevelId(sceneEntry.mapLevels ?? null, sceneGrid);
+      const activeLevelId = viewerLevelId && viewerLevelId !== BASE_MAP_LEVEL_ID
+        ? viewerLevelId
+        : legacyActiveLevelId;
       const level = mapLevels.levels.find((entry) => entry.id === levelId) ?? null;
       const hasMap = typeof level?.mapUrl === 'string' && level.mapUrl.trim().length > 0;
       const isVisible = level ? level.visible !== false : false;
@@ -4914,20 +4931,94 @@ export function mountBoardInteractions(store, routes = {}) {
     return boardState.overlay ?? null;
   }
 
-  function syncMapLevelsForState(state = {}, sceneId = null) {
-    const mapLevels = resolveSceneMapLevelsState(state.boardState ?? {}, sceneId);
-    mapLevelRenderer.sync(mapLevels, { sceneGrid: state.grid ?? null, view: viewState });
-    mapLevelCutoutTool.notifyMapLevelsChange(mapLevels);
-    syncMapLevelNavigationControls(mapLevels);
+  // Levels v2: resolve the per-user viewer level for a scene. The GM
+  // navigation, the renderer's "active" metadata, and the player-visible
+  // level indicator all read from this so each user sees their own
+  // level (driven by `userLevelState[userId]`) rather than the legacy
+  // scene-global `mapLevels.activeLevelId`.
+  function getViewerLevelIdForCurrentUser(state = {}, sceneId = null) {
+    const userId = getCurrentUserId();
+    if (!sceneId) {
+      return BASE_MAP_LEVEL_ID;
+    }
+    const boardState = state?.boardState && typeof state.boardState === 'object'
+      ? state.boardState
+      : {};
+    const sceneStateEntries = boardState.sceneState && typeof boardState.sceneState === 'object'
+      ? boardState.sceneState
+      : {};
+    const sceneEntry = sceneStateEntries[sceneId] && typeof sceneStateEntries[sceneId] === 'object'
+      ? sceneStateEntries[sceneId]
+      : null;
+    const placements = Array.isArray(boardState.placements?.[sceneId])
+      ? boardState.placements[sceneId]
+      : [];
+    const normalizedMapLevels = normalizeMapLevelsState(sceneEntry?.mapLevels ?? null, {
+      sceneGrid: sceneEntry?.grid ?? null,
+    });
+    const validLevelIds = [BASE_MAP_LEVEL_ID];
+    normalizedMapLevels.levels.forEach((level) => {
+      if (level && typeof level.id === 'string' && level.id) {
+        validLevelIds.push(level.id);
+      }
+    });
+    return resolveActiveLevelIdForUser({
+      sceneState: sceneEntry,
+      userId,
+      placements,
+      validLevelIds,
+    });
   }
 
-  function syncMapLevelNavigationControls(mapLevelsState = null) {
+  function getViewerLevelDisplayName(state = {}, sceneId = null, viewerLevelId = null) {
+    if (!sceneId || typeof viewerLevelId !== 'string' || !viewerLevelId) {
+      return null;
+    }
+    if (viewerLevelId === BASE_MAP_LEVEL_ID) {
+      return 'Level 0';
+    }
+    const boardState = state?.boardState && typeof state.boardState === 'object'
+      ? state.boardState
+      : {};
+    const sceneStateEntries = boardState.sceneState && typeof boardState.sceneState === 'object'
+      ? boardState.sceneState
+      : {};
+    const sceneEntry = sceneStateEntries[sceneId] && typeof sceneStateEntries[sceneId] === 'object'
+      ? sceneStateEntries[sceneId]
+      : null;
+    const viewModel = buildLevelViewModel({
+      mapLevels: normalizeMapLevelsState(sceneEntry?.mapLevels ?? null, {
+        sceneGrid: sceneEntry?.grid ?? null,
+      }),
+      sceneGrid: sceneEntry?.grid ?? null,
+    });
+    const match = viewModel.find((entry) => entry.id === viewerLevelId);
+    if (match) {
+      return match.displayLabel || match.name || null;
+    }
+    return null;
+  }
+
+  function syncMapLevelsForState(state = {}, sceneId = null) {
+    const mapLevels = resolveSceneMapLevelsState(state.boardState ?? {}, sceneId);
+    const viewerLevelId = getViewerLevelIdForCurrentUser(state, sceneId);
+    mapLevelRenderer.sync(mapLevels, {
+      sceneGrid: state.grid ?? null,
+      view: viewState,
+      activeLevelId: viewerLevelId,
+    });
+    mapLevelCutoutTool.notifyMapLevelsChange(mapLevels);
+    syncMapLevelNavigationControls(mapLevels, { currentLevelId: viewerLevelId });
+    syncMapLevelIndicator(state, sceneId, viewerLevelId);
+  }
+
+  function syncMapLevelNavigationControls(mapLevelsState = null, options = {}) {
     if (!mapLevelNav) {
       return;
     }
 
     const gmUser = isGmUser();
-    const controls = getMapLevelNavigationControlState(mapLevelsState);
+    const controls = getMapLevelNavigationControlState(mapLevelsState, options);
     const visible = gmUser && controls.hasLevels;
     mapLevelNav.hidden = !visible;
     mapLevelNav.setAttribute('aria-hidden', visible ? 'false' : 'true');
@@ -4952,6 +5043,38 @@ export function mountBoardInteractions(store, routes = {}) {
     setStackButtonState(mapLevelNavUp, !controls.canMoveUp);
   }
 
+  function syncMapLevelIndicator(state = {}, sceneId = null, viewerLevelId = null) {
+    if (!mapLevelIndicator) {
+      return;
+    }
+
+    const resolvedLevelId = viewerLevelId ?? getViewerLevelIdForCurrentUser(state, sceneId);
+    if (!sceneId || !resolvedLevelId) {
+      mapLevelIndicator.hidden = true;
+      mapLevelIndicator.setAttribute('aria-hidden', 'true');
+      if (mapLevelIndicatorValue) {
+        mapLevelIndicatorValue.textContent = '\u2014';
+      }
+      return;
+    }
+
+    const displayName = getViewerLevelDisplayName(state, sceneId, resolvedLevelId);
+    if (!displayName) {
+      mapLevelIndicator.hidden = true;
+      mapLevelIndicator.setAttribute('aria-hidden', 'true');
+      if (mapLevelIndicatorValue) {
+        mapLevelIndicatorValue.textContent = '\u2014';
+      }
+      return;
+    }
+
+    mapLevelIndicator.hidden = false;
+    mapLevelIndicator.setAttribute('aria-hidden', 'false');
+    if (mapLevelIndicatorValue) {
+      mapLevelIndicatorValue.textContent = displayName;
+    }
+  }
+
   function handleMapLevelNavigationClick(direction = 'up') {
     if (!isGmUser()) {
       return;
@@ -4964,13 +5087,23 @@ export function mountBoardInteractions(store, routes = {}) {
 
     const state = boardApi.getState?.() ?? {};
     const mapLevels = resolveSceneTokenLevelState(state, activeSceneId);
-    const controls = getMapLevelNavigationControlState(mapLevels);
+    // Levels v2: GM browsing operates on the GM's own per-user level
+    // (`userLevelState[gmId]`), not the legacy scene-global active id.
+    const currentLevelId = getViewerLevelIdForCurrentUser(state, activeSceneId);
+    const controls = getMapLevelNavigationControlState(mapLevels, { currentLevelId });
     const targetLevel = getAdjacentTokenLevel(mapLevels, controls.currentLevelId, direction);
     if (!targetLevel?.id) {
-      syncMapLevelNavigationControls(mapLevels);
+      syncMapLevelNavigationControls(mapLevels, { currentLevelId });
       return;
     }
 
+    const gmUserId = getCurrentUserId();
+    if (!gmUserId) {
+      syncMapLevelNavigationControls(mapLevels, { currentLevelId });
+      return;
+    }
+
+    const updatedAt = Date.now();
     let updated = false;
     boardApi.updateState?.((draft) => {
       const sceneEntry = ensureSceneStateDraftEntry(draft, activeSceneId);
@@ -4978,28 +5111,38 @@ export function mountBoardInteractions(store, routes = {}) {
         return;
       }
 
-      const normalizedMapLevels = normalizeMapLevelsState(sceneEntry.mapLevels ?? null, {
-        sceneGrid: sceneEntry.grid ?? null,
-      });
-      if (
-        normalizedMapLevels.activeLevelId === targetLevel.id ||
-        !normalizedMapLevels.levels.some((level) => level?.id === targetLevel.id)
-      ) {
+      if (!sceneEntry.userLevelState || typeof sceneEntry.userLevelState !== 'object') {
+        sceneEntry.userLevelState = {};
+      }
+      const existing = sceneEntry.userLevelState[gmUserId];
+      if (existing && existing.levelId === targetLevel.id && existing.source === 'manual') {
         return;
       }
-
-      normalizedMapLevels.activeLevelId = targetLevel.id;
-      sceneEntry.mapLevels = normalizedMapLevels;
+      sceneEntry.userLevelState[gmUserId] = {
+        levelId: targetLevel.id,
+        source: 'manual',
+        updatedAt,
+      };
       updated = true;
     });
 
     if (!updated) {
-      syncMapLevelNavigationControls(mapLevels);
+      syncMapLevelNavigationControls(mapLevels, { currentLevelId });
       return;
     }
 
     markSceneStateDirty(activeSceneId);
-    persistBoardStateSnapshot();
+    // Levels v2: broadcast the GM's per-user level change as a
+    // `user-level.set` op so other clients pick it up via the existing
+    // op applier path. The op applier mirrors the local mutation above.
+    const userLevelOp = {
+      type: 'user-level.set',
+      sceneId: activeSceneId,
+      userId: gmUserId,
+      levelId: targetLevel.id,
+      source: 'manual',
+    };
+    persistBoardStateSnapshot({}, [userLevelOp]);
 
     const latestState = boardApi.getState?.() ?? {};
     syncMapLevelsForState(latestState, activeSceneId);
@@ -15393,7 +15536,22 @@ function createMapLevelCutoutTool() {
       : {};
     const sceneGrid = sceneEntry.grid ?? state.grid ?? null;
     const mapLevels = normalizeMapLevelsState(sceneEntry.mapLevels ?? null, { sceneGrid });
-    const activeId = typeof mapLevels.activeLevelId === 'string' ? mapLevels.activeLevelId : '';
+    // Levels v2: cutout editing follows the GM's per-user viewer level
+    // (`userLevelState[gmId]`) rather than the legacy scene-global
+    // `mapLevels.activeLevelId`. When the GM has not yet browsed in v2,
+    // `getViewerLevelIdForCurrentUser` returns BASE_MAP_LEVEL_ID — which
+    // is not a stored level — so we fall back to the legacy active id
+    // so existing scenes still surface the right cutout-edit context.
+    // Per §5.1 the cutout editor is intentionally disabled on Level 0,
+    // so once Step 3 lets the GM explicitly browse to Level 0 we can
+    // drop this fallback.
+    const viewerLevelId = getViewerLevelIdForCurrentUser(state, sceneId);
+    const isBaseViewer = viewerLevelId === BASE_MAP_LEVEL_ID;
+    const activeId = !isBaseViewer && typeof viewerLevelId === 'string' && viewerLevelId
+      ? viewerLevelId
+      : typeof mapLevels.activeLevelId === 'string'
+        ? mapLevels.activeLevelId
+        : '';
     const requestedId = typeof levelId === 'string' && levelId.trim()
       ? levelId.trim()
       : activeId;

--- a/dnd/vtt/assets/js/ui/map-level-renderer.js
+++ b/dnd/vtt/assets/js/ui/map-level-renderer.js
@@ -19,11 +19,17 @@ export function createMapLevelRenderer({
   const levelElements = new Map();
   let lastSignature = null;
 
-  function sync(rawMapLevels = null, { sceneGrid = null, view = null } = {}) {
+  function sync(rawMapLevels = null, { sceneGrid = null, view = null, activeLevelId = undefined } = {}) {
     const mapLevels = normalizeMapLevelsState(rawMapLevels, { sceneGrid });
     const renderableLevels = getRenderableMapLevels(mapLevels);
+    // Levels v2: callers may supply an explicit `activeLevelId` resolved
+    // from per-user `userLevelState` so the rendered "active" metadata
+    // reflects the viewer's level. `undefined` falls back to the legacy
+    // `mapLevels.activeLevelId` value; an explicit empty string clears.
+    const resolvedActiveLevelId =
+      activeLevelId === undefined ? mapLevels.activeLevelId ?? '' : activeLevelId ?? '';
     const signature = safeStableStringify({
-      activeLevelId: mapLevels.activeLevelId,
+      activeLevelId: resolvedActiveLevelId,
       cutoutView: buildMapLevelCutoutViewSignature(view),
       levels: renderableLevels,
     });
@@ -33,7 +39,7 @@ export function createMapLevelRenderer({
     }
     lastSignature = signature;
 
-    root.dataset.activeMapLevelId = mapLevels.activeLevelId ?? '';
+    root.dataset.activeMapLevelId = resolvedActiveLevelId || '';
     root.dataset.mapLevelCount = String(renderableLevels.length);
 
     if (renderableLevels.length === 0) {

--- a/dnd/vtt/assets/js/ui/token-levels.js
+++ b/dnd/vtt/assets/js/ui/token-levels.js
@@ -245,9 +245,19 @@ export function getTokenLevelControlState(mapLevelsState = null, placement = {})
   };
 }
 
-export function getMapLevelNavigationControlState(mapLevelsState = null) {
+export function getMapLevelNavigationControlState(mapLevelsState = null, options = {}) {
   const levels = getOrderedTokenMapLevels(mapLevelsState?.levels ?? []);
-  const currentLevelId = resolveTokenLevelId({}, mapLevelsState);
+  // Levels v2: callers (e.g. the GM nav) may pass an explicit
+  // `currentLevelId` resolved from the per-user `userLevelState` so the
+  // nav reflects the GM's per-user level instead of the legacy
+  // `mapLevels.activeLevelId`. When omitted we keep the prior behavior.
+  const overrideId = normalizeTokenLevelId(options?.currentLevelId);
+  let currentLevelId;
+  if (overrideId && levels.some((level) => level.id === overrideId)) {
+    currentLevelId = overrideId;
+  } else {
+    currentLevelId = resolveTokenLevelId({}, mapLevelsState);
+  }
   const currentLevel = levels.find((level) => level.id === currentLevelId) ?? null;
 
   return {

--- a/dnd/vtt/components/SceneBoard.php
+++ b/dnd/vtt/components/SceneBoard.php
@@ -9,6 +9,16 @@ function renderVttSceneBoard(bool $isGm = false): string
         <header class="vtt-board__header">
             <div class="vtt-board__scene-meta">
                 <h1 id="active-scene-name" class="vtt-board__title">No Active Scene</h1>
+                <p
+                    class="vtt-board__level-indicator"
+                    data-map-level-indicator
+                    hidden
+                    aria-hidden="true"
+                    aria-live="polite"
+                >
+                    <span class="vtt-board__level-indicator-label">Level:</span>
+                    <span class="vtt-board__level-indicator-value" data-map-level-indicator-value>&mdash;</span>
+                </p>
                 <?php if ($isGm): ?>
                 <div
                     class="vtt-board__level-nav"


### PR DESCRIPTION
Implements Step 2 of the VTT Levels v2 plan: each user now has their own current level, GM browsing writes only the GM's per-user state instead of the legacy scene-global active id, and every user sees a top-right "Level: N" indicator that reflects their resolved level.

- New `resolveActiveLevelIdForUser` helper applies §4.2's priority chain (validated `userLevelState[userId]` → most-recent claimed token → Level 0), with optional `validLevelIds` filtering for stale ids.
- GM up/down nav now mutates `userLevelState[gmId]` and broadcasts a single `user-level.set` op; `mapLevels.activeLevelId` is no longer written from the nav path. Existing scenes keep the legacy value frozen as a read-only fallback for player visibility until Step 5.
- Map level renderer and `getMapLevelNavigationControlState` accept explicit overrides so callers can drive them from per-user state.
- Cutout edit affordances follow the GM's per-user level when it is a stored Level 1+ id and fall back to the legacy id while the GM is on Level 0 (Step 3 will register Level 0 in the nav and §5.1 disables cutouts there).
- 11 new unit tests cover the resolver, nav override, and renderer override (419 total, up from 408 at the end of Step 1).