### PR TITLE
Add Levels v2 step 4: GM Activate button

### DIFF
--- a/dnd/vtt/assets/css/board.css
+++ b/dnd/vtt/assets/css/board.css
@@ -144,6 +144,48 @@
   white-space: nowrap;
 }
 
+.vtt-board__level-activate {
+  appearance: none;
+  flex: 0 0 auto;
+  margin-left: 0.25rem;
+  padding: 0.15rem 0.55rem;
+  height: 1.35rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid rgba(148, 163, 184, 0.38);
+  border-radius: calc(var(--vtt-radius) / 2);
+  background: rgba(148, 163, 184, 0.14);
+  color: var(--vtt-text-muted);
+  cursor: pointer;
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  line-height: 1;
+  text-transform: uppercase;
+  transition:
+    background var(--vtt-transition),
+    border-color var(--vtt-transition),
+    color var(--vtt-transition),
+    opacity var(--vtt-transition);
+}
+
+.vtt-board__level-activate:hover:not(:disabled) {
+  border-color: rgba(191, 219, 254, 0.62);
+  background: rgba(148, 163, 184, 0.24);
+  color: #fff;
+}
+
+.vtt-board__level-activate:disabled {
+  cursor: not-allowed;
+  opacity: 0.38;
+}
+
+.vtt-board__level-activate:focus-visible {
+  outline: 2px solid var(--vtt-accent);
+  outline-offset: 2px;
+}
+
 .vtt-board__level-indicator {
   display: inline-flex;
   align-items: center;

--- a/dnd/vtt/assets/js/services/__tests__/board-state-op-applier-levels-v2.test.mjs
+++ b/dnd/vtt/assets/js/services/__tests__/board-state-op-applier-levels-v2.test.mjs
@@ -2,6 +2,7 @@ import { describe, test } from 'node:test';
 import assert from 'node:assert/strict';
 
 import { applyBoardStateOpLocally } from '../board-state-op-applier.js';
+import { KNOWN_LEVEL_USER_IDS } from '../../state/normalize/map-levels.js';
 
 // Levels v2 (Step 1): client-side op applier handlers for the new
 // claim and user-level op types. Mirrors the server's `applyBoardStateOp`
@@ -187,5 +188,33 @@ describe('Board State Op Applier — user-level.activate', () => {
     });
     assert.equal(mutated, true);
     assert.equal(state.sceneState['scene-7'].userLevelState.indigo.levelId, 'level-0');
+  });
+
+  test('Step 4: activate with KNOWN_LEVEL_USER_IDS pulls every roster member to one level', () => {
+    // The Activate button (§5.3) builds its op by passing
+    // `userIds: [...KNOWN_LEVEL_USER_IDS]`. Every known user — including
+    // the GM — must end up on the activated level with source=activate.
+    const state = seedBoardState();
+    state.sceneState['scene-1'].userLevelState = {
+      // Pre-existing claim-driven state should be overwritten by Activate.
+      indigo: { levelId: 'map-level-a', source: 'claim', tokenId: 'hero', updatedAt: 1 },
+    };
+    const mutated = applyBoardStateOpLocally(state, {
+      type: 'user-level.activate',
+      sceneId: 'scene-1',
+      levelId: 'level-0',
+      userIds: [...KNOWN_LEVEL_USER_IDS],
+    });
+    assert.equal(mutated, true);
+    const entries = state.sceneState['scene-1'].userLevelState;
+    for (const userId of KNOWN_LEVEL_USER_IDS) {
+      assert.equal(entries[userId].levelId, 'level-0', `${userId} should be pulled to level-0`);
+      assert.equal(entries[userId].source, 'activate', `${userId} should have source=activate`);
+    }
+    // The previous claim entry's tokenId should be dropped: activate
+    // writes a fresh entry that intentionally omits tokenId so the
+    // follow-token rule re-engages on the next claimed-token level
+    // change.
+    assert.equal(entries.indigo.tokenId, undefined);
   });
 });

--- a/dnd/vtt/assets/js/state/__tests__/map-levels-v2-normalization.test.mjs
+++ b/dnd/vtt/assets/js/state/__tests__/map-levels-v2-normalization.test.mjs
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 
 import {
   BASE_MAP_LEVEL_ID,
+  KNOWN_LEVEL_USER_IDS,
   buildLevelViewModel,
   levelIdExistsInViewModel,
   normalizeClaimedTokensMap,
@@ -32,6 +33,19 @@ describe('Levels v2 — base level constant and placement resolution', () => {
 
   test('resolvePlacementLevelId trims and returns a stored level id', () => {
     assert.equal(resolvePlacementLevelId({ levelId: '  map-level-a  ' }), 'map-level-a');
+  });
+});
+
+describe('Levels v2 — KNOWN_LEVEL_USER_IDS roster', () => {
+  test('lists the configured chat/player roster as lowercase profile ids', () => {
+    // Step 4 (§5.3): Activate must pull every known user, not only
+    // currently connected websocket clients. The roster mirrors the
+    // password→user map in dnd/index.php normalized to lowercase.
+    assert.deepEqual(KNOWN_LEVEL_USER_IDS, ['gm', 'frunk', 'sharon', 'indigo', 'zepha']);
+  });
+
+  test('is frozen so callers cannot mutate the shared roster', () => {
+    assert.equal(Object.isFrozen(KNOWN_LEVEL_USER_IDS), true);
   });
 });
 

--- a/dnd/vtt/assets/js/state/normalize/map-levels.js
+++ b/dnd/vtt/assets/js/state/normalize/map-levels.js
@@ -10,6 +10,18 @@ export const MAP_LEVEL_ID_PREFIX = 'map-level-';
 // Placements without an explicit `levelId` resolve to this id.
 export const BASE_MAP_LEVEL_ID = 'level-0';
 
+// Levels v2 (§5.3): the GM's Activate button pulls every known user to the
+// GM's current viewing level. The roster is the configured chat/player set
+// (see dnd/index.php password map) normalized to lowercase profile ids — not
+// only currently connected websocket clients — so reloads stay consistent.
+export const KNOWN_LEVEL_USER_IDS = Object.freeze([
+  'gm',
+  'frunk',
+  'sharon',
+  'indigo',
+  'zepha',
+]);
+
 const mapLevelSeed = Date.now();
 let mapLevelSequence = 0;
 

--- a/dnd/vtt/assets/js/ui/board-interactions.js
+++ b/dnd/vtt/assets/js/ui/board-interactions.js
@@ -28,6 +28,7 @@ import {
 } from '../state/normalize/grid.js';
 import {
   BASE_MAP_LEVEL_ID,
+  KNOWN_LEVEL_USER_IDS,
   buildLevelViewModel,
   normalizeMapLevelsState,
   resolveActiveLevelIdForUser,
@@ -496,6 +497,7 @@ export function mountBoardInteractions(store, routes = {}) {
   const mapLevelNavName = document.querySelector('[data-map-level-nav-name]');
   const mapLevelNavDown = document.querySelector('[data-action="view-map-level-down"]');
   const mapLevelNavUp = document.querySelector('[data-action="view-map-level-up"]');
+  const mapLevelActivateButton = document.querySelector('[data-action="activate-map-level"]');
   const mapLevelIndicator = document.querySelector('[data-map-level-indicator]');
   const mapLevelIndicatorValue = document.querySelector('[data-map-level-indicator-value]');
   const appMain = document.getElementById('vtt-main');
@@ -1801,6 +1803,11 @@ export function mountBoardInteractions(store, routes = {}) {
   mapLevelNavUp?.addEventListener('click', (event) => {
     event.preventDefault();
     handleMapLevelNavigationClick('up');
+  });
+
+  mapLevelActivateButton?.addEventListener('click', (event) => {
+    event.preventDefault();
+    handleMapLevelActivateClick();
   });
 
   if (sceneListContainer) {
@@ -5161,6 +5168,74 @@ export function mountBoardInteractions(store, routes = {}) {
     syncMapLevelsForState(latestState, activeSceneId);
     if (status) {
       status.textContent = `Viewing ${targetLevel.name || 'map level'}.`;
+    }
+  }
+
+  // Levels v2 (§5.3): GM-only Activate. Pulls every known user (the
+  // configured chat/player roster, not just connected sockets) to the
+  // GM's current viewing level. Tokens are not moved; the next
+  // claimed-token level change overrides activate for that player.
+  function handleMapLevelActivateClick() {
+    if (!isGmUser()) {
+      return;
+    }
+
+    const activeSceneId = getActiveSceneId();
+    if (!activeSceneId || typeof boardApi.updateState !== 'function') {
+      return;
+    }
+
+    const state = boardApi.getState?.() ?? {};
+    const targetLevelId = getViewerLevelIdForCurrentUser(state, activeSceneId);
+    if (!targetLevelId) {
+      return;
+    }
+
+    const userIds = KNOWN_LEVEL_USER_IDS.slice();
+    if (userIds.length === 0) {
+      return;
+    }
+
+    const updatedAt = Date.now();
+    let mutated = false;
+    boardApi.updateState?.((draft) => {
+      const sceneEntry = ensureSceneStateDraftEntry(draft, activeSceneId);
+      if (!sceneEntry) {
+        return;
+      }
+
+      if (!sceneEntry.userLevelState || typeof sceneEntry.userLevelState !== 'object') {
+        sceneEntry.userLevelState = {};
+      }
+      userIds.forEach((userId) => {
+        sceneEntry.userLevelState[userId] = {
+          levelId: targetLevelId,
+          source: 'activate',
+          updatedAt,
+        };
+      });
+      mutated = true;
+    });
+
+    if (!mutated) {
+      return;
+    }
+
+    markSceneStateDirty(activeSceneId);
+    const activateOp = {
+      type: 'user-level.activate',
+      sceneId: activeSceneId,
+      levelId: targetLevelId,
+      userIds,
+    };
+    persistBoardStateSnapshot({}, [activateOp]);
+
+    const latestState = boardApi.getState?.() ?? {};
+    syncMapLevelsForState(latestState, activeSceneId);
+    if (status) {
+      const levelName = getViewerLevelDisplayName(latestState, activeSceneId, targetLevelId)
+        || 'map level';
+      status.textContent = `Pulled all players to ${levelName}.`;
     }
   }
 

--- a/dnd/vtt/components/SceneBoard.php
+++ b/dnd/vtt/components/SceneBoard.php
@@ -47,6 +47,13 @@ function renderVttSceneBoard(bool $isGm = false): string
                     >
                         <span aria-hidden="true">&#9650;</span>
                     </button>
+                    <button
+                        class="vtt-board__level-activate"
+                        type="button"
+                        data-action="activate-map-level"
+                        aria-label="Pull all players to this level"
+                        title="Pull all players to this level"
+                    >Activate</button>
                 </div>
                 <?php endif; ?>
                 <div class="vtt-board__round-tracker" data-round-tracker hidden>


### PR DESCRIPTION
Adds a GM-only Activate control to the top-right level nav that pulls every known user (the configured chat/player roster: gm, frunk, sharon, indigo, zepha) to the GM's current viewing level. Activate writes userLevelState entries with source='activate' (no tokenId) so the follow-token rule re-engages cleanly on the next claimed-token level change.

The roster is exposed as KNOWN_LEVEL_USER_IDS from map-levels.js so the handler and its tests share one source of truth, and so the list is frozen against accidental mutation.

3 new JS tests (425 total, all passing).