### PR TITLE
Add Levels v2 step 5: visibility, scaling, and arrow indicators

### DIFF
--- a/dnd/vtt/assets/css/board.css
+++ b/dnd/vtt/assets/css/board.css
@@ -2730,9 +2730,56 @@
   background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.3), rgba(15, 23, 42, 0.85));
   pointer-events: auto;
   transform: translate3d(0, 0, 0);
+  transform-origin: 50% 50%;
   transition: transform 180ms ease, width 180ms ease, height 180ms ease;
   will-change: transform;
   z-index: 0;
+}
+
+/* Levels v2 §5.5.2/§5.5.3: cross-level arrow indicators. Below-level tokens
+   carry a green down-arrow + distance; above-level tokens carry a red
+   up-arrow + distance. Same-level tokens have no badge. The indicator sits
+   in the top-right of the token and inherits the token's transform (so it
+   shrinks with below-level tokens, which is the intended readability:
+   distant-below tokens are smaller, including their badge). */
+.vtt-token__level-indicator {
+  position: absolute;
+  top: calc(var(--tok-unit) * -6);
+  right: calc(var(--tok-unit) * -6);
+  display: inline-flex;
+  align-items: center;
+  gap: calc(var(--tok-unit) * 2);
+  padding: calc(var(--tok-unit) * 2) calc(var(--tok-unit) * 4);
+  border-radius: 999px;
+  font-size: calc(var(--tok-unit) * 11);
+  font-weight: 700;
+  line-height: 1;
+  letter-spacing: 0.02em;
+  color: #f8fafc;
+  background: rgba(15, 23, 42, 0.85);
+  box-shadow: 0 4px 10px rgba(15, 23, 42, 0.45);
+  pointer-events: none;
+  z-index: 4;
+}
+
+.vtt-token__level-indicator[data-direction='below'] {
+  color: #ecfccb;
+  background: rgba(22, 101, 52, 0.92);
+  box-shadow: 0 4px 10px rgba(22, 101, 52, 0.45);
+}
+
+.vtt-token__level-indicator[data-direction='above'] {
+  color: #fee2e2;
+  background: rgba(127, 29, 29, 0.92);
+  box-shadow: 0 4px 10px rgba(127, 29, 29, 0.45);
+}
+
+.vtt-token__level-indicator-arrow {
+  font-size: calc(var(--tok-unit) * 9);
+}
+
+.vtt-token__level-indicator-distance {
+  font-variant-numeric: tabular-nums;
 }
 
 .vtt-token[data-group-color]::before {

--- a/dnd/vtt/assets/js/ui/__tests__/token-levels.test.mjs
+++ b/dnd/vtt/assets/js/ui/__tests__/token-levels.test.mjs
@@ -3,10 +3,12 @@ import assert from 'node:assert/strict';
 
 import {
   getAdjacentTokenLevel,
+  getMapLevelDistanceScale,
   getMapLevelNavigationControlState,
   getOrderedTokenMapLevels,
   getPlayerTokenMapLevelVisibility,
   getTokenLevelControlState,
+  getTokenLevelPresentation,
   isPlacementInteractableOnPlayerMapLevel,
   isPlacementOnPlayerVisibleMapLevel,
   resolvePlayerActiveMapLevelId,
@@ -359,5 +361,333 @@ describe('token level helpers', () => {
     assert.equal(isPlacementOnPlayerVisibleMapLevel(placement, mapLevels), true);
     assert.equal(isPlacementInteractableOnPlayerMapLevel(placement, mapLevels, { point: { column: 7, row: 8 } }), false);
     assert.equal(isPlacementInteractableOnPlayerMapLevel({ ...placement, column: 8 }, mapLevels, { point: { column: 8, row: 8 } }), true);
+  });
+});
+
+describe('Levels v2 token presentation', () => {
+  // §5.5.2: below-level scaling clamps at 50%; above-level stays 100%.
+  test('getMapLevelDistanceScale returns the correct scale for direction/distance', () => {
+    assert.equal(getMapLevelDistanceScale('same', 0), 1);
+    assert.equal(getMapLevelDistanceScale('above', 1), 1);
+    assert.equal(getMapLevelDistanceScale('above', 5), 1);
+    assert.equal(Math.round(getMapLevelDistanceScale('below', 1) * 100) / 100, 0.9);
+    assert.equal(Math.round(getMapLevelDistanceScale('below', 2) * 100) / 100, 0.8);
+    assert.equal(Math.round(getMapLevelDistanceScale('below', 4) * 100) / 100, 0.6);
+    assert.equal(getMapLevelDistanceScale('below', 5), 0.5);
+    assert.equal(getMapLevelDistanceScale('below', 12), 0.5);
+  });
+
+  test('same-level placement returns full visibility, no indicator, scale 1', () => {
+    const mapLevels = {
+      levels: [
+        { id: 'upper', name: 'Upper', visible: true, mapUrl: '/u.png', zIndex: 1 },
+      ],
+    };
+    const presentation = getTokenLevelPresentation(
+      { id: 't', levelId: 'upper', column: 1, row: 1 },
+      mapLevels,
+      { viewerLevelId: 'upper', gmViewing: false },
+    );
+    assert.equal(presentation.visible, true);
+    assert.equal(presentation.fullyVisible, true);
+    assert.equal(presentation.sameLevel, true);
+    assert.equal(presentation.direction, 'same');
+    assert.equal(presentation.distance, 0);
+    assert.equal(presentation.scale, 1);
+    assert.equal(presentation.indicator, null);
+  });
+
+  test('GM bypass: above and below tokens are always visible regardless of cutouts', () => {
+    const mapLevels = {
+      levels: [
+        // Level 1+ that fully blocks vision (no cutouts).
+        { id: 'upper', name: 'Upper', visible: true, mapUrl: '/u.png', zIndex: 1 },
+      ],
+    };
+    const aboveAsGm = getTokenLevelPresentation(
+      { id: 'above', levelId: 'upper', column: 5, row: 5 },
+      mapLevels,
+      { viewerLevelId: 'level-0', gmViewing: true },
+    );
+    assert.equal(aboveAsGm.visible, true);
+    assert.equal(aboveAsGm.direction, 'above');
+    assert.equal(aboveAsGm.distance, 1);
+    assert.equal(aboveAsGm.scale, 1);
+    assert.deepEqual(aboveAsGm.indicator, { direction: 'above', distance: 1 });
+
+    const belowAsGm = getTokenLevelPresentation(
+      { id: 'below', levelId: 'level-0', column: 5, row: 5 },
+      mapLevels,
+      { viewerLevelId: 'upper', gmViewing: true },
+    );
+    assert.equal(belowAsGm.visible, true);
+    assert.equal(belowAsGm.direction, 'below');
+    assert.equal(belowAsGm.distance, 1);
+    assert.equal(Math.round(belowAsGm.scale * 100) / 100, 0.9);
+    assert.deepEqual(belowAsGm.indicator, { direction: 'below', distance: 1 });
+  });
+
+  test('player below-level: edge rule reveals tokens whose cells are within one square of a cutout', () => {
+    // Viewer on Upper looking down at Level 0. Upper has a 1x1 cutout at (5, 5).
+    // Expanded cutout cells (3x3 around the raw cutout) span (4..6, 4..6).
+    const mapLevels = {
+      levels: [
+        {
+          id: 'upper',
+          name: 'Upper',
+          visible: true,
+          mapUrl: '/u.png',
+          zIndex: 1,
+          cutouts: [{ column: 5, row: 5, width: 1, height: 1 }],
+        },
+      ],
+    };
+
+    const inside = getTokenLevelPresentation(
+      { id: 'inside', levelId: 'level-0', column: 5, row: 5 },
+      mapLevels,
+      { viewerLevelId: 'upper', gmViewing: false },
+    );
+    assert.equal(inside.visible, true);
+    assert.equal(inside.direction, 'below');
+
+    const adjacent = getTokenLevelPresentation(
+      { id: 'adjacent', levelId: 'level-0', column: 4, row: 5 },
+      mapLevels,
+      { viewerLevelId: 'upper', gmViewing: false },
+    );
+    assert.equal(adjacent.visible, true, 'edge cell must reveal token');
+
+    const corner = getTokenLevelPresentation(
+      { id: 'corner', levelId: 'level-0', column: 4, row: 4 },
+      mapLevels,
+      { viewerLevelId: 'upper', gmViewing: false },
+    );
+    assert.equal(corner.visible, true, 'diagonal/corner cell must reveal token');
+
+    const farAway = getTokenLevelPresentation(
+      { id: 'far', levelId: 'level-0', column: 1, row: 1 },
+      mapLevels,
+      { viewerLevelId: 'upper', gmViewing: false },
+    );
+    assert.equal(farAway.visible, false, 'cells outside expanded cutout stay hidden');
+  });
+
+  test('player above-level visibility uses the same edge rule mirrored upward', () => {
+    // Viewer on Level 0 looking up at Upper. The blocking level is Upper
+    // (the higher level), so its expanded cutout determines visibility.
+    const mapLevels = {
+      levels: [
+        {
+          id: 'upper',
+          name: 'Upper',
+          visible: true,
+          mapUrl: '/u.png',
+          zIndex: 1,
+          cutouts: [{ column: 5, row: 5, width: 1, height: 1 }],
+        },
+      ],
+    };
+
+    const above = getTokenLevelPresentation(
+      { id: 'above', levelId: 'upper', column: 4, row: 6 },
+      mapLevels,
+      { viewerLevelId: 'level-0', gmViewing: false },
+    );
+    assert.equal(above.visible, true);
+    assert.equal(above.direction, 'above');
+    assert.equal(above.distance, 1);
+    assert.equal(above.scale, 1);
+    assert.deepEqual(above.indicator, { direction: 'above', distance: 1 });
+
+    const blocked = getTokenLevelPresentation(
+      { id: 'above-blocked', levelId: 'upper', column: 0, row: 0 },
+      mapLevels,
+      { viewerLevelId: 'level-0', gmViewing: false },
+    );
+    assert.equal(blocked.visible, false);
+  });
+
+  test('multi-level edge intersection requires every blocking level to overlap', () => {
+    // Viewer Level 2, token Level 0. Two blocking levels (Upper and Roof)
+    // must both have an expanded cutout covering at least one of the
+    // token's occupied cells.
+    const mapLevels = {
+      levels: [
+        {
+          id: 'upper',
+          name: 'Upper',
+          visible: true,
+          mapUrl: '/u.png',
+          zIndex: 1,
+          cutouts: [{ column: 5, row: 5, width: 1, height: 1 }],
+        },
+        {
+          id: 'roof',
+          name: 'Roof',
+          visible: true,
+          mapUrl: '/r.png',
+          zIndex: 2,
+          cutouts: [{ column: 7, row: 5, width: 1, height: 1 }],
+        },
+      ],
+    };
+
+    const noOverlap = getTokenLevelPresentation(
+      { id: 'no-overlap', levelId: 'level-0', column: 5, row: 5 },
+      mapLevels,
+      { viewerLevelId: 'roof', gmViewing: false },
+    );
+    // Expanded Upper covers (4..6, 4..6); expanded Roof covers (6..8, 4..6).
+    // Cell (5,5) is in Upper's expanded set but not Roof's, so blocked.
+    assert.equal(noOverlap.visible, false);
+
+    const intersection = getTokenLevelPresentation(
+      { id: 'overlap', levelId: 'level-0', column: 6, row: 5 },
+      mapLevels,
+      { viewerLevelId: 'roof', gmViewing: false },
+    );
+    // Cell (6,5) is inside both expanded cutouts.
+    assert.equal(intersection.visible, true);
+    assert.equal(intersection.direction, 'below');
+    assert.equal(intersection.distance, 2);
+    assert.equal(Math.round(intersection.scale * 100) / 100, 0.8);
+  });
+
+  test('non-blocking levels (hidden, opacity 0, blocksLowerLevelVision=false) are skipped', () => {
+    const mapLevels = {
+      levels: [
+        {
+          id: 'transparent',
+          name: 'Transparent',
+          visible: true,
+          mapUrl: '/t.png',
+          zIndex: 1,
+          opacity: 0,
+          cutouts: [],
+        },
+      ],
+    };
+    const presentation = getTokenLevelPresentation(
+      { id: 'token', levelId: 'level-0', column: 12, row: 12 },
+      mapLevels,
+      { viewerLevelId: 'transparent', gmViewing: false },
+    );
+    // No blocking levels remaining → path is open per §5.5.4 step 7.
+    assert.equal(presentation.visible, true);
+    assert.equal(presentation.direction, 'below');
+  });
+
+  test('placement on Level 0 (legacy missing levelId) is recognized as the base level', () => {
+    const mapLevels = {
+      levels: [
+        { id: 'upper', name: 'Upper', visible: true, mapUrl: '/u.png', zIndex: 1 },
+      ],
+    };
+    const legacy = getTokenLevelPresentation(
+      { id: 'legacy', column: 1, row: 1 },
+      mapLevels,
+      { viewerLevelId: 'level-0', gmViewing: false },
+    );
+    assert.equal(legacy.levelId, 'level-0');
+    assert.equal(legacy.sameLevel, true);
+    assert.equal(legacy.visible, true);
+  });
+
+  test('viewer falls back to Level 0 when viewerLevelId is missing or unknown', () => {
+    const mapLevels = {
+      levels: [
+        { id: 'upper', name: 'Upper', visible: true, mapUrl: '/u.png', zIndex: 1 },
+      ],
+    };
+    const missing = getTokenLevelPresentation(
+      { id: 'token', levelId: 'upper', column: 0, row: 0 },
+      mapLevels,
+      { gmViewing: true },
+    );
+    assert.equal(missing.activeLevelId, 'level-0');
+    assert.equal(missing.direction, 'above');
+
+    const unknown = getTokenLevelPresentation(
+      { id: 'token', levelId: 'upper', column: 0, row: 0 },
+      mapLevels,
+      { viewerLevelId: 'does-not-exist', gmViewing: true },
+    );
+    assert.equal(unknown.activeLevelId, 'level-0');
+    assert.equal(unknown.direction, 'above');
+  });
+
+  test('multi-cell placement is binary: any visible cell shows the whole token', () => {
+    // §5.5.4 final paragraph: cross-level visibility is binary in v2.
+    const mapLevels = {
+      levels: [
+        {
+          id: 'upper',
+          name: 'Upper',
+          visible: true,
+          mapUrl: '/u.png',
+          zIndex: 1,
+          cutouts: [{ column: 3, row: 3, width: 1, height: 1 }],
+        },
+      ],
+    };
+    // 2x2 token at (2,2)-(3,3). Cell (3,3) is in expanded cutout (cells 2..4 around (3,3)).
+    const presentation = getTokenLevelPresentation(
+      { id: 'big', levelId: 'level-0', column: 2, row: 2, width: 2, height: 2 },
+      mapLevels,
+      { viewerLevelId: 'upper', gmViewing: false },
+    );
+    assert.equal(presentation.visible, true);
+    assert.equal(presentation.fullyVisible, true);
+    // visibleCells is null per the binary v2 rule (no partial mask).
+    assert.equal(presentation.visibleCells, null);
+  });
+
+  test('interaction mode uses interaction blockers separately from vision', () => {
+    const mapLevels = {
+      levels: [
+        {
+          id: 'upper',
+          name: 'Upper',
+          visible: true,
+          mapUrl: '/u.png',
+          zIndex: 1,
+          blocksLowerLevelVision: false,
+          blocksLowerLevelInteraction: true,
+          cutouts: [{ column: 5, row: 5, width: 1, height: 1 }],
+        },
+      ],
+    };
+    const placement = { id: 'ground', levelId: 'level-0', column: 0, row: 0 };
+    // Vision: Upper does not block vision → token visible.
+    const vision = getTokenLevelPresentation(placement, mapLevels, {
+      viewerLevelId: 'upper',
+      gmViewing: false,
+      mode: 'vision',
+    });
+    assert.equal(vision.visible, true);
+    // Interaction: Upper blocks interaction. Cell (0,0) is outside the
+    // expanded cutout, so the token cannot be clicked.
+    const interaction = getTokenLevelPresentation(placement, mapLevels, {
+      viewerLevelId: 'upper',
+      gmViewing: false,
+      mode: 'interaction',
+      cells: [{ column: 0, row: 0 }],
+    });
+    assert.equal(interaction.visible, false);
+  });
+
+  test('placement referencing a deleted level reports not visible', () => {
+    const mapLevels = {
+      levels: [
+        { id: 'upper', name: 'Upper', visible: true, mapUrl: '/u.png', zIndex: 1 },
+      ],
+    };
+    const orphan = getTokenLevelPresentation(
+      { id: 'orphan', levelId: 'gone', column: 0, row: 0 },
+      mapLevels,
+      { viewerLevelId: 'upper', gmViewing: true },
+    );
+    assert.equal(orphan.visible, false);
   });
 });

--- a/dnd/vtt/assets/js/ui/board-interactions.js
+++ b/dnd/vtt/assets/js/ui/board-interactions.js
@@ -65,6 +65,7 @@ import {
   getOrderedTokenMapLevels,
   getPlayerTokenMapLevelVisibility,
   getTokenLevelControlState,
+  getTokenLevelPresentation,
   isPlacementInteractableOnPlayerMapLevel,
   resolveSceneTokenLevelState,
   resolveTokenLevelId,
@@ -6170,6 +6171,7 @@ export function mountBoardInteractions(store, routes = {}) {
     // Pre-compute fog checker once (null when fog inactive or GM viewing)
     const isCellFogged = gmViewing ? null : createFogChecker(state);
     const tokenLevelState = getActiveSceneTokenLevelState(state);
+    const viewerLevelId = activeSceneKey ? getViewerLevelIdForCurrentUser(state, activeSceneKey) : null;
 
     placements.forEach((placement, placementIndex) => {
       const normalized = normalizePlacementForRender(placement);
@@ -6198,13 +6200,15 @@ export function mountBoardInteractions(store, routes = {}) {
       }
 
       const levelPlacement = { ...placement, column, row, width, height };
-      const levelId = resolveTokenLevelId(levelPlacement, tokenLevelState);
-      const tokenLevelVisibility = gmViewing
-        ? null
-        : getPlayerTokenMapLevelVisibility(levelPlacement, tokenLevelState);
-      if (!gmViewing && !tokenLevelVisibility?.visible) {
+      const presentation = getTokenLevelPresentation(levelPlacement, tokenLevelState, {
+        viewerLevelId,
+        gmViewing,
+        mode: 'vision',
+      });
+      if (!presentation.visible) {
         return;
       }
+      const levelId = presentation.levelId ?? resolveTokenLevelId(levelPlacement, tokenLevelState);
 
       // Hide tokens that are wholly under fog of war for non-GM users.
       // Check every cell the token occupies; if ALL are fogged, skip rendering.
@@ -6226,6 +6230,9 @@ export function mountBoardInteractions(store, routes = {}) {
       renderedIds.add(normalized.id);
 
       const tokenZIndex = getTokenRenderStackOrder(stackOrder, levelId, tokenLevelState);
+      const presentationScale = Number.isFinite(presentation.scale) && presentation.scale > 0
+        ? presentation.scale
+        : 1;
       renderedPlacements.push({
         id: normalized.id,
         column,
@@ -6234,7 +6241,13 @@ export function mountBoardInteractions(store, routes = {}) {
         height,
         levelId,
         sortOrder: tokenZIndex,
-        visibleCells: tokenLevelVisibility?.visibleCells ?? null,
+        visibleCells: null,
+        scale: presentationScale,
+        scaleOriginX: 0.5,
+        scaleOriginY: 0.5,
+        levelDirection: presentation.direction,
+        levelDistance: presentation.distance,
+        sameLevel: presentation.sameLevel,
       });
 
       let token = existingNodes.get(normalized.id);
@@ -6251,15 +6264,11 @@ export function mountBoardInteractions(store, routes = {}) {
       token.style.height = `${height * gridSize}px`;
       const left = leftOffset + column * gridSize;
       const top = topOffset + row * gridSize;
-      const baseTransform = `translate3d(${left}px, ${top}px, 0)`;
+      const baseTransform = buildTokenLevelTransform(left, top, presentationScale);
       token.style.transform = baseTransform;
-      applyTokenMapLevelVisibilityMask(token, tokenLevelVisibility, {
-        column,
-        row,
-        width,
-        height,
-        gridSize,
-      });
+      token.style.transformOrigin = '50% 50%';
+      clearTokenMapLevelVisibilityMask(token);
+      applyTokenLevelPresentation(token, presentation);
 
       token.classList.toggle('vtt-token--hidden', Boolean(normalized.hidden));
 
@@ -6412,6 +6421,8 @@ export function mountBoardInteractions(store, routes = {}) {
     const gmViewing = isGmUser();
     const isCellFogged = gmViewing ? null : createFogChecker(state);
     const tokenLevelState = getActiveSceneTokenLevelState(state);
+    const auraSceneKey = state?.boardState?.activeSceneId ?? null;
+    const auraViewerLevelId = auraSceneKey ? getViewerLevelIdForCurrentUser(state, auraSceneKey) : null;
 
     placements.forEach((placement) => {
       const normalized = normalizePlacementForRender(placement);
@@ -6426,7 +6437,7 @@ export function mountBoardInteractions(store, routes = {}) {
 
       if (
         !gmViewing &&
-        !getPlayerTokenMapLevelVisibility(
+        !getTokenLevelPresentation(
           {
             ...placement,
             column: normalized.column,
@@ -6434,7 +6445,12 @@ export function mountBoardInteractions(store, routes = {}) {
             width: normalized.width,
             height: normalized.height,
           },
-          tokenLevelState
+          tokenLevelState,
+          {
+            viewerLevelId: auraViewerLevelId,
+            gmViewing: false,
+            mode: 'vision',
+          },
         ).visible
       ) {
         return;
@@ -6534,6 +6550,71 @@ export function mountBoardInteractions(store, routes = {}) {
     }
 
     return levelIndex * TOKEN_LEVEL_STACK_STRIDE + normalizedStackOrder;
+  }
+
+  // Levels v2 §5.5: build the token transform string with the per-level
+  // scale baked in. Drag math reads scale from `dragElements` so the
+  // translate3d update preserves the cross-level shrink while the user
+  // drags. `transform-origin: 50% 50%` keeps the scaled token centered on
+  // its grid cell so hit testing matches.
+  function buildTokenLevelTransform(left, top, scale) {
+    const safeScale = Number.isFinite(scale) && scale > 0 ? scale : 1;
+    if (safeScale === 1) {
+      return `translate3d(${left}px, ${top}px, 0)`;
+    }
+    return `translate3d(${left}px, ${top}px, 0) scale(${safeScale})`;
+  }
+
+  // Levels v2 §5.5.2/§5.5.3: paint the level direction badge — green
+  // down-arrow + distance for tokens below the viewer, red up-arrow +
+  // distance for tokens above. Same-level tokens carry no badge. The badge
+  // sits inside the token element so it inherits the parent transform
+  // (including scale), but `vector-effect`-style sizing is handled in CSS
+  // via the `--vtt-token-level-distance` custom property.
+  function applyTokenLevelPresentation(token, presentation) {
+    if (!token) {
+      return;
+    }
+    const direction = presentation?.direction ?? 'same';
+    if (direction === 'same' || !presentation?.indicator) {
+      delete token.dataset.mapLevelDirection;
+      delete token.dataset.mapLevelDistance;
+      const existing = token.querySelector('.vtt-token__level-indicator');
+      if (existing) {
+        existing.remove();
+      }
+      return;
+    }
+
+    const distance = Math.max(
+      1,
+      Math.trunc(Number.isFinite(presentation.distance) ? presentation.distance : 1),
+    );
+    token.dataset.mapLevelDirection = direction;
+    token.dataset.mapLevelDistance = String(distance);
+
+    let indicator = token.querySelector('.vtt-token__level-indicator');
+    if (!indicator) {
+      indicator = document.createElement('div');
+      indicator.className = 'vtt-token__level-indicator';
+      const arrow = document.createElement('span');
+      arrow.className = 'vtt-token__level-indicator-arrow';
+      arrow.setAttribute('aria-hidden', 'true');
+      indicator.appendChild(arrow);
+      const distanceLabel = document.createElement('span');
+      distanceLabel.className = 'vtt-token__level-indicator-distance';
+      indicator.appendChild(distanceLabel);
+      token.appendChild(indicator);
+    }
+    indicator.dataset.direction = direction;
+    const distanceLabel = indicator.querySelector('.vtt-token__level-indicator-distance');
+    if (distanceLabel) {
+      distanceLabel.textContent = String(distance);
+    }
+    const arrow = indicator.querySelector('.vtt-token__level-indicator-arrow');
+    if (arrow) {
+      arrow.textContent = direction === 'above' ? '\u25B2' : '\u25BC';
+    }
   }
 
   function applyTokenMapLevelVisibilityMask(token, visibility, { column, row, width, height, gridSize } = {}) {
@@ -10607,7 +10688,13 @@ export function mountBoardInteractions(store, routes = {}) {
           height: normalized.height,
         }
       : placement;
-    return getPlayerTokenMapLevelVisibility(placementForLevel, tokenLevelState).visible;
+    const activeSceneKey = state?.boardState?.activeSceneId ?? null;
+    const viewerLevelId = activeSceneKey ? getViewerLevelIdForCurrentUser(state, activeSceneKey) : null;
+    return getTokenLevelPresentation(placementForLevel, tokenLevelState, {
+      viewerLevelId,
+      gmViewing: false,
+      mode: 'vision',
+    }).visible;
   }
 
   function findRenderedPlacementAtPoint(event) {
@@ -10666,8 +10753,10 @@ export function mountBoardInteractions(store, routes = {}) {
       row: Math.floor(pointY / gridSize),
     };
     const gmViewing = isGmUser();
-    const state = gmViewing ? null : boardApi.getState?.() ?? {};
-    const tokenLevelState = gmViewing ? null : getActiveSceneTokenLevelState(state);
+    const state = boardApi.getState?.() ?? {};
+    const tokenLevelState = getActiveSceneTokenLevelState(state);
+    const activeSceneKey = state?.boardState?.activeSceneId ?? null;
+    const viewerLevelId = activeSceneKey ? getViewerLevelIdForCurrentUser(state, activeSceneKey) : null;
 
     for (let index = renderedPlacements.length - 1; index >= 0; index -= 1) {
       const placement = renderedPlacements[index];
@@ -10679,18 +10768,35 @@ export function mountBoardInteractions(store, routes = {}) {
       const row = Number.isFinite(placement.row) ? placement.row : 0;
       const width = Math.max(1, Number.isFinite(placement.width) ? placement.width : 1);
       const height = Math.max(1, Number.isFinite(placement.height) ? placement.height : 1);
-
-      const left = column * gridSize;
-      const top = row * gridSize;
-      const right = left + width * gridSize;
-      const bottom = top + height * gridSize;
+      // Levels v2 §5.5.5: hit area follows the rendered scale so shrunk
+      // below-level tokens can only be clicked on their visible footprint.
+      // We scale around the token's center to match the CSS
+      // `transform-origin: 50% 50%`.
+      const scale = Number.isFinite(placement.scale) && placement.scale > 0 ? placement.scale : 1;
+      const cellWidth = width * gridSize;
+      const cellHeight = height * gridSize;
+      const cellLeft = column * gridSize;
+      const cellTop = row * gridSize;
+      const centerX = cellLeft + cellWidth / 2;
+      const centerY = cellTop + cellHeight / 2;
+      const halfW = (cellWidth / 2) * scale;
+      const halfH = (cellHeight / 2) * scale;
+      const left = centerX - halfW;
+      const right = centerX + halfW;
+      const top = centerY - halfH;
+      const bottom = centerY + halfH;
 
       if (pointX >= left && pointX < right && pointY >= top && pointY < bottom) {
-        if (
-          !gmViewing &&
-          !isPlacementInteractableOnPlayerMapLevel(placement, tokenLevelState, { point: pointCell })
-        ) {
-          continue;
+        if (!gmViewing) {
+          const interactable = getTokenLevelPresentation(placement, tokenLevelState, {
+            viewerLevelId,
+            gmViewing: false,
+            mode: 'interaction',
+            cells: [pointCell],
+          }).visible;
+          if (!interactable) {
+            continue;
+          }
         }
 
         // For non-GM users, skip tokens hidden by fog of war
@@ -13652,17 +13758,30 @@ export function mountBoardInteractions(store, routes = {}) {
             height: normalized.height,
           }
         : placement;
-      let canOpen = getPlayerTokenMapLevelVisibility(placementForLevel, tokenLevelState).visible;
+      const settingsSceneKey = state?.boardState?.activeSceneId ?? null;
+      const settingsViewerLevelId = settingsSceneKey
+        ? getViewerLevelIdForCurrentUser(state, settingsSceneKey)
+        : null;
+      let canOpen = getTokenLevelPresentation(placementForLevel, tokenLevelState, {
+        viewerLevelId: settingsViewerLevelId,
+        gmViewing: false,
+        mode: 'vision',
+      }).visible;
       if (Number.isFinite(clientX) && Number.isFinite(clientY)) {
         const localPoint = getLocalMapPoint({ clientX, clientY });
         const gridPoint = localPoint ? mapPointToGrid(localPoint) : null;
         if (gridPoint) {
-          canOpen = isPlacementInteractableOnPlayerMapLevel(placementForLevel, tokenLevelState, {
-            point: {
-              column: Math.floor(gridPoint.column),
-              row: Math.floor(gridPoint.row),
-            },
-          });
+          canOpen = getTokenLevelPresentation(placementForLevel, tokenLevelState, {
+            viewerLevelId: settingsViewerLevelId,
+            gmViewing: false,
+            mode: 'interaction',
+            cells: [
+              {
+                column: Math.floor(gridPoint.column),
+                row: Math.floor(gridPoint.row),
+              },
+            ],
+          }).visible;
         }
       }
 

--- a/dnd/vtt/assets/js/ui/token-interactions.js
+++ b/dnd/vtt/assets/js/ui/token-interactions.js
@@ -165,12 +165,22 @@ export function createTokenInteractions({
         return;
       }
 
-      const tokenWidth = (placement.width ?? 1) * gridSize;
-      const tokenHeight = (placement.height ?? 1) * gridSize;
-      const tokenLeft = (placement.column ?? 0) * gridSize + offsets.left;
-      const tokenTop = (placement.row ?? 0) * gridSize + offsets.top;
-      const tokenRight = tokenLeft + tokenWidth;
-      const tokenBottom = tokenTop + tokenHeight;
+      // Levels v2 §5.5.5: marquee hit box scales around the cell center to
+      // match the rendered token's footprint, so a shrunk below-level token
+      // can only be lassoed when the box overlaps its visible area.
+      const cellWidth = (placement.width ?? 1) * gridSize;
+      const cellHeight = (placement.height ?? 1) * gridSize;
+      const cellLeft = (placement.column ?? 0) * gridSize + offsets.left;
+      const cellTop = (placement.row ?? 0) * gridSize + offsets.top;
+      const scale = Number.isFinite(placement.scale) && placement.scale > 0 ? placement.scale : 1;
+      const halfW = (cellWidth / 2) * scale;
+      const halfH = (cellHeight / 2) * scale;
+      const centerX = cellLeft + cellWidth / 2;
+      const centerY = cellTop + cellHeight / 2;
+      const tokenLeft = centerX - halfW;
+      const tokenTop = centerY - halfH;
+      const tokenRight = centerX + halfW;
+      const tokenBottom = centerY + halfH;
 
       const overlapsX = tokenRight > minX && tokenLeft < maxX;
       const overlapsY = tokenBottom > minY && tokenTop < maxY;
@@ -376,14 +386,26 @@ export function createTokenInteractions({
     const topOffset = Number.isFinite(offsets.top) ? offsets.top : 0;
     dragElements = new Map();
     if (tokenLayer) {
+      const renderedById = new Map();
+      const renderedList = getRenderedPlacements?.() ?? [];
+      renderedList.forEach((entry) => {
+        if (entry && typeof entry === 'object' && entry.id) {
+          renderedById.set(entry.id, entry);
+        }
+      });
       preview.forEach((pos, id) => {
         const el = tokenLayer.querySelector(`[data-placement-id="${id}"]`);
         if (el instanceof HTMLElement) {
           const baseLeft = leftOffset + (pos.column ?? 0) * gridSize;
           const baseTop = topOffset + (pos.row ?? 0) * gridSize;
+          // Levels v2: preserve the per-level scale on the dragged element
+          // so a below-level token stays shrunk while it follows the
+          // pointer. updateTokenDrag re-applies this with translate3d.
+          const rendered = renderedById.get(id);
+          const scale = Number.isFinite(rendered?.scale) && rendered.scale > 0 ? rendered.scale : 1;
           el.classList.add('is-dragging');
           el.style.zIndex = '100000';
-          dragElements.set(id, { element: el, baseLeft, baseTop });
+          dragElements.set(id, { element: el, baseLeft, baseTop, scale });
         }
       });
     }
@@ -478,7 +500,10 @@ export function createTokenInteractions({
         }
         const left = lo + (pos.column ?? 0) * gridSize;
         const top = to + (pos.row ?? 0) * gridSize;
-        cached.element.style.transform = `translate3d(${left}px, ${top}px, 0)`;
+        const scale = Number.isFinite(cached.scale) && cached.scale > 0 ? cached.scale : 1;
+        cached.element.style.transform = scale === 1
+          ? `translate3d(${left}px, ${top}px, 0)`
+          : `translate3d(${left}px, ${top}px, 0) scale(${scale})`;
       });
     } else {
       // Fallback: no cached elements, use original render path

--- a/dnd/vtt/assets/js/ui/token-levels.js
+++ b/dnd/vtt/assets/js/ui/token-levels.js
@@ -433,6 +433,247 @@ function isCellOpenThroughHigherMapLevels(levels, startIndex, endIndex, cell, mo
   return true;
 }
 
+// Levels v2 §5.5.4: scale below-level tokens by 10% per level of distance,
+// floored at 50%. Same-level and above-level tokens render at 100%.
+export function getMapLevelDistanceScale(direction, distance) {
+  if (direction !== 'below') {
+    return 1;
+  }
+  const steps = Math.max(0, Math.trunc(Number.isFinite(distance) ? distance : 0));
+  if (steps <= 0) {
+    return 1;
+  }
+  return Math.max(0.5, 1 - steps * 0.1);
+}
+
+// Build the level list used by the v2 presentation pipeline:
+// `[Level 0, ...stored Level 1+]` ordered by zIndex.
+function getOrderedLevelsWithBase(rawLevels = []) {
+  return [buildVirtualBaseLevelEntry(), ...getOrderedTokenMapLevels(rawLevels)];
+}
+
+// Levels v2 §5.5.4 step 5: expanded cutout cells are the raw cutout cells
+// plus every cell sharing an edge or corner with a raw cell (8-neighborhood).
+// Returned as a Set keyed by `${column},${row}` so callers can do O(1) lookups
+// when intersecting across multiple blocking levels.
+function buildExpandedCutoutCellSet(level) {
+  const result = new Set();
+  const cutouts = Array.isArray(level?.cutouts) ? level.cutouts : [];
+  cutouts.forEach((cutout) => {
+    const column = normalizeNonNegativeInt(cutout?.column ?? cutout?.col ?? cutout?.x, null);
+    const row = normalizeNonNegativeInt(cutout?.row ?? cutout?.y, null);
+    if (column === null || row === null) {
+      return;
+    }
+    const width = Math.max(1, normalizeNonNegativeInt(cutout?.width ?? cutout?.columns ?? cutout?.w, 1));
+    const height = Math.max(1, normalizeNonNegativeInt(cutout?.height ?? cutout?.rows ?? cutout?.h, 1));
+
+    for (let dx = -1; dx < width + 1; dx += 1) {
+      for (let dy = -1; dy < height + 1; dy += 1) {
+        const cellColumn = column + dx;
+        const cellRow = row + dy;
+        if (cellColumn < 0 || cellRow < 0) {
+          continue;
+        }
+        result.add(`${cellColumn},${cellRow}`);
+      }
+    }
+  });
+  return result;
+}
+
+// Levels v2 §5.5: compute a token's presentation relative to a viewer level.
+// Inputs:
+//   - placement: token data (column/row/width/height/levelId).
+//   - mapLevelsState: scene's normalized map levels (Level 1+ only; Level 0
+//     is virtual and always prepended internally).
+//   - options.viewerLevelId: the per-user resolved active level. Defaults
+//     to Level 0 when missing or unknown.
+//   - options.gmViewing: GM bypass — every token is visible regardless of
+//     cutouts (§5.5.2/§5.5.3).
+//   - options.mode: 'vision' (default) or 'interaction' for click-through
+//     gating; matches the Step 1 blocker semantics.
+//   - options.cells: optional explicit cell list (used by interaction
+//     point checks).
+// Returns presentation metadata: {visible, fullyVisible, hasLevels,
+// sameLevel, direction, distance, scale, indicator, levelId,
+// activeLevelId, levelIndex, activeLevelIndex, bounds, visibleCells}.
+// `visibleCells` is non-null only when same-level partial-cell visibility
+// applies (legacy partial-mask behavior). Cross-level visibility is binary
+// per §5.5.4.
+export function getTokenLevelPresentation(placement = {}, mapLevelsState = null, options = {}) {
+  const levels = getOrderedLevelsWithBase(mapLevelsState?.levels ?? []);
+  const placementLevelId = resolvePlacementLevelId(placement);
+  const placementLevelIndex = levels.findIndex((level) => level.id === placementLevelId);
+
+  const viewerOverride = normalizeTokenLevelId(options?.viewerLevelId);
+  const viewerLevelId = viewerOverride && levels.some((level) => level.id === viewerOverride)
+    ? viewerOverride
+    : BASE_MAP_LEVEL_ID;
+  const viewerLevelIndex = levels.findIndex((level) => level.id === viewerLevelId);
+
+  if (placementLevelIndex < 0 || viewerLevelIndex < 0) {
+    return createTokenLevelPresentationResult({
+      visible: false,
+      hasLevels: levels.length > 1,
+      levelId: placementLevelId,
+      activeLevelId: viewerLevelId,
+      levelIndex: placementLevelIndex,
+      activeLevelIndex: viewerLevelIndex,
+    });
+  }
+
+  const direction =
+    placementLevelIndex === viewerLevelIndex
+      ? 'same'
+      : placementLevelIndex > viewerLevelIndex
+        ? 'above'
+        : 'below';
+  const distance = Math.abs(placementLevelIndex - viewerLevelIndex);
+  const scale = getMapLevelDistanceScale(direction, distance);
+  const indicator = direction === 'same' ? null : { direction, distance };
+  const gmViewing = Boolean(options?.gmViewing);
+  const placementBounds = normalizePlacementBounds(placement);
+
+  if (direction === 'same') {
+    return createTokenLevelPresentationResult({
+      visible: true,
+      fullyVisible: true,
+      hasLevels: true,
+      sameLevel: true,
+      direction,
+      distance: 0,
+      scale: 1,
+      indicator: null,
+      levelId: placementLevelId,
+      activeLevelId: viewerLevelId,
+      levelIndex: placementLevelIndex,
+      activeLevelIndex: viewerLevelIndex,
+      bounds: placementBounds,
+    });
+  }
+
+  if (gmViewing) {
+    return createTokenLevelPresentationResult({
+      visible: true,
+      fullyVisible: true,
+      hasLevels: true,
+      direction,
+      distance,
+      scale,
+      indicator,
+      levelId: placementLevelId,
+      activeLevelId: viewerLevelId,
+      levelIndex: placementLevelIndex,
+      activeLevelIndex: viewerLevelIndex,
+      bounds: placementBounds,
+    });
+  }
+
+  const lower = Math.min(placementLevelIndex, viewerLevelIndex);
+  const higher = Math.max(placementLevelIndex, viewerLevelIndex);
+  const mode = options?.mode === 'interaction' ? 'interaction' : 'vision';
+  const blockingExpandedSets = [];
+  for (let index = lower + 1; index <= higher; index += 1) {
+    const level = levels[index];
+    if (!doesMapLevelBlockLowerLevels(level, mode)) {
+      continue;
+    }
+    blockingExpandedSets.push(buildExpandedCutoutCellSet(level));
+  }
+
+  if (!blockingExpandedSets.length) {
+    return createTokenLevelPresentationResult({
+      visible: true,
+      fullyVisible: true,
+      hasLevels: true,
+      direction,
+      distance,
+      scale,
+      indicator,
+      levelId: placementLevelId,
+      activeLevelId: viewerLevelId,
+      levelIndex: placementLevelIndex,
+      activeLevelIndex: viewerLevelIndex,
+      bounds: placementBounds,
+    });
+  }
+
+  const cells = Array.isArray(options?.cells)
+    ? normalizePlacementCells(options.cells, placementBounds)
+    : getPlacementCells(placementBounds);
+
+  if (!cells.length) {
+    return createTokenLevelPresentationResult({
+      visible: false,
+      hasLevels: true,
+      direction,
+      distance,
+      scale,
+      indicator: null,
+      levelId: placementLevelId,
+      activeLevelId: viewerLevelId,
+      levelIndex: placementLevelIndex,
+      activeLevelIndex: viewerLevelIndex,
+      bounds: placementBounds,
+    });
+  }
+
+  const anyVisible = cells.some((cell) => {
+    const key = `${cell.column},${cell.row}`;
+    return blockingExpandedSets.every((set) => set.has(key));
+  });
+
+  return createTokenLevelPresentationResult({
+    visible: anyVisible,
+    fullyVisible: anyVisible,
+    hasLevels: true,
+    direction,
+    distance,
+    scale,
+    indicator: anyVisible ? indicator : null,
+    levelId: placementLevelId,
+    activeLevelId: viewerLevelId,
+    levelIndex: placementLevelIndex,
+    activeLevelIndex: viewerLevelIndex,
+    bounds: placementBounds,
+  });
+}
+
+function createTokenLevelPresentationResult({
+  visible,
+  fullyVisible = false,
+  hasLevels = false,
+  sameLevel = false,
+  direction = 'same',
+  distance = 0,
+  scale = 1,
+  indicator = null,
+  levelId = null,
+  activeLevelId = null,
+  levelIndex = -1,
+  activeLevelIndex = -1,
+  bounds = null,
+  visibleCells = null,
+} = {}) {
+  return {
+    visible: Boolean(visible),
+    fullyVisible: Boolean(fullyVisible),
+    hasLevels: Boolean(hasLevels),
+    sameLevel: Boolean(sameLevel),
+    direction,
+    distance: Math.max(0, Math.trunc(Number.isFinite(distance) ? distance : 0)),
+    scale: Number.isFinite(scale) && scale > 0 ? scale : 1,
+    indicator: indicator && typeof indicator === 'object' ? indicator : null,
+    levelId,
+    activeLevelId,
+    levelIndex,
+    activeLevelIndex,
+    bounds,
+    visibleCells: Array.isArray(visibleCells) ? visibleCells : null,
+  };
+}
+
 function doesMapLevelBlockLowerLevels(level, mode) {
   if (!level || typeof level !== 'object' || level.visible === false) {
     return false;


### PR DESCRIPTION
Tokens above the viewer now show a red up-arrow + distance; tokens below shrink by 10% per level (floored at 50%) and show a green down-arrow. Player visibility uses a precise edge rule: a token is visible if any of its occupied cells lies within the expanded cutout (raw + 8-neighborhood) of every blocking level. The GM always sees every token but still gets the per-level shrink and arrow badges. Hit testing, marquee selection, and drag preview all respect the rendered scale so shrunk tokens behave the way they look.