### PR TITLE
Add Levels v2 step 7: claim-driven view-follow

### DIFF
--- a/dnd/vtt/assets/js/ui/__tests__/level-view-follow.test.mjs
+++ b/dnd/vtt/assets/js/ui/__tests__/level-view-follow.test.mjs
@@ -1,0 +1,287 @@
+import { describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  computePlacementNormalizedCenter,
+  createLevelViewFollowTracker,
+  detectClaimedTokenLevelTransition,
+} from '../level-view-follow.js';
+
+describe('Levels v2 view-follow — detectClaimedTokenLevelTransition', () => {
+  test('returns false when the next entry is missing or not claim-sourced', () => {
+    const previous = { source: 'claim', tokenId: 't1', levelId: 'level-0', updatedAt: 100 };
+    assert.equal(detectClaimedTokenLevelTransition(previous, null), false);
+    assert.equal(detectClaimedTokenLevelTransition(previous, undefined), false);
+    assert.equal(
+      detectClaimedTokenLevelTransition(previous, {
+        source: 'manual',
+        levelId: 'level-1',
+        updatedAt: 200,
+      }),
+      false,
+    );
+    assert.equal(
+      detectClaimedTokenLevelTransition(previous, {
+        source: 'activate',
+        levelId: 'level-1',
+        updatedAt: 200,
+      }),
+      false,
+    );
+  });
+
+  test('first observation is the baseline — no pan even when next is claim-sourced', () => {
+    const next = {
+      source: 'claim',
+      tokenId: 'placement-1',
+      levelId: 'level-1',
+      updatedAt: 100,
+    };
+    assert.equal(detectClaimedTokenLevelTransition(null, next), false);
+    assert.equal(detectClaimedTokenLevelTransition(undefined, next), false);
+    assert.equal(detectClaimedTokenLevelTransition({ source: 'manual' }, next), false);
+  });
+
+  test('different tokenId between claim entries triggers a transition', () => {
+    const previous = { source: 'claim', tokenId: 't1', levelId: 'level-0', updatedAt: 100 };
+    const next = { source: 'claim', tokenId: 't2', levelId: 'level-0', updatedAt: 100 };
+    assert.equal(detectClaimedTokenLevelTransition(previous, next), true);
+  });
+
+  test('same token but different levelId triggers a transition', () => {
+    const previous = { source: 'claim', tokenId: 't1', levelId: 'level-0', updatedAt: 100 };
+    const next = { source: 'claim', tokenId: 't1', levelId: 'level-1', updatedAt: 100 };
+    assert.equal(detectClaimedTokenLevelTransition(previous, next), true);
+  });
+
+  test('same token and level but newer updatedAt triggers a transition', () => {
+    const previous = { source: 'claim', tokenId: 't1', levelId: 'level-1', updatedAt: 100 };
+    const next = { source: 'claim', tokenId: 't1', levelId: 'level-1', updatedAt: 200 };
+    assert.equal(detectClaimedTokenLevelTransition(previous, next), true);
+  });
+
+  test('identical entries do not trigger a transition', () => {
+    const previous = { source: 'claim', tokenId: 't1', levelId: 'level-1', updatedAt: 200 };
+    const next = { source: 'claim', tokenId: 't1', levelId: 'level-1', updatedAt: 200 };
+    assert.equal(detectClaimedTokenLevelTransition(previous, next), false);
+  });
+
+  test('blank or missing tokenId in next entry is treated as unclaimed', () => {
+    const previous = { source: 'claim', tokenId: 't1', levelId: 'level-1', updatedAt: 100 };
+    assert.equal(
+      detectClaimedTokenLevelTransition(previous, {
+        source: 'claim',
+        tokenId: '   ',
+        levelId: 'level-2',
+        updatedAt: 200,
+      }),
+      false,
+    );
+    assert.equal(
+      detectClaimedTokenLevelTransition(previous, {
+        source: 'claim',
+        levelId: 'level-2',
+        updatedAt: 200,
+      }),
+      false,
+    );
+  });
+});
+
+describe('Levels v2 view-follow — computePlacementNormalizedCenter', () => {
+  const baseGrid = {
+    gridSize: 64,
+    mapPixelSize: { width: 1024, height: 768 },
+    gridOffsets: { left: 0, top: 0 },
+  };
+
+  test('returns the placement center as a normalized 0..1 pair', () => {
+    const center = computePlacementNormalizedCenter(
+      { column: 4, row: 2, width: 2, height: 2 },
+      baseGrid,
+    );
+    assert.ok(center);
+    // (4 + 1) * 64 = 320 → 320 / 1024 = 0.3125
+    assert.equal(center.x, 0.3125);
+    // (2 + 1) * 64 = 192 → 192 / 768 = 0.25
+    assert.equal(center.y, 0.25);
+  });
+
+  test('honors leftOffset / topOffset from the grid offsets', () => {
+    const center = computePlacementNormalizedCenter(
+      { column: 0, row: 0, width: 1, height: 1 },
+      { gridSize: 64, mapPixelSize: { width: 1024, height: 768 }, gridOffsets: { left: 32, top: 16 } },
+    );
+    assert.ok(center);
+    // 32 + 0.5 * 64 = 64 → 64 / 1024
+    assert.equal(center.x, 64 / 1024);
+    // 16 + 0.5 * 64 = 48 → 48 / 768
+    assert.equal(center.y, 48 / 768);
+  });
+
+  test('clamps to [0, 1] for placements outside the map area', () => {
+    const center = computePlacementNormalizedCenter(
+      { column: -10, row: 100, width: 1, height: 1 },
+      baseGrid,
+    );
+    assert.ok(center);
+    assert.equal(center.x, 0);
+    assert.equal(center.y, 1);
+  });
+
+  test('falls back to defaults for missing width/height/columns and "col"', () => {
+    const center = computePlacementNormalizedCenter(
+      { col: 2, row: 1 },
+      baseGrid,
+    );
+    assert.ok(center);
+    // col: 2, default width: 1 → (2 + 0.5) * 64 = 160 → 160/1024 = 0.15625
+    assert.equal(center.x, 0.15625);
+    // row: 1, default height: 1 → (1 + 0.5) * 64 = 96 → 96/768 = 0.125
+    assert.equal(center.y, 0.125);
+  });
+
+  test('returns null for invalid placement or geometry inputs', () => {
+    assert.equal(computePlacementNormalizedCenter(null, baseGrid), null);
+    assert.equal(computePlacementNormalizedCenter({}, null), null);
+    assert.equal(
+      computePlacementNormalizedCenter({ column: 1, row: 1 }, { gridSize: 0, mapPixelSize: { width: 100, height: 100 } }),
+      null,
+    );
+    assert.equal(
+      computePlacementNormalizedCenter(
+        { column: 1, row: 1 },
+        { gridSize: 64, mapPixelSize: { width: 0, height: 100 } },
+      ),
+      null,
+    );
+    assert.equal(
+      computePlacementNormalizedCenter(
+        { column: 1, row: 1 },
+        { gridSize: 64, mapPixelSize: { height: 100 } },
+      ),
+      null,
+    );
+  });
+});
+
+describe('Levels v2 view-follow — createLevelViewFollowTracker', () => {
+  test('first consume on a scene records the baseline without firing', () => {
+    const tracker = createLevelViewFollowTracker();
+    const fresh = tracker.consume({
+      sceneId: 'scene-a',
+      userLevelEntry: {
+        source: 'claim',
+        tokenId: 'p1',
+        levelId: 'level-0',
+        updatedAt: 100,
+      },
+    });
+    assert.equal(fresh, false);
+    assert.deepEqual(tracker.peek('scene-a'), {
+      tokenId: 'p1',
+      levelId: 'level-0',
+      updatedAt: 100,
+    });
+  });
+
+  test('repeat consume with the same entry does not fire', () => {
+    const tracker = createLevelViewFollowTracker();
+    const entry = { source: 'claim', tokenId: 'p1', levelId: 'level-1', updatedAt: 100 };
+    tracker.consume({ sceneId: 'scene-a', userLevelEntry: entry });
+    const fresh = tracker.consume({ sceneId: 'scene-a', userLevelEntry: entry });
+    assert.equal(fresh, false);
+  });
+
+  test('updated entry fires once and updates the baseline', () => {
+    const tracker = createLevelViewFollowTracker();
+    tracker.consume({
+      sceneId: 'scene-a',
+      userLevelEntry: { source: 'claim', tokenId: 'p1', levelId: 'level-1', updatedAt: 100 },
+    });
+    const firstFire = tracker.consume({
+      sceneId: 'scene-a',
+      userLevelEntry: { source: 'claim', tokenId: 'p1', levelId: 'level-2', updatedAt: 200 },
+    });
+    const secondFire = tracker.consume({
+      sceneId: 'scene-a',
+      userLevelEntry: { source: 'claim', tokenId: 'p1', levelId: 'level-2', updatedAt: 200 },
+    });
+    assert.equal(firstFire, true);
+    assert.equal(secondFire, false);
+    assert.deepEqual(tracker.peek('scene-a'), {
+      tokenId: 'p1',
+      levelId: 'level-2',
+      updatedAt: 200,
+    });
+  });
+
+  test('non-claim entries clear the baseline so the next claim observation is a baseline again', () => {
+    const tracker = createLevelViewFollowTracker();
+    tracker.consume({
+      sceneId: 'scene-a',
+      userLevelEntry: { source: 'claim', tokenId: 'p1', levelId: 'level-1', updatedAt: 100 },
+    });
+    tracker.consume({
+      sceneId: 'scene-a',
+      userLevelEntry: { source: 'activate', levelId: 'level-2', updatedAt: 200 },
+    });
+    assert.equal(tracker.peek('scene-a'), null);
+    const fresh = tracker.consume({
+      sceneId: 'scene-a',
+      userLevelEntry: { source: 'claim', tokenId: 'p1', levelId: 'level-2', updatedAt: 300 },
+    });
+    assert.equal(fresh, false);
+  });
+
+  test('reset(sceneId) drops only that scene; reset() drops all', () => {
+    const tracker = createLevelViewFollowTracker();
+    tracker.consume({
+      sceneId: 'scene-a',
+      userLevelEntry: { source: 'claim', tokenId: 'p1', levelId: 'level-1', updatedAt: 100 },
+    });
+    tracker.consume({
+      sceneId: 'scene-b',
+      userLevelEntry: { source: 'claim', tokenId: 'p2', levelId: 'level-1', updatedAt: 100 },
+    });
+    tracker.reset('scene-a');
+    assert.equal(tracker.peek('scene-a'), null);
+    assert.deepEqual(tracker.peek('scene-b'), {
+      tokenId: 'p2',
+      levelId: 'level-1',
+      updatedAt: 100,
+    });
+    tracker.reset();
+    assert.equal(tracker.peek('scene-b'), null);
+  });
+
+  test('different scenes track independent baselines', () => {
+    const tracker = createLevelViewFollowTracker();
+    tracker.consume({
+      sceneId: 'scene-a',
+      userLevelEntry: { source: 'claim', tokenId: 'p1', levelId: 'level-1', updatedAt: 100 },
+    });
+    const fresh = tracker.consume({
+      sceneId: 'scene-b',
+      userLevelEntry: { source: 'claim', tokenId: 'p1', levelId: 'level-1', updatedAt: 100 },
+    });
+    assert.equal(fresh, false);
+  });
+
+  test('consume requires a sceneId string', () => {
+    const tracker = createLevelViewFollowTracker();
+    assert.equal(
+      tracker.consume({
+        sceneId: '',
+        userLevelEntry: { source: 'claim', tokenId: 'p1', levelId: 'level-1', updatedAt: 100 },
+      }),
+      false,
+    );
+    assert.equal(
+      tracker.consume({
+        userLevelEntry: { source: 'claim', tokenId: 'p1', levelId: 'level-1', updatedAt: 100 },
+      }),
+      false,
+    );
+  });
+});

--- a/dnd/vtt/assets/js/ui/board-interactions.js
+++ b/dnd/vtt/assets/js/ui/board-interactions.js
@@ -52,6 +52,10 @@ import { mountFogOfWar, renderFog, renderFogSelection, isFogSelectActive, isPosi
 import { createConditionTooltips } from './condition-tooltips.js';
 import { createMapPings } from './map-pings.js';
 import {
+  computePlacementNormalizedCenter,
+  createLevelViewFollowTracker,
+} from './level-view-follow.js';
+import {
   createMapLevelRenderer,
   resolveSceneMapLevelsState,
 } from './map-level-renderer.js';
@@ -756,6 +760,9 @@ export function mountBoardInteractions(store, routes = {}) {
     markPingsDirty: () => markPingsDirty(),
     persistBoardStateSnapshot: () => persistBoardStateSnapshot(),
   });
+  // Levels v2 §5.2: track the current user's claim-sourced userLevelState
+  // so claim-driven level changes pan the view to the claimed token.
+  const levelViewFollowTracker = createLevelViewFollowTracker();
   const TOKEN_DRAG_TYPE = 'application/x-vtt-token-template';
   const TOKEN_DRAG_FALLBACK_TYPE = 'text/plain';
   const MAP_LOAD_WATCHDOG_DELAY_MS = 5000;
@@ -3910,6 +3917,10 @@ export function mountBoardInteractions(store, routes = {}) {
       if (activeSceneId !== lastActiveSceneId) {
         lastActiveSceneId = activeSceneId;
         mapLevelCutoutTool.reset();
+        // Levels v2 §5.2: drop the previous scene's view-follow baseline so
+        // entering a new scene establishes a fresh baseline (no auto-pan on
+        // first observation).
+        levelViewFollowTracker.reset();
         selectedTokenIds.clear();
         notifySelectionChanged();
         resetCombatGroups();
@@ -3960,6 +3971,8 @@ export function mountBoardInteractions(store, routes = {}) {
       overlayTool.notifyMapState();
       applyCombatStateFromBoardState(state);
       mapPings.processIncomingPings(state.boardState?.pings ?? [], activeSceneId);
+      // Levels v2 §5.2: pan the view to a claim-sourced level update.
+      maybeFollowClaimedTokenView(state, activeSceneId);
       // Use the active scene ID or fall back to the default scene ID.
       // This ensures drawings sync even when no scene is explicitly selected.
       syncDrawingsFromState(state.boardState, activeSceneId || DEFAULT_SCENE_ID);
@@ -5048,6 +5061,47 @@ export function mountBoardInteractions(store, routes = {}) {
       return match.displayLabel || match.name || null;
     }
     return null;
+  }
+
+  // Levels v2 §5.2: when the current user's per-scene userLevelState is
+  // updated by a claim-driven level change (source: 'claim' with a
+  // `tokenId`), pan the view to that token so the player automatically
+  // follows their character/NPC across levels. The tracker filters first
+  // observations so opening a scene does not auto-pan.
+  function maybeFollowClaimedTokenView(state = {}, sceneId = null) {
+    if (typeof sceneId !== 'string' || !sceneId) {
+      return;
+    }
+    const userId = getCurrentUserId();
+    if (!userId) {
+      return;
+    }
+    const sceneEntry = state?.boardState?.sceneState?.[sceneId];
+    const userLevelEntry = sceneEntry && typeof sceneEntry === 'object'
+      ? sceneEntry?.userLevelState?.[userId] ?? null
+      : null;
+    const fresh = levelViewFollowTracker.consume({ sceneId, userLevelEntry });
+    if (!fresh) {
+      return;
+    }
+    const placements = state?.boardState?.placements?.[sceneId];
+    if (!Array.isArray(placements)) {
+      return;
+    }
+    const tokenId = userLevelEntry?.tokenId;
+    const placement = placements.find((entry) => entry && entry.id === tokenId);
+    if (!placement) {
+      return;
+    }
+    const center = computePlacementNormalizedCenter(placement, {
+      gridSize: viewState?.gridSize,
+      mapPixelSize: viewState?.mapPixelSize,
+      gridOffsets: viewState?.gridOffsets,
+    });
+    if (!center) {
+      return;
+    }
+    mapPings.centerViewOnPoint(center);
   }
 
   function syncMapLevelsForState(state = {}, sceneId = null) {

--- a/dnd/vtt/assets/js/ui/level-view-follow.js
+++ b/dnd/vtt/assets/js/ui/level-view-follow.js
@@ -1,0 +1,139 @@
+/**
+ * Levels v2 §5.2 view-follow helpers.
+ *
+ * When a claimant's `userLevelState` entry is updated with `source: 'claim'`
+ * and a `tokenId`, that user's view should pan to the claimed token. This
+ * module exposes the pure detector + geometry pieces so they can be tested
+ * without DOM/state plumbing; board-interactions wires them into the live
+ * view.
+ *
+ * Trigger rules (intentional):
+ *   - First observation of a scene's per-user entry is the baseline; no pan.
+ *   - A pan fires only when the entry has `source: 'claim'` AND `tokenId`
+ *     AND something about it has changed since the last observation
+ *     (different `tokenId`, `levelId`, or `updatedAt`).
+ *   - GM browsing (`source: 'manual'`) and Activate (`source: 'activate'`)
+ *     do not trigger pans because they do not match `source: 'claim'`.
+ */
+
+function normalizeEntrySnapshot(entry) {
+  if (!entry || typeof entry !== 'object') {
+    return null;
+  }
+  if (entry.source !== 'claim') {
+    return null;
+  }
+  const tokenId = typeof entry.tokenId === 'string' ? entry.tokenId.trim() : '';
+  if (!tokenId) {
+    return null;
+  }
+  const levelId = typeof entry.levelId === 'string' ? entry.levelId : '';
+  const updatedAtRaw = Number(entry.updatedAt);
+  const updatedAt = Number.isFinite(updatedAtRaw) ? updatedAtRaw : 0;
+  return { source: 'claim', tokenId, levelId, updatedAt };
+}
+
+export function detectClaimedTokenLevelTransition(prevEntry, nextEntry) {
+  const next = normalizeEntrySnapshot(nextEntry);
+  if (!next) {
+    return false;
+  }
+  const prev = normalizeEntrySnapshot(prevEntry);
+  if (!prev) {
+    return false;
+  }
+  if (prev.tokenId !== next.tokenId) {
+    return true;
+  }
+  if (prev.levelId !== next.levelId) {
+    return true;
+  }
+  if (prev.updatedAt !== next.updatedAt) {
+    return true;
+  }
+  return false;
+}
+
+export function computePlacementNormalizedCenter(placement, options = {}) {
+  if (!placement || typeof placement !== 'object') {
+    return null;
+  }
+  const column = Number(placement.column ?? placement.col ?? 0);
+  const row = Number(placement.row ?? 0);
+  if (!Number.isFinite(column) || !Number.isFinite(row)) {
+    return null;
+  }
+  const widthRaw = Number(placement.width ?? placement.columns ?? 1);
+  const heightRaw = Number(placement.height ?? placement.rows ?? 1);
+  const width = Number.isFinite(widthRaw) && widthRaw > 0 ? widthRaw : 1;
+  const height = Number.isFinite(heightRaw) && heightRaw > 0 ? heightRaw : 1;
+
+  const cellSize = Number(options?.gridSize);
+  if (!Number.isFinite(cellSize) || cellSize <= 0) {
+    return null;
+  }
+  const mapWidth = Number(options?.mapPixelSize?.width);
+  const mapHeight = Number(options?.mapPixelSize?.height);
+  if (!Number.isFinite(mapWidth) || mapWidth <= 0) {
+    return null;
+  }
+  if (!Number.isFinite(mapHeight) || mapHeight <= 0) {
+    return null;
+  }
+  const offsets = options?.gridOffsets ?? null;
+  const leftOffset = Number.isFinite(offsets?.left) ? offsets.left : 0;
+  const topOffset = Number.isFinite(offsets?.top) ? offsets.top : 0;
+
+  const centerX = leftOffset + (column + width / 2) * cellSize;
+  const centerY = topOffset + (row + height / 2) * cellSize;
+  const normalizedX = Math.min(1, Math.max(0, centerX / mapWidth));
+  const normalizedY = Math.min(1, Math.max(0, centerY / mapHeight));
+  if (!Number.isFinite(normalizedX) || !Number.isFinite(normalizedY)) {
+    return null;
+  }
+  return { x: normalizedX, y: normalizedY };
+}
+
+export function createLevelViewFollowTracker() {
+  const lastEntries = new Map();
+
+  function reset(sceneId) {
+    if (sceneId === undefined || sceneId === null) {
+      lastEntries.clear();
+      return;
+    }
+    lastEntries.delete(sceneId);
+  }
+
+  function consume({ sceneId, userLevelEntry } = {}) {
+    if (typeof sceneId !== 'string' || !sceneId) {
+      return false;
+    }
+    const previous = lastEntries.get(sceneId) ?? null;
+    const fresh = detectClaimedTokenLevelTransition(previous, userLevelEntry);
+    const next = normalizeEntrySnapshot(userLevelEntry);
+    if (next) {
+      lastEntries.set(sceneId, next);
+    } else {
+      lastEntries.delete(sceneId);
+    }
+    return fresh;
+  }
+
+  function peek(sceneId) {
+    if (typeof sceneId !== 'string' || !sceneId) {
+      return null;
+    }
+    const entry = lastEntries.get(sceneId);
+    if (!entry) {
+      return null;
+    }
+    return {
+      tokenId: entry.tokenId,
+      levelId: entry.levelId,
+      updatedAt: entry.updatedAt,
+    };
+  }
+
+  return { reset, consume, peek };
+}

--- a/dnd/vtt/assets/js/ui/map-pings.js
+++ b/dnd/vtt/assets/js/ui/map-pings.js
@@ -374,11 +374,34 @@ export function createMapPings({
     }
   }
 
+  // Levels v2 §5.2: expose the pan helper so claim-driven view-follow can
+  // reuse the same camera-centering math as alt-shift-click focus pings.
+  // Accepts a `{ x, y }` pair already normalized to [0, 1] of the active
+  // map; returns false when the view isn't ready (no map loaded, missing
+  // dimensions) so the caller can decide whether to retry.
+  function centerViewOnPoint(point) {
+    if (!point || typeof point !== 'object') {
+      return false;
+    }
+    const x = Number(point.x);
+    const y = Number(point.y);
+    if (!Number.isFinite(x) || !Number.isFinite(y)) {
+      return false;
+    }
+    const viewState = getViewState() ?? {};
+    if (!viewState.mapLoaded) {
+      return false;
+    }
+    centerViewOnPing({ x, y });
+    return true;
+  }
+
   return {
     handleMapPing,
     processIncomingPings,
     sanitizePingsForPersistence,
     clonePingEntries,
     normalizeIncomingPing,
+    centerViewOnPoint,
   };
 }


### PR DESCRIPTION
When a player's per-scene userLevelState entry is updated with source: 'claim' and a tokenId (today only via the GM moving a claimed token through the token-settings panel), the claimant's view now pans to the token using the same camera-centering math as alt-shift-click focus pings. Per §5.2 the GM's own view does not pan; only the player whose claim drove the level change follows.

A new level-view-follow.js module owns the pure pieces: a transition detector that filters first-observation baselines (so opening a scene does not auto-pan), a placement-to-normalized-center helper that mirrors the renderer's grid math, and a per-scene tracker. map-pings.js exposes centerViewOnPoint as a thin wrapper over the existing pan path, and board-interactions.js wires the tracker into applyStateToBoard: scene change resets baselines, every render checks for a fresh claim-driven transition, and pans when one fires.

19 new tests (466 total, up from 447).