### PR TITLE
Add Levels v2 step 8: token falling

### DIFF
--- a/dnd/vtt/assets/css/board.css
+++ b/dnd/vtt/assets/css/board.css
@@ -2835,6 +2835,49 @@
   opacity: 0.35;
 }
 
+/* Levels v2 (§5.6): falling animation — scale up by 5%, quick wobble,
+ * scale down so the token reads as dropping away. The keyframes target
+ * the inner image so the token's outer positional transform (translate +
+ * cross-level scale) is preserved. The animation plays once per fall
+ * chain via the JS class toggle in token-fall-animation.js. Duration
+ * stays in lockstep with TOKEN_FALL_DURATION_MS. */
+.vtt-token--falling .vtt-token__image,
+.vtt-token--falling.vtt-token--placeholder::before {
+  animation: vtt-token-fall var(--vtt-token-fall-duration, 1s) ease-in-out;
+  transform-origin: 50% 50%;
+}
+
+@keyframes vtt-token-fall {
+  0% {
+    transform: scale(1) rotate(0deg);
+    opacity: 1;
+  }
+  15% {
+    transform: scale(1.05) rotate(-3deg);
+    opacity: 1;
+  }
+  30% {
+    transform: scale(1.05) rotate(4deg);
+    opacity: 1;
+  }
+  45% {
+    transform: scale(1.03) rotate(-2deg);
+    opacity: 1;
+  }
+  60% {
+    transform: scale(1) rotate(0deg);
+    opacity: 1;
+  }
+  85% {
+    transform: scale(0.55) rotate(0deg);
+    opacity: 0.5;
+  }
+  100% {
+    transform: scale(1) rotate(0deg);
+    opacity: 1;
+  }
+}
+
 .vtt-token[data-combat-team='ally'] {
   border-color: rgba(74, 222, 128, 0.9);
   box-shadow: 0 10px 24px rgba(22, 101, 52, 0.45);

--- a/dnd/vtt/assets/js/ui/__tests__/token-fall-animation.test.mjs
+++ b/dnd/vtt/assets/js/ui/__tests__/token-fall-animation.test.mjs
@@ -1,0 +1,72 @@
+import { describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  isTokenFallInFlight,
+  playTokenFallAnimation,
+  TOKEN_FALL_DURATION_MS,
+} from '../token-fall-animation.js';
+
+// Levels v2 §5.6: the animation module is a thin runtime wrapper around
+// the CSS keyframes. These tests cover the class toggle + Promise resolve
+// behavior. The actual visual frames live in board.css.
+
+function createFakeTokenElement() {
+  const classes = new Set();
+  return {
+    classList: {
+      add(name) {
+        classes.add(name);
+      },
+      remove(name) {
+        classes.delete(name);
+      },
+      has(name) {
+        return classes.has(name);
+      },
+    },
+    _classes: classes,
+  };
+}
+
+describe('Levels v2 token fall animation', () => {
+  test('TOKEN_FALL_DURATION_MS is a positive number', () => {
+    assert.equal(typeof TOKEN_FALL_DURATION_MS, 'number');
+    assert.equal(TOKEN_FALL_DURATION_MS > 0, true);
+  });
+
+  test('playTokenFallAnimation adds the falling class then removes it on resolve', async () => {
+    const el = createFakeTokenElement();
+    const promise = playTokenFallAnimation(el, { duration: 30 });
+    assert.equal(el._classes.has('vtt-token--falling'), true);
+    assert.equal(isTokenFallInFlight(el), true);
+    await promise;
+    assert.equal(el._classes.has('vtt-token--falling'), false);
+    assert.equal(isTokenFallInFlight(el), false);
+  });
+
+  test('playTokenFallAnimation: a second call cancels the prior in-flight animation', async () => {
+    const el = createFakeTokenElement();
+    const first = playTokenFallAnimation(el, { duration: 200 });
+    // Restart immediately — the prior promise should resolve early so
+    // callers do not hang on a stale fall.
+    const second = playTokenFallAnimation(el, { duration: 30 });
+    await first;
+    // Class should still be set because the second animation is in
+    // flight; the first resolved early via cancel().
+    assert.equal(el._classes.has('vtt-token--falling'), true);
+    await second;
+    assert.equal(el._classes.has('vtt-token--falling'), false);
+  });
+
+  test('playTokenFallAnimation: invalid element resolves immediately without throwing', async () => {
+    const result = await playTokenFallAnimation(null);
+    assert.equal(result, undefined);
+  });
+
+  test('isTokenFallInFlight: returns false for null/empty inputs', () => {
+    assert.equal(isTokenFallInFlight(null), false);
+    assert.equal(isTokenFallInFlight(undefined), false);
+    assert.equal(isTokenFallInFlight({}), false);
+  });
+});

--- a/dnd/vtt/assets/js/ui/__tests__/token-levels.test.mjs
+++ b/dnd/vtt/assets/js/ui/__tests__/token-levels.test.mjs
@@ -3,12 +3,14 @@ import assert from 'node:assert/strict';
 
 import {
   getAdjacentTokenLevel,
+  getFallingDestinationLevelId,
   getMapLevelDistanceScale,
   getMapLevelNavigationControlState,
   getOrderedTokenMapLevels,
   getPlayerTokenMapLevelVisibility,
   getTokenLevelControlState,
   getTokenLevelPresentation,
+  isPlacementFullyInsideRawCutouts,
   isPlacementInteractableOnPlayerMapLevel,
   isPlacementOnPlayerVisibleMapLevel,
   resolvePlayerActiveMapLevelId,
@@ -689,5 +691,217 @@ describe('Levels v2 token presentation', () => {
       { viewerLevelId: 'upper', gmViewing: true },
     );
     assert.equal(orphan.visible, false);
+  });
+});
+
+// Levels v2 §5.6: falling — raw-cutout containment, chained fall
+// resolution, and edge-buffer non-trigger.
+describe('Levels v2 falling detection', () => {
+  test('isPlacementFullyInsideRawCutouts: single-cell token entirely inside a cutout returns true', () => {
+    const level = {
+      id: 'upper',
+      cutouts: [{ column: 5, row: 5, width: 1, height: 1 }],
+    };
+    const placement = { id: 't', column: 5, row: 5, width: 1, height: 1 };
+    assert.equal(isPlacementFullyInsideRawCutouts(placement, level), true);
+  });
+
+  test('isPlacementFullyInsideRawCutouts: edge-of-cutout placement does NOT trigger', () => {
+    // The §5.6 rule is "every occupied cell sits inside the raw cutout
+    // area" — edge-of-cutout placement should NOT fall. Step 5's edge
+    // expansion (8-neighborhood) is for visibility only.
+    const level = {
+      id: 'upper',
+      cutouts: [{ column: 5, row: 5, width: 2, height: 2 }],
+    };
+    const adjacent = { id: 't', column: 4, row: 5, width: 1, height: 1 };
+    const corner = { id: 't', column: 4, row: 4, width: 1, height: 1 };
+    assert.equal(isPlacementFullyInsideRawCutouts(adjacent, level), false);
+    assert.equal(isPlacementFullyInsideRawCutouts(corner, level), false);
+  });
+
+  test('isPlacementFullyInsideRawCutouts: multi-cell token partially over a cutout returns false', () => {
+    const level = {
+      id: 'upper',
+      cutouts: [{ column: 5, row: 5, width: 1, height: 1 }],
+    };
+    const placement = { id: 't', column: 5, row: 5, width: 2, height: 2 };
+    assert.equal(isPlacementFullyInsideRawCutouts(placement, level), false);
+  });
+
+  test('isPlacementFullyInsideRawCutouts: multi-cell token fully covered by a wide cutout returns true', () => {
+    const level = {
+      id: 'upper',
+      cutouts: [{ column: 5, row: 5, width: 3, height: 3 }],
+    };
+    const placement = { id: 't', column: 6, row: 6, width: 2, height: 2 };
+    assert.equal(isPlacementFullyInsideRawCutouts(placement, level), true);
+  });
+
+  test('isPlacementFullyInsideRawCutouts: missing or empty cutouts returns false', () => {
+    const placement = { id: 't', column: 0, row: 0, width: 1, height: 1 };
+    assert.equal(isPlacementFullyInsideRawCutouts(placement, null), false);
+    assert.equal(isPlacementFullyInsideRawCutouts(placement, {}), false);
+    assert.equal(isPlacementFullyInsideRawCutouts(placement, { cutouts: [] }), false);
+  });
+
+  test('getFallingDestinationLevelId: single fall from Level 1 to Level 0', () => {
+    const mapLevels = {
+      levels: [
+        {
+          id: 'upper',
+          name: 'Upper',
+          mapUrl: '/u.png',
+          zIndex: 1,
+          cutouts: [{ column: 4, row: 4, width: 1, height: 1 }],
+        },
+      ],
+    };
+    const placement = { id: 't', levelId: 'upper', column: 4, row: 4, width: 1, height: 1 };
+    assert.equal(getFallingDestinationLevelId(placement, mapLevels), 'level-0');
+  });
+
+  test('getFallingDestinationLevelId: chained fall from Level 2 through Level 1 to Level 0', () => {
+    // Cutouts on both upper levels stack so a token landing on the cell
+    // falls through both. Step 5 visibility uses edge expansion; falling
+    // uses raw cells only — confirm the helper walks the chain via raw
+    // containment.
+    const mapLevels = {
+      levels: [
+        {
+          id: 'level1',
+          name: 'Level 1',
+          mapUrl: '/1.png',
+          zIndex: 1,
+          cutouts: [{ column: 7, row: 3, width: 1, height: 1 }],
+        },
+        {
+          id: 'level2',
+          name: 'Level 2',
+          mapUrl: '/2.png',
+          zIndex: 2,
+          cutouts: [{ column: 7, row: 3, width: 1, height: 1 }],
+        },
+      ],
+    };
+    const placement = { id: 't', levelId: 'level2', column: 7, row: 3, width: 1, height: 1 };
+    assert.equal(getFallingDestinationLevelId(placement, mapLevels), 'level-0');
+  });
+
+  test('getFallingDestinationLevelId: chained fall stops at the first level WITHOUT a cutout', () => {
+    const mapLevels = {
+      levels: [
+        // Level 1: NO cutout at the placement column — chain stops here.
+        {
+          id: 'level1',
+          name: 'Level 1',
+          mapUrl: '/1.png',
+          zIndex: 1,
+          cutouts: [{ column: 0, row: 0, width: 1, height: 1 }],
+        },
+        // Level 2: cutout under the placement.
+        {
+          id: 'level2',
+          name: 'Level 2',
+          mapUrl: '/2.png',
+          zIndex: 2,
+          cutouts: [{ column: 7, row: 3, width: 1, height: 1 }],
+        },
+      ],
+    };
+    const placement = { id: 't', levelId: 'level2', column: 7, row: 3, width: 1, height: 1 };
+    assert.equal(getFallingDestinationLevelId(placement, mapLevels), 'level1');
+  });
+
+  test('getFallingDestinationLevelId: token already on Level 0 never falls', () => {
+    const mapLevels = {
+      levels: [
+        {
+          id: 'upper',
+          name: 'Upper',
+          mapUrl: '/u.png',
+          zIndex: 1,
+          cutouts: [{ column: 0, row: 0, width: 5, height: 5 }],
+        },
+      ],
+    };
+    const placement = { id: 't', levelId: 'level-0', column: 1, row: 1, width: 1, height: 1 };
+    assert.equal(getFallingDestinationLevelId(placement, mapLevels), null);
+  });
+
+  test('getFallingDestinationLevelId: token with missing levelId is treated as Level 0 and never falls', () => {
+    const mapLevels = {
+      levels: [
+        {
+          id: 'upper',
+          name: 'Upper',
+          mapUrl: '/u.png',
+          zIndex: 1,
+          cutouts: [{ column: 0, row: 0, width: 5, height: 5 }],
+        },
+      ],
+    };
+    // Legacy placements with no levelId resolve to Level 0 per
+    // resolvePlacementLevelId; they should not be re-classified as
+    // upper-level just because they sit over a cutout above them.
+    const placement = { id: 't', column: 1, row: 1, width: 1, height: 1 };
+    assert.equal(getFallingDestinationLevelId(placement, mapLevels), null);
+  });
+
+  test('getFallingDestinationLevelId: edge-of-cutout placement does not fall', () => {
+    const mapLevels = {
+      levels: [
+        {
+          id: 'upper',
+          name: 'Upper',
+          mapUrl: '/u.png',
+          zIndex: 1,
+          cutouts: [{ column: 5, row: 5, width: 2, height: 2 }],
+        },
+      ],
+    };
+    // Adjacent to but not inside the cutout.
+    const placement = { id: 't', levelId: 'upper', column: 4, row: 5, width: 1, height: 1 };
+    assert.equal(getFallingDestinationLevelId(placement, mapLevels), null);
+  });
+
+  test('getFallingDestinationLevelId: multi-cell partial overlap does not fall', () => {
+    const mapLevels = {
+      levels: [
+        {
+          id: 'upper',
+          name: 'Upper',
+          mapUrl: '/u.png',
+          zIndex: 1,
+          cutouts: [{ column: 5, row: 5, width: 1, height: 1 }],
+        },
+      ],
+    };
+    // 2x2 token covers (5,5), (6,5), (5,6), (6,6) but the cutout is
+    // only (5,5). Partial — does not fall.
+    const placement = { id: 't', levelId: 'upper', column: 5, row: 5, width: 2, height: 2 };
+    assert.equal(getFallingDestinationLevelId(placement, mapLevels), null);
+  });
+
+  test('getFallingDestinationLevelId: returns null when no levels exist', () => {
+    const placement = { id: 't', levelId: 'upper', column: 0, row: 0, width: 1, height: 1 };
+    assert.equal(getFallingDestinationLevelId(placement, { levels: [] }), null);
+    assert.equal(getFallingDestinationLevelId(placement, null), null);
+  });
+
+  test('getFallingDestinationLevelId: returns null when current level is unknown', () => {
+    const mapLevels = {
+      levels: [
+        {
+          id: 'upper',
+          name: 'Upper',
+          mapUrl: '/u.png',
+          zIndex: 1,
+          cutouts: [{ column: 0, row: 0, width: 5, height: 5 }],
+        },
+      ],
+    };
+    const placement = { id: 't', levelId: 'phantom', column: 1, row: 1, width: 1, height: 1 };
+    assert.equal(getFallingDestinationLevelId(placement, mapLevels), null);
   });
 });

--- a/dnd/vtt/assets/js/ui/board-interactions.js
+++ b/dnd/vtt/assets/js/ui/board-interactions.js
@@ -67,6 +67,7 @@ import {
 } from './token-stack-order.js';
 import {
   getAdjacentTokenLevel,
+  getFallingDestinationLevelId,
   getMapLevelNavigationControlState,
   getOrderedTokenMapLevels,
   getPlayerTokenMapLevelVisibility,
@@ -76,6 +77,7 @@ import {
   resolveSceneTokenLevelState,
   resolveTokenLevelId,
 } from './token-levels.js';
+import { playTokenFallAnimation } from './token-fall-animation.js';
 import {
   broadcastStaminaSync,
   subscribeToStaminaSync,
@@ -817,6 +819,12 @@ export function mountBoardInteractions(store, routes = {}) {
     toNonNegativeNumber: (value, fallback) => toNonNegativeNumber(value, fallback),
     persistBoardStateSnapshot: (options, opsOverride) =>
       persistBoardStateSnapshot(options, opsOverride),
+    // Levels v2 (§5.6): drag commits route here so dropped tokens that
+    // land entirely over a cutout fall to the next valid level.
+    processPlacementFalls: (sceneId, placementIds) =>
+      processPlacementFalls(sceneId, placementIds),
+    triggerTokenFallAnimations: (placementIds) =>
+      triggerTokenFallAnimations(placementIds),
   });
   const {
     startSelectionBox,
@@ -14235,14 +14243,30 @@ export function mountBoardInteractions(store, routes = {}) {
       levelId: targetLevel.id,
     });
 
+    // Levels v2 (§5.6): if the GM moved a token to a level whose cutout
+    // sits entirely under the token's footprint, the token falls. Chained
+    // falls resolve to the final resting level inside processPlacementFalls.
+    const fallenIds = processPlacementFalls(activeSceneId, [activeTokenSettingsId]);
+
     refreshTokenSettings();
     renderTokens(boardApi.getState?.() ?? {}, tokenLayer, viewState);
     renderAuras(boardApi.getState?.() ?? {}, auraLayer, viewState);
+    triggerTokenFallAnimations(fallenIds);
 
     if (status) {
       const label = tokenLabel(getPlacementFromStore(activeTokenSettingsId));
-      const levelName = targetLevel.name || 'map level';
-      status.textContent = `Moved ${label} to ${levelName}.`;
+      const finalPlacement = getPlacementFromStore(activeTokenSettingsId);
+      const finalLevelId = resolvePlacementLevelId(finalPlacement);
+      const levelName = (() => {
+        if (fallenIds.length && finalLevelId) {
+          const levelView = getViewerLevelDisplayName(state, activeSceneId, finalLevelId);
+          return levelView || targetLevel.name || 'map level';
+        }
+        return targetLevel.name || 'map level';
+      })();
+      status.textContent = fallenIds.length
+        ? `${label} fell to ${levelName}.`
+        : `Moved ${label} to ${levelName}.`;
     }
   }
 
@@ -14308,6 +14332,146 @@ export function mountBoardInteractions(store, routes = {}) {
         tokenId: placementId,
       },
     ]);
+  }
+
+  // Levels v2 (§5.6): after a token movement (drag commit or level-move),
+  // detect placements that landed entirely inside the raw cutouts of their
+  // current level and drop them to the next valid level. Chained falls are
+  // applied in `getFallingDestinationLevelId` (which walks down until the
+  // resting level). Persists the level change as one logical mutation per
+  // placement, mirrors claimant `userLevelState` updates, and returns the
+  // list of placement ids that fell so callers can trigger the animation
+  // after their re-render.
+  function processPlacementFalls(sceneId, placementIds) {
+    if (
+      typeof sceneId !== 'string' || !sceneId
+      || !Array.isArray(placementIds) || !placementIds.length
+      || typeof boardApi.updateState !== 'function'
+    ) {
+      return [];
+    }
+    const state = boardApi.getState?.() ?? {};
+    const mapLevels = resolveSceneTokenLevelState(state, sceneId);
+    const placements = state.boardState?.placements?.[sceneId] ?? [];
+    if (!Array.isArray(placements) || !placements.length) {
+      return [];
+    }
+
+    const fallTargets = [];
+    placementIds.forEach((placementId) => {
+      if (typeof placementId !== 'string' || !placementId) {
+        return;
+      }
+      const placement = placements.find((entry) => entry?.id === placementId);
+      if (!placement) {
+        return;
+      }
+      const toLevelId = getFallingDestinationLevelId(placement, mapLevels);
+      if (!toLevelId) {
+        return;
+      }
+      fallTargets.push({
+        placementId,
+        fromLevelId: resolvePlacementLevelId(placement),
+        toLevelId,
+      });
+    });
+
+    if (!fallTargets.length) {
+      return [];
+    }
+
+    const fallTimestamp = Date.now();
+    const ops = [];
+    let mutated = false;
+
+    boardApi.updateState?.((draft) => {
+      const drafts = ensureScenePlacementDraft(draft, sceneId);
+      if (!Array.isArray(drafts) || !drafts.length) {
+        return;
+      }
+      fallTargets.forEach(({ placementId, toLevelId }) => {
+        const idx = drafts.findIndex((entry) => entry?.id === placementId);
+        if (idx < 0) {
+          return;
+        }
+        const target = drafts[idx];
+        if (!target || typeof target !== 'object') {
+          return;
+        }
+        target.levelId = toLevelId;
+        target._lastModified = fallTimestamp;
+        mutated = true;
+        ops.push({
+          type: 'placement.update',
+          sceneId,
+          placementId,
+          patch: { levelId: toLevelId },
+        });
+      });
+    });
+
+    if (!mutated) {
+      return [];
+    }
+
+    fallTargets.forEach(({ placementId }) => {
+      markPlacementDirty(sceneId, placementId);
+    });
+
+    if (ops.length > 0) {
+      persistBoardStateSnapshot({}, ops);
+    }
+
+    // Levels v2 (§4.2 + §5.6): when a claimed token falls, the same
+    // logical mutation must update the claimant's `userLevelState` so
+    // their view follows. `applyClaimDrivenUserLevelUpdate` short-circuits
+    // for unclaimed placements and emits its own `user-level.set` op.
+    fallTargets.forEach(({ placementId, toLevelId }) => {
+      applyClaimDrivenUserLevelUpdate({
+        sceneId,
+        placementId,
+        levelId: toLevelId,
+      });
+    });
+
+    return fallTargets.map((entry) => entry.placementId);
+  }
+
+  // Levels v2 (§5.6): play the fall animation on the rendered token DOM
+  // for each fallen placement id. Schedules via requestAnimationFrame so
+  // the caller's renderTokens has already painted the post-fall element
+  // (correct level scale + indicator) before the wobble starts.
+  function triggerTokenFallAnimations(placementIds) {
+    if (!Array.isArray(placementIds) || !placementIds.length || !tokenLayer) {
+      return;
+    }
+    const ids = placementIds.filter((id) => typeof id === 'string' && id);
+    if (!ids.length) {
+      return;
+    }
+    const schedule = typeof requestAnimationFrame === 'function'
+      ? requestAnimationFrame
+      : (callback) => setTimeout(callback, 0);
+    schedule(() => {
+      const nodes = tokenLayer.querySelectorAll('[data-placement-id]');
+      const tokensById = new Map();
+      nodes.forEach((node) => {
+        if (!(node instanceof HTMLElement)) {
+          return;
+        }
+        const id = node.dataset.placementId;
+        if (id) {
+          tokensById.set(id, node);
+        }
+      });
+      ids.forEach((id) => {
+        const tokenEl = tokensById.get(id);
+        if (tokenEl) {
+          playTokenFallAnimation(tokenEl).catch(() => {});
+        }
+      });
+    });
   }
 
   function syncTokenStackControls(placementId = activeTokenSettingsId) {

--- a/dnd/vtt/assets/js/ui/token-fall-animation.js
+++ b/dnd/vtt/assets/js/ui/token-fall-animation.js
@@ -1,0 +1,81 @@
+// Levels v2 §5.6: lightweight CSS-class-based fall animation for tokens
+// that drop through a cutout to a lower level. The animation is a one-shot
+// per fall chain — chained drops snap through to the resting level and
+// only the initial drop plays the wobble. The keyframes themselves live
+// in `board.css` (`@keyframes vtt-token-fall`); this module is the thin
+// runtime wrapper that toggles the trigger class and resolves a Promise
+// when the animation ends so callers can sequence reveal-of-final-state.
+
+const FALL_CLASS = 'vtt-token--falling';
+// Keep in sync with `--vtt-token-fall-duration` in board.css. The plan
+// targets ~1 second of animation.
+export const TOKEN_FALL_DURATION_MS = 1000;
+
+// Track active fall timers per token element so a rapid second fall
+// (e.g. GM repositioning a token mid-animation) cleans up the prior
+// state without leaving the class stuck on the element.
+const activeFalls = new WeakMap();
+
+export function playTokenFallAnimation(tokenElement, options = {}) {
+  if (!tokenElement || typeof tokenElement.classList?.add !== 'function') {
+    return Promise.resolve();
+  }
+
+  const duration = Number.isFinite(options?.duration) && options.duration > 0
+    ? options.duration
+    : TOKEN_FALL_DURATION_MS;
+
+  const previous = activeFalls.get(tokenElement);
+  if (previous) {
+    if (typeof previous.cancel === 'function') {
+      previous.cancel();
+    }
+  }
+
+  return new Promise((resolve) => {
+    let resolved = false;
+    let timerId = null;
+
+    const finalize = () => {
+      if (resolved) {
+        return;
+      }
+      resolved = true;
+      if (timerId !== null) {
+        clearTimeout(timerId);
+        timerId = null;
+      }
+      try {
+        tokenElement.classList.remove(FALL_CLASS);
+      } catch (error) {
+        // Ignore if the element was unmounted before cleanup.
+      }
+      const recorded = activeFalls.get(tokenElement);
+      if (recorded && recorded.cancel === cancel) {
+        activeFalls.delete(tokenElement);
+      }
+      resolve();
+    };
+
+    const cancel = () => finalize();
+
+    activeFalls.set(tokenElement, { cancel });
+
+    try {
+      tokenElement.classList.add(FALL_CLASS);
+    } catch (error) {
+      // If we cannot add the class, resolve immediately so callers do not
+      // hang waiting on an animation that will never play.
+      finalize();
+      return;
+    }
+
+    timerId = setTimeout(finalize, duration);
+  });
+}
+
+// Test/utility: returns true if a fall animation is currently in flight
+// on the supplied element.
+export function isTokenFallInFlight(tokenElement) {
+  return Boolean(tokenElement && activeFalls.has(tokenElement));
+}

--- a/dnd/vtt/assets/js/ui/token-interactions.js
+++ b/dnd/vtt/assets/js/ui/token-interactions.js
@@ -44,6 +44,10 @@ export function createTokenInteractions({
   ensureScenePlacementDraft,
   toNonNegativeNumber,
   persistBoardStateSnapshot,
+  // Levels v2 (§5.6): post-commit fall detection. Optional; when omitted
+  // commits run with no fall handling (matches pre-v2 behavior).
+  processPlacementFalls = null,
+  triggerTokenFallAnimations = null,
   windowRef = typeof window === 'undefined' ? undefined : window,
 } = {}) {
   let dragRenderRafId = null;
@@ -762,13 +766,34 @@ export function createTokenInteractions({
       persistBoardStateSnapshot({}, placementMoveOps);
     }
 
+    // Levels v2 (§5.6): drag commit triggers raw-cutout fall detection
+    // for the just-moved tokens. processPlacementFalls handles chained
+    // falls, persists the level change as a `placement.update` op, and
+    // mirrors the claimant's userLevelState. The animation is fired on
+    // the post-render token DOM via triggerTokenFallAnimations after the
+    // renderTokens call below paints the new size/indicator.
+    let fallenIds = [];
+    if (movedCount && typeof processPlacementFalls === 'function') {
+      const result = processPlacementFalls(activeSceneId, movedIds);
+      if (Array.isArray(result)) {
+        fallenIds = result;
+      }
+    }
+
     const statusEl = getStatusElement();
     if (movedCount && statusEl) {
       const noun = movedCount === 1 ? 'token' : 'tokens';
-      statusEl.textContent = `Moved ${movedCount} ${noun}.`;
+      const fellNoun = fallenIds.length === 1 ? 'token' : 'tokens';
+      statusEl.textContent = fallenIds.length
+        ? `Moved ${movedCount} ${noun}; ${fallenIds.length} ${fellNoun} fell.`
+        : `Moved ${movedCount} ${noun}.`;
     }
 
     renderTokens(boardApi.getState?.() ?? {}, tokenLayer, viewState);
+
+    if (fallenIds.length && typeof triggerTokenFallAnimations === 'function') {
+      triggerTokenFallAnimations(fallenIds);
+    }
   }
 
   function clearDragCandidate(pointerId = null) {

--- a/dnd/vtt/assets/js/ui/token-levels.js
+++ b/dnd/vtt/assets/js/ui/token-levels.js
@@ -674,6 +674,62 @@ function createTokenLevelPresentationResult({
   };
 }
 
+// Levels v2 §5.6: a placement falls when every occupied cell sits inside a
+// raw cutout (no edge-buffer expansion) on the placement's current level.
+// Returns false for Level 0 since the base map has no cutouts. Returns
+// false for placements on unknown/missing levels — falling only applies to
+// stored Level 1+ entries.
+export function isPlacementFullyInsideRawCutouts(placement = {}, level = null) {
+  if (!level || typeof level !== 'object') {
+    return false;
+  }
+  if (!Array.isArray(level.cutouts) || level.cutouts.length === 0) {
+    return false;
+  }
+  const bounds = normalizePlacementBounds(placement);
+  const cells = getPlacementCells(bounds);
+  if (!cells.length) {
+    return false;
+  }
+  return cells.every((cell) => isMapLevelCutOutAtCell(level, cell));
+}
+
+// Levels v2 §5.6: walk the level chain downward as long as the placement is
+// fully inside the raw cutouts of its current level. The animation plays
+// once at the start of a chain; this helper returns the FINAL resting
+// levelId so callers can persist it as one logical mutation. Returns null
+// when the placement does not fall (already on Level 0, current level
+// unknown, or position not entirely inside the raw cutouts).
+//
+// `mapLevelsState` is the normalized map levels state (`mapLevels` slice
+// from scene state); the helper builds the full ordered list with Level 0
+// prepended internally.
+export function getFallingDestinationLevelId(placement = {}, mapLevelsState = null) {
+  const levels = getOrderedLevelsWithBase(mapLevelsState?.levels ?? []);
+  if (levels.length <= 1) {
+    return null;
+  }
+  const placementLevelId = resolvePlacementLevelId(placement);
+  const startIdx = levels.findIndex((level) => level.id === placementLevelId);
+  if (startIdx <= 0) {
+    return null;
+  }
+
+  let restingIdx = startIdx;
+  while (restingIdx > 0) {
+    const level = levels[restingIdx];
+    if (!isPlacementFullyInsideRawCutouts(placement, level)) {
+      break;
+    }
+    restingIdx -= 1;
+  }
+
+  if (restingIdx === startIdx) {
+    return null;
+  }
+  return levels[restingIdx].id;
+}
+
 function doesMapLevelBlockLowerLevels(level, mode) {
   if (!level || typeof level !== 'object' || level.visible === false) {
     return false;


### PR DESCRIPTION
Tokens that end a movement entirely inside a raw cutout now drop to the next valid level, with chained falls resolving to the final resting level in one logical mutation. The existing cutout edge expansion (Step 5's 8-neighborhood) is for visibility only — falling uses raw cutout cells per §5.6, so a token adjacent to or partially overlapping a cutout does not fall.

token-levels.js gains two pure helpers: isPlacementFullyInsideRawCutouts (every occupied cell in a raw cutout, no edge buffer) and getFallingDestinationLevelId (walks the [Level 0, ...stored] chain downward until either a level without a covering cutout or Level 0 stops the chain). The Step 5 follow-up note explicitly called for raw cells here, separate from the visibility expansion.

board-interactions.js adds processPlacementFalls and triggerTokenFallAnimations. processPlacementFalls is called from both the GM token-settings level-move path (handleTokenLevelMoveClick) and the drag-commit path (commitDragPreview, via two new optional callbacks threaded through createTokenInteractions). It mutates each falling placement's levelId in a single updateState block, marks dirty, broadcasts a placement.update op carrying the level patch, and calls applyClaimDrivenUserLevelUpdate per fall so the §4.2 invariant (claimant userLevelState updates whenever a claimed token's level changes) is satisfied for the falling path. triggerTokenFallAnimations schedules the wobble via requestAnimationFrame so the animation runs against the post-render DOM (correct level scale + indicator already painted).

The animation itself is a thin CSS-class toggle wrapper. token-fall- animation.js exposes playTokenFallAnimation which adds vtt-token--falling to the supplied element and resolves a Promise after the duration; a second call on the same element cancels the prior animation early so rapid re-falls don't leave the trigger class stuck. The keyframes target the inner image element, not the token itself, so the outer translate3d/cross-level scale transform is preserved while the inner content does the scale-up/wobble/scale-down/return cycle. Per §5.6 the animation plays once per fall chain regardless of how many levels were traversed.

Tests: 19 new (485 total, up from 466). Falling detection covers single-fall, chained-fall, chained-fall stopping at first non-cutout level, edge-of-cutout no-trigger, partial-overlap no-trigger, Level 0 floor, missing/unknown levelId paths, and empty mapLevelsState. The animation module test suite covers class toggle on/off, cancel-on- restart, and invalid-input no-throw.