### PR TITLE
Push chat updates over Pusher to fix ERR_INSUFFICIENT_RESOURCES

### DIFF
--- a/dnd/character_sheet/index.php
+++ b/dnd/character_sheet/index.php
@@ -24,6 +24,9 @@ foreach ($chatParticipantsMap as $participantId => $participantLabel) {
   );
 }
 
+require_once __DIR__ . '/../includes/chat_pusher.php';
+$chatPusherConfig = getChatPusherClientConfig();
+
 // Include navigation bar
 require_once '../includes/strix-nav.php';
 ?>
@@ -36,6 +39,9 @@ require_once '../includes/strix-nav.php';
   <link rel="stylesheet" href="../css/chat-panel.css?v=<?php echo (int) $assetVersion; ?>" />
   <link rel="stylesheet" href="styles.css?v=<?php echo (int) $assetVersion; ?>" />
   <script type="module" src="sheet.js?v=<?php echo (int) $assetVersion; ?>"></script>
+<?php if ($chatPusherConfig !== null): ?>
+  <script src="https://js.pusher.com/8.4.0/pusher.min.js"></script>
+<?php endif; ?>
 </head>
 <body class="character-sheet-page" data-character="<?php echo htmlspecialchars($activeCharacter, ENT_QUOTES, 'UTF-8'); ?>">
   <?php renderStrixNav('charactersheet'); ?>
@@ -126,6 +132,7 @@ require_once '../includes/strix-nav.php';
   <script>
     window.chatHandlerUrl = '/dnd/chat_handler.php';
     window.chatParticipants = <?php echo json_encode($chatParticipantList, JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP); ?>;
+    window.chatPusherConfig = <?php echo json_encode($chatPusherConfig, JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP); ?>;
     window.characterSheetChatConfig = {
       isGM: <?php echo $isGm ? 'true' : 'false'; ?>,
       currentUser: <?php echo json_encode($currentUser, JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP); ?>

--- a/dnd/chat_handler.php
+++ b/dnd/chat_handler.php
@@ -2,6 +2,8 @@
 // Chat handler for dashboard real-time messaging
 // Handles chat_send, chat_fetch, and chat_upload actions
 
+require_once __DIR__ . '/includes/chat_pusher.php';
+
 if (PHP_SAPI !== 'cli') {
     if (session_status() === PHP_SESSION_NONE) {
         session_start();
@@ -537,6 +539,8 @@ function handleChatSend($dataFile, $maxMessages, array $validParticipants) {
         exit;
     }
 
+    broadcastChatUpdate($messageType === 'whisper' ? 'whisper' : 'message');
+
     echo json_encode(['success' => true, 'message' => $entry]);
     exit;
 }
@@ -600,6 +604,8 @@ function handleChatClear($dataFile)
         echo json_encode(['success' => false, 'error' => 'Failed to clear chat history.']);
         exit;
     }
+
+    broadcastChatUpdate('clear');
 
     echo json_encode(['success' => true]);
     exit;
@@ -682,6 +688,8 @@ function handleRollStatusUpdate($dataFile)
         echo json_encode(['success' => false, 'error' => 'Failed to update message']);
         exit;
     }
+
+    broadcastChatUpdate('roll-status');
 
     echo json_encode([
         'success' => true,

--- a/dnd/dashboard.php
+++ b/dnd/dashboard.php
@@ -35,6 +35,9 @@ foreach ($chatParticipantsMap as $participantId => $participantLabel) {
     );
 }
 
+require_once __DIR__ . '/includes/chat_pusher.php';
+$chatPusherConfig = getChatPusherClientConfig();
+
 // Define character list
 $characters = array('frunk', 'sharon', 'indigo', 'zepha');
 
@@ -912,6 +915,9 @@ $defaultInventoryTab = $is_gm ? 'frunk' : $user;
     <link rel="stylesheet" href="Halloween/theme.css" id="halloween-theme" disabled>
     <link rel="stylesheet" href="Christmas/theme.css" id="christmas-theme" disabled>
     <link rel="stylesheet" href="Frunk/theme.css" id="frunk-theme" disabled>
+<?php if ($chatPusherConfig !== null): ?>
+    <script src="https://js.pusher.com/8.4.0/pusher.min.js"></script>
+<?php endif; ?>
 </head>
 <body class="dashboard-page">
     <!-- Top Navigation Bar -->
@@ -1440,6 +1446,7 @@ $defaultInventoryTab = $is_gm ? 'frunk' : $user;
         let currentCharacter = '<?php echo $currentCharacter; ?>';
         window.currentCharacter = currentCharacter;
         window.chatParticipants = chatParticipants;
+        window.chatPusherConfig = <?php echo json_encode($chatPusherConfig); ?>;
         let characterData = {};
         let currentClubIndex = 0;
         let currentPastClassIndex = -1;

--- a/dnd/includes/chat_pusher.php
+++ b/dnd/includes/chat_pusher.php
@@ -1,0 +1,109 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Chat Pusher helpers.
+ *
+ * The chat panel runs in three host pages (dashboard, VTT, character sheet)
+ * and shares the Pusher credentials defined in vtt/config/pusher.php. The
+ * chat broadcast is a notification-only event — clients refetch through the
+ * regular chat HTTP endpoint when notified, which keeps whisper visibility
+ * filtering intact and avoids the 10 KB Pusher payload limit.
+ */
+
+require_once __DIR__ . '/../vtt/lib/PusherClient.php';
+
+/**
+ * Public-facing config for the browser. Returns null when Pusher is
+ * disabled / unconfigured, so the client falls back to the legacy poll.
+ *
+ * @return array{key:string,cluster:string,channel:string}|null
+ */
+function getChatPusherClientConfig(): ?array
+{
+    $config = loadChatPusherConfig();
+    if ($config === null) {
+        return null;
+    }
+
+    $key = (string) ($config['key'] ?? '');
+    $cluster = (string) ($config['cluster'] ?? 'us3');
+    $channel = (string) ($config['chat_channel'] ?? 'dnd-chat');
+
+    if ($key === '' || $channel === '') {
+        return null;
+    }
+
+    return [
+        'key' => $key,
+        'cluster' => $cluster,
+        'channel' => $channel,
+    ];
+}
+
+/**
+ * Server-side broadcast of a `chat-updated` notification. Called after a
+ * successful chat send / clear / roll-status update. The event payload is
+ * deliberately small — clients refetch via HTTP to get authoritative,
+ * per-user filtered content.
+ *
+ * Fails silently when Pusher is unavailable so the chat write itself is
+ * never blocked by an outbound API problem.
+ */
+function broadcastChatUpdate(string $kind = 'message'): void
+{
+    $config = loadChatPusherConfig();
+    if ($config === null) {
+        return;
+    }
+
+    $appId = (string) ($config['app_id'] ?? '');
+    $key = (string) ($config['key'] ?? '');
+    $secret = (string) ($config['secret'] ?? '');
+    $cluster = (string) ($config['cluster'] ?? 'us3');
+    $channel = (string) ($config['chat_channel'] ?? 'dnd-chat');
+    // Use a tighter timeout than the board broadcaster — chat sends are
+    // user-interactive and we don't want a Pusher outage to stall the UI.
+    $timeout = 2;
+
+    if ($appId === '' || $key === '' || $secret === '' || $channel === '') {
+        return;
+    }
+
+    try {
+        $client = new PusherClient($appId, $key, $secret, $cluster, $timeout);
+        $client->trigger($channel, 'chat-updated', [
+            'kind' => $kind,
+            'ts' => date('c'),
+        ]);
+    } catch (Throwable $e) {
+        error_log('[Chat] Pusher broadcast failed: ' . $e->getMessage());
+    }
+}
+
+/**
+ * @return array<string,mixed>|null
+ */
+function loadChatPusherConfig(): ?array
+{
+    static $cached = null;
+    static $loaded = false;
+
+    if ($loaded) {
+        return $cached;
+    }
+
+    $loaded = true;
+    $configPath = __DIR__ . '/../vtt/config/pusher.php';
+    if (!is_file($configPath)) {
+        return null;
+    }
+
+    $config = require $configPath;
+    if (!is_array($config) || empty($config['enabled'])) {
+        return null;
+    }
+
+    $cached = $config;
+    return $cached;
+}

--- a/dnd/js/chat-panel.js
+++ b/dnd/js/chat-panel.js
@@ -1,6 +1,11 @@
 (function () {
-    // Chat polling interval - lowered for faster message sync
-    const FETCH_INTERVAL_MS = 1500;
+    // When Pusher is connected, polling is just a safety net for missed
+    // events; we slow to 30s to keep socket-pool pressure off chat
+    // (avoids ERR_INSUFFICIENT_RESOURCES on busy VTT tabs). When Pusher
+    // is unavailable we fall back to the legacy fast-poll cadence so
+    // chat still feels live.
+    const FETCH_INTERVAL_PUSHER_MS = 30000;
+    const FETCH_INTERVAL_FALLBACK_MS = 1500;
     const MAX_MESSAGES = 100;
     let escapeListenerAttached = false;
     const CHAT_ENDPOINT = (typeof window !== 'undefined' && window.chatHandlerUrl)
@@ -131,6 +136,10 @@
         let isOpen = false;
         let fetchTimer = null;
         let fetchInProgress = false;
+        let fetchIntervalMs = FETCH_INTERVAL_FALLBACK_MS;
+        let chatPusherClient = null;
+        let chatPusherChannel = null;
+        let chatPusherWasConnected = false;
         let latestServerTimestamp = '';
         let messages = [];
         let lightboxElements = null;
@@ -1681,7 +1690,66 @@
 
         function ensureInterval() {
             if (fetchTimer === null) {
-                fetchTimer = window.setInterval(fetchMessages, FETCH_INTERVAL_MS);
+                fetchTimer = window.setInterval(fetchMessages, fetchIntervalMs);
+            }
+        }
+
+        function setFetchCadence(nextMs) {
+            if (typeof nextMs !== 'number' || nextMs <= 0 || nextMs === fetchIntervalMs) {
+                return;
+            }
+            fetchIntervalMs = nextMs;
+            if (fetchTimer !== null) {
+                window.clearInterval(fetchTimer);
+                fetchTimer = null;
+                ensureInterval();
+            }
+        }
+
+        function initChatPusher() {
+            const config = (typeof window !== 'undefined' && window.chatPusherConfig)
+                ? window.chatPusherConfig
+                : null;
+            if (!config || !config.key || !config.channel) {
+                return;
+            }
+            if (typeof window === 'undefined' || typeof window.Pusher !== 'function') {
+                return;
+            }
+
+            try {
+                chatPusherClient = new window.Pusher(config.key, {
+                    cluster: config.cluster || 'us3',
+                    forceTLS: true,
+                    disableStats: true,
+                });
+
+                chatPusherChannel = chatPusherClient.subscribe(config.channel);
+                chatPusherChannel.bind('chat-updated', () => {
+                    fetchMessages();
+                });
+
+                chatPusherClient.connection.bind('connected', () => {
+                    // Safety-net cadence is sufficient once the websocket
+                    // is alive — pushed events drive the UI.
+                    setFetchCadence(FETCH_INTERVAL_PUSHER_MS);
+                    // On *re*-connect (not the initial connect), catch up
+                    // on any messages that landed during the gap.
+                    if (chatPusherWasConnected) {
+                        fetchMessages();
+                    }
+                    chatPusherWasConnected = true;
+                });
+
+                // If the websocket goes away, fall back to fast polling so
+                // chat keeps flowing while reconnect is in progress.
+                const handleDrop = () => setFetchCadence(FETCH_INTERVAL_FALLBACK_MS);
+                chatPusherClient.connection.bind('disconnected', handleDrop);
+                chatPusherClient.connection.bind('unavailable', handleDrop);
+                chatPusherClient.connection.bind('failed', handleDrop);
+            } catch (error) {
+                chatPusherClient = null;
+                chatPusherChannel = null;
             }
         }
 
@@ -2416,6 +2484,7 @@
 
         setOpen(false);
         renderMessages();
+        initChatPusher();
         ensureInterval();
         fetchMessages();
 

--- a/dnd/vtt/bootstrap.php
+++ b/dnd/vtt/bootstrap.php
@@ -175,6 +175,7 @@ function getVttBootstrapConfig(?array $authContext = null): array
 
     // Load Pusher config if available
     $pusherConfig = null;
+    $chatPusherConfig = null;
     $pusherConfigPath = __DIR__ . '/config/pusher.php';
     if (is_file($pusherConfigPath)) {
         $pusherData = require $pusherConfigPath;
@@ -184,6 +185,14 @@ function getVttBootstrapConfig(?array $authContext = null): array
                 'cluster' => $pusherData['cluster'] ?? 'us3',
                 'channel' => $pusherData['channel'] ?? 'vtt-board',
             ];
+            $chatChannel = $pusherData['chat_channel'] ?? 'dnd-chat';
+            if (!empty($pusherData['key']) && $chatChannel !== '') {
+                $chatPusherConfig = [
+                    'key' => $pusherData['key'],
+                    'cluster' => $pusherData['cluster'] ?? 'us3',
+                    'channel' => $chatChannel,
+                ];
+            }
         }
     }
 
@@ -198,6 +207,7 @@ function getVttBootstrapConfig(?array $authContext = null): array
         'chatParticipants' => loadChatParticipants(),
         'chatHandlerUrl' => $routes['chat'] ?? '/dnd/chat_handler.php',
         'pusher' => $pusherConfig,
+        'chatPusher' => $chatPusherConfig,
     ];
 }
 

--- a/dnd/vtt/config/pusher.php
+++ b/dnd/vtt/config/pusher.php
@@ -26,6 +26,12 @@ return [
     // Channel name for VTT board state updates
     'channel' => 'vtt-board',
 
+    // Channel name for dashboard/VTT/character-sheet chat updates.
+    // Carries `chat-updated` notification events (no payload) emitted on
+    // chat send / clear / roll-status changes. Subscribers refetch via the
+    // chat HTTP endpoint, which preserves whisper visibility filtering.
+    'chat_channel' => 'dnd-chat',
+
     // HTTP request timeout in seconds
     'timeout' => 5,
 

--- a/dnd/vtt/templates/layout.php
+++ b/dnd/vtt/templates/layout.php
@@ -44,6 +44,9 @@ require_once __DIR__ . '/../../includes/strix-nav.php';
             cluster: 'us3',
             channel: 'vtt-board'
         };
+        // Pusher chat channel — `chat-updated` notifications drive
+        // immediate refetch instead of 1.5s polling.
+        window.chatPusherConfig = <?= json_encode($config['chatPusher'] ?? null, JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP) ?>;
     </script>
     <script src="../js/chat-panel.js?v=<?= $assetVersion ?>"></script>
     <script type="module" src="assets/js/bootstrap.js?v=<?= $assetVersion ?>"></script>


### PR DESCRIPTION
## Summary
- Migrate the chat panel from a 1.5s polling loop to Pusher push notifications, fixing the `ERR_INSUFFICIENT_RESOURCES` errors that surface mid-session on the VTT page when Chrome's per-host socket pool gets exhausted by concurrent board saves, stamina syncs, image fetches, the existing Pusher socket, and 40 chat polls/min/tab.
- After a successful `chat_send` / `chat_clear` / `update_roll`, `chat_handler.php` emits a small `chat-updated` event on a new `dnd-chat` Pusher channel. Clients refetch via the existing chat HTTP endpoint when notified — this keeps whisper visibility server-authoritative and sidesteps the 10 KB Pusher payload limit.
- When Pusher is connected, polling drops from 1.5s → 30s as a safety net. If the websocket disconnects or Pusher init fails, polling reverts to 1.5s so chat stays live.

## Files
- `dnd/vtt/config/pusher.php` — added `chat_channel: 'dnd-chat'`.
- `dnd/includes/chat_pusher.php` — new helper: `getChatPusherClientConfig()` (browser config) + `broadcastChatUpdate($kind)` (server emit, 2s timeout, fails silently).
- `dnd/chat_handler.php` — emit on send / clear / roll-status update.
- `dnd/js/chat-panel.js` — subscribe to `dnd-chat`; refetch on `chat-updated`; dynamic poll cadence (30s / 1.5s) keyed off connection state; refetch on reconnect to catch up on missed events.
- `dnd/vtt/bootstrap.php` + `dnd/vtt/templates/layout.php` — bootstrap config exposes `chatPusher`; layout sets `window.chatPusherConfig`.
- `dnd/dashboard.php`, `dnd/character_sheet/index.php` — load `pusher.min.js` only when chat Pusher is configured; expose `window.chatPusherConfig`.

## Test plan
- [ ] Open VTT in two tabs as different users; type in one and confirm the other receives in <500ms without the 1.5s `chat_handler.php` polling traffic in the Network tab.
- [ ] Confirm a chat Pusher subscription appears in the console alongside the existing `vtt-board` subscription.
- [ ] Send a whisper from A to B and confirm only B sees it (visibility filter still applied via the HTTP refetch).
- [ ] GM clears chat and updates a project roll status; both propagate via the same notification channel.
- [ ] Disable Pusher (`enabled => false` in `dnd/vtt/config/pusher.php`) and confirm chat falls back to the 1.5s poll cadence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)