### PR TITLE
Serialize full-snapshot board saves to fix 409 popback

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -44,7 +44,8 @@
       "PowerShell(Get-ChildItem -Path \"$env:ProgramFiles\",\"${env:ProgramFiles\\(x86\\)}\",\"$env:LOCALAPPDATA\",\"$env:APPDATA\" -Filter gh.exe -Recurse -ErrorAction SilentlyContinue -Depth 4 | Select-Object -First 5 -ExpandProperty FullName)",
       "Bash(node --test \"dnd/vtt/assets/js/state/__tests__/map-levels-v2-normalization.test.mjs\")",
       "Bash(node -e \"import\\('./dnd/vtt/assets/js/state/normalize/map-levels.js'\\).then\\(m => console.log\\(Object.keys\\(m\\).sort\\(\\).join\\('\\\\n'\\)\\)\\)\")",
-      "Bash(node --check \"dnd/vtt/assets/js/ui/board-interactions.js\")"
+      "Bash(node --check \"dnd/vtt/assets/js/ui/board-interactions.js\")",
+      "Bash(git -C \"C:/Users/tasta/OneDrive/Documents/GitHub/gmscreen/.claude/worktrees/serene-shirley-0c90e8\" log --oneline -20)"
     ],
     "deny": []
   }

--- a/dnd/vtt/LEVELS_V2_PLAN.md
+++ b/dnd/vtt/LEVELS_V2_PLAN.md
@@ -973,4 +973,14 @@ Fix:
 
 **Test status after fixes:** 488 of 488 tests still pass. The cutout fix touches a path that has no direct unit test coverage (cutout editor is inside an IIFE in board-interactions.js); the stamina fix adds an `await` around an existing function flow and changes the call signature in `handleTokenDrop` only.
 
+**Bug C — 409 Conflict / "popback" on rapid scene-manager actions (2026-04-27)**
+
+Reported as: rapid level add/delete or layer-visibility toggling produces a `POST /api/state.php` 409 Conflict and the most recent change visibly reverts ("pops back"). Stack trace shows the failing save coming from `scene-manager.js:81` → `scene-manager.js:314` (`toggle-map-level-visibility`) and similar `mutateSceneMapLevels` paths.
+
+Root cause: scene-manager (and settings-panel and any other forceFullSnapshot caller) routes through `_persistBoardState({ forceFullSnapshot: true })`. When two such saves fire close together, the persistence layer's `coalesce: true` aborts the in-flight fetch of save A and sends save B with whatever `currentBoardStateVersion` was captured at queue time. The server may have already processed save A and bumped its version (the abort only cancels the *response*, not the request). Save B then arrives with a now-stale `_version` → 409. The conflict handler calls `applyBoardStateConflictSnapshot(result.data)` which **overwrites local boardState with the server snapshot** — and the server snapshot does not yet reflect save B's mutation, so the user sees the action revert.
+
+Fix landed in `board-interactions.js`: introduced `snapshotSaveQueue` (a Promise chain) and split `persistBoardStateSnapshot` into a thin wrapper plus the existing `doPersistBoardStateSnapshot`. When a caller passes `forceFullSnapshot: true`, the wrapper appends the new save to the queue so each forceFullSnapshot save waits for the prior one's response before being built and sent. By the time `doPersistBoardStateSnapshot` runs, `currentBoardStateVersion` reflects the prior server response (or the conflict snapshot's incoming version on a 409), so the next save carries an up-to-date version. Ops/delta saves keep their fast `coalesce: true` path because the `db64ca8` ops bypass already handles stale versions for them. The escape hatch from ops to snapshot (when `opsResult.escape === true`) re-enters through `doPersistBoardStateSnapshot` directly, since the caller is already inside a queued task. The keepalive flush continues to use the unqueued path because it doesn't pass `forceFullSnapshot`.
+
+**Test status after fix:** 488 of 488 tests still pass. The change is scoped to `persistBoardStateSnapshot` inside the IIFE in `board-interactions.js`; no public surface or test mock changed.
+
 

--- a/dnd/vtt/assets/js/ui/board-interactions.js
+++ b/dnd/vtt/assets/js/ui/board-interactions.js
@@ -1770,7 +1770,18 @@ export function mountBoardInteractions(store, routes = {}) {
   // the ops path never silently drops templates/drawings/etc.
   const USE_DELTA_SAVES = true;
 
-  const persistBoardStateSnapshot = (options = {}, opsOverride = null) => {
+  // Serialize full-snapshot saves so rapid scene/level mutations (e.g.
+  // delete level → add level → toggle visibility) do not carry a stale
+  // `_version`. The persistence layer's `coalesce: true` aborts a prior
+  // in-flight save's fetch, but the server may have already processed
+  // that aborted request and bumped its version. The next save would
+  // then 409, and the conflict-snapshot recovery path overwrites the
+  // user's local change ("popback"). Ops/delta saves keep their fast
+  // coalesce path because the v2 ops endpoint already bypasses the
+  // stale-version check.
+  let snapshotSaveQueue = Promise.resolve();
+
+  const doPersistBoardStateSnapshot = (options = {}, opsOverride = null) => {
     if (!routes?.state || typeof boardApi.getState !== 'function') {
       console.warn('[VTT] Cannot persist board state: routes.state missing or boardApi.getState unavailable');
       return;
@@ -1880,9 +1891,11 @@ export function mountBoardInteractions(store, routes = {}) {
       const opsResult = persistBoardStateOps(routes.state, opsOverride, envelope, options);
       // Escape hatch: the ops buffer is too large or spans too many
       // scenes for a single delta flush. Fall back to a full-snapshot
-      // save by re-entering without the override.
+      // save by re-entering without the override. We re-enter through
+      // the inner function (not the queue wrapper) because we are
+      // already inside a queued task when forceFullSnapshot is true.
       if (opsResult && typeof opsResult === 'object' && opsResult.escape === true) {
-        return persistBoardStateSnapshot(options, null);
+        return doPersistBoardStateSnapshot(options, null);
       }
       savePromise = opsResult ?? null;
       saveFlushDescriptor = {
@@ -1982,6 +1995,18 @@ export function mountBoardInteractions(store, routes = {}) {
     }
 
     return savePromise ?? null;
+  };
+
+  const persistBoardStateSnapshot = (options = {}, opsOverride = null) => {
+    if (options?.forceFullSnapshot !== true) {
+      return doPersistBoardStateSnapshot(options, opsOverride);
+    }
+    const previous = snapshotSaveQueue;
+    const next = previous
+      .catch(() => null)
+      .then(() => doPersistBoardStateSnapshot(options, opsOverride));
+    snapshotSaveQueue = next.catch(() => null);
+    return next;
   };
 
   let keepaliveFlushScheduled = false;


### PR DESCRIPTION
Rapid scene-manager actions (delete level → add level → toggle layer visibility) produced a `POST /api/state.php` 409 Conflict and the most recent change visibly reverted. Root cause: scene-manager routes through `_persistBoardState({ forceFullSnapshot: true })`. The persistence layer's `coalesce: true` aborts the in-flight fetch of save A and sends save B with the same `currentBoardStateVersion`, but the server may have already processed save A and bumped its version. Save B then 409s, and `applyBoardStateConflictSnapshot` overwrites local state with the server snapshot — which doesn't yet reflect save B's mutation, hence the "popback".

Fix: introduce a `snapshotSaveQueue` Promise chain and split `persistBoardStateSnapshot` into a queue wrapper plus the existing implementation (renamed `doPersistBoardStateSnapshot`). Callers that pass `forceFullSnapshot: true` now serialize through the queue, so each such save waits for the prior save's response before being built. By the time `doPersistBoardStateSnapshot` runs, `currentBoardStateVersion` reflects the prior server response (or the conflict snapshot's incoming version on a 409), so the next save carries an up-to-date version.

Ops/delta saves keep their fast `coalesce: true` path because the v2 ops endpoint already bypasses the stale-version check (db46dc8). The keepalive flush continues to use the unqueued path. The recursive ops→snapshot escape hatch re-enters through the inner function directly to avoid double-queueing inside an already-queued task.

Documented as Bug C in the Levels v2 plan §13. All 488 existing JS tests still pass.