### PR TITLE
Reshape measurement arrow with king-move path, gradient, and ghost drag

### DIFF
--- a/dnd/vtt/assets/css/board.css
+++ b/dnd/vtt/assets/css/board.css
@@ -2574,6 +2574,17 @@
     0 16px 36px rgba(79, 70, 229, 0.4);
 }
 
+/* Ghost clone shown while dragging a token. The original token stays
+   anchored at its starting square (so the measurement arrow's tail
+   has something to attach to); this translucent copy follows the
+   pointer to preview the drop location. */
+.vtt-token.vtt-token--drag-ghost {
+  opacity: 0.55;
+  pointer-events: none;
+  filter: drop-shadow(0 6px 14px rgba(15, 23, 42, 0.45));
+  transition: none;
+}
+
 .vtt-token.vtt-token--hidden {
   opacity: 0.5;
   border-color: rgba(148, 163, 184, 0.4);
@@ -4088,9 +4099,12 @@
 }
 
 .vtt-board__ruler {
-  position: absolute;
+  /* position: fixed pins the readout to the viewport so it stays visible
+     even when the map is panned or zoomed past the canvas edges. */
+  position: fixed;
   bottom: 1rem;
   right: 1rem;
+  z-index: 10000;
   background: rgba(15, 23, 42, 0.85);
   padding: 1rem 1.25rem;
   border-radius: var(--vtt-radius);
@@ -4099,6 +4113,7 @@
   font-size: 1.1rem;
   font-weight: 600;
   box-shadow: 0 12px 32px rgba(15, 23, 42, 0.35);
+  pointer-events: none;
 }
 
 .vtt-board__ruler-value {
@@ -4117,17 +4132,26 @@
 }
 
 .vtt-measure-overlay__path {
-  stroke: rgba(96, 165, 250, 0.9);
-  stroke-width: 6;
+  /* Stroke (gradient) and stroke-width (scaled to grid) are set in JS;
+     CSS only provides linecap/join + a soft drop shadow for legibility. */
   stroke-linecap: round;
   stroke-linejoin: round;
   fill: none;
+  filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.45));
+}
+
+.vtt-measure-overlay__arrowhead {
+  fill: #0f0f0f;
+  stroke: rgba(255, 255, 255, 0.85);
+  stroke-width: 0.6;
+  stroke-linejoin: round;
 }
 
 .vtt-measure-overlay__node {
-  fill: rgba(59, 130, 246, 0.95);
-  stroke: rgba(15, 23, 42, 0.92);
-  stroke-width: 4;
+  /* Endpoint circles hidden by default — the gradient arrow + arrowhead
+     already convey the endpoints. Kept in the DOM so multi-waypoint
+     measurements can re-enable them later if desired. */
+  display: none;
 }
 
 .vtt-measure-overlay__label {

--- a/dnd/vtt/assets/js/ui/drag-ruler.js
+++ b/dnd/vtt/assets/js/ui/drag-ruler.js
@@ -1,6 +1,14 @@
 const SVG_NS = 'http://www.w3.org/2000/svg';
 const MAX_MEASUREMENT_POINTS = 21; // 20 segments
 
+// Arrow visual constants
+const ARROW_STROKE_RATIO = 0.32;        // stroke-width as fraction of grid size
+const ARROW_BEND_RADIUS_RATIO = 0.55;   // smooth-bend radius as fraction of grid size
+const ARROW_GRADIENT_ID = 'vtt-measure-arrow-gradient';
+const ARROW_HEAD_ID = 'vtt-measure-arrow-head';
+const ARROW_COLOR_START = '#ef4444';    // red at source
+const ARROW_COLOR_END = '#0f0f0f';      // near-black at destination
+
 let sharedState = null;
 let cachedMapRect = null;
 
@@ -415,7 +423,7 @@ function updateOverlay(state) {
   if (!segments.length) {
     state.overlay.svg.setAttribute('hidden', 'hidden');
     state.overlay.svg.style.display = 'none';
-    state.overlay.path.setAttribute('points', '');
+    state.overlay.path.setAttribute('d', '');
     state.overlay.nodes.innerHTML = '';
     state.overlay.labels.innerHTML = '';
     state.ruler.setAttribute('hidden', 'hidden');
@@ -428,12 +436,35 @@ function updateOverlay(state) {
     return;
   }
 
+  const gridMetrics = getGridMetrics(state.grid, state.mapTransform);
+  const gridSize =
+    gridMetrics && gridMetrics.size > 0 ? gridMetrics.size : 64;
+
   state.overlay.svg.removeAttribute('hidden');
   state.overlay.svg.style.display = '';
+
+  // Build a king-move SVG path: diagonal segment from source, smooth bend,
+  // cardinal segment into destination. Pure cardinal/diagonal collapses to
+  // a straight line.
+  const pathD = buildArrowPathD(points, gridSize);
+  state.overlay.path.setAttribute('d', pathD);
+
+  // Stroke thickness scales with grid size so it looks consistent at any zoom.
   state.overlay.path.setAttribute(
-    'points',
-    points.map((point) => `${point.mapX},${point.mapY}`).join(' ')
+    'stroke-width',
+    String(Math.max(2, gridSize * ARROW_STROKE_RATIO))
   );
+
+  // Re-anchor the linear gradient to follow the actual path direction
+  // (first point -> last point in user-space coordinates).
+  if (state.overlay.gradient) {
+    const startPt = points[0];
+    const endPt = points[points.length - 1];
+    state.overlay.gradient.setAttribute('x1', String(startPt.mapX));
+    state.overlay.gradient.setAttribute('y1', String(startPt.mapY));
+    state.overlay.gradient.setAttribute('x2', String(endPt.mapX));
+    state.overlay.gradient.setAttribute('y2', String(endPt.mapY));
+  }
 
   syncNodeMarkers(state.overlay.nodes, points);
   syncSegmentLabels(state.overlay.labels, segments);
@@ -488,6 +519,86 @@ function getSegments(points) {
     segments.push({ start, end, squares });
   }
   return segments;
+}
+
+/**
+ * Build an SVG path `d` attribute that follows D&D king-move semantics:
+ * from each source point, travel `min(|dx|,|dy|)` diagonal squares first,
+ * then `||dx|-|dy||` cardinal squares into the destination, with a smooth
+ * quadratic bend at the corner. Pure cardinal or pure diagonal segments
+ * collapse to a straight line (the bend point coincides with an endpoint).
+ *
+ * @param {Array<{mapX:number, mapY:number, column:number, row:number}>} points
+ * @param {number} gridSize  Pixel size of one grid square (used for bend radius).
+ * @returns {string} SVG path data, or empty string if fewer than 2 points.
+ */
+function buildArrowPathD(points, gridSize) {
+  if (!Array.isArray(points) || points.length < 2) {
+    return '';
+  }
+
+  const safeGrid = Number.isFinite(gridSize) && gridSize > 0 ? gridSize : 64;
+  const bendRadius = safeGrid * ARROW_BEND_RADIUS_RATIO;
+
+  const parts = [`M ${fmt(points[0].mapX)} ${fmt(points[0].mapY)}`];
+
+  for (let i = 1; i < points.length; i += 1) {
+    const a = points[i - 1];
+    const b = points[i];
+
+    const dCol = b.column - a.column;
+    const dRow = b.row - a.row;
+    const adCol = Math.abs(dCol);
+    const adRow = Math.abs(dRow);
+    const sCol = Math.sign(dCol);
+    const sRow = Math.sign(dRow);
+
+    const diagSteps = Math.min(adCol, adRow);
+    const cardSteps = Math.max(adCol, adRow) - diagSteps;
+
+    // Pure cardinal (dCol==0 or dRow==0) or pure diagonal (|dCol|==|dRow|).
+    if (diagSteps === 0 || cardSteps === 0) {
+      parts.push(`L ${fmt(b.mapX)} ${fmt(b.mapY)}`);
+      continue;
+    }
+
+    // Bend point in map-space: end of the diagonal segment from the source.
+    const bendX = a.mapX + sCol * diagSteps * safeGrid;
+    const bendY = a.mapY + sRow * diagSteps * safeGrid;
+
+    const diagLen = Math.hypot(bendX - a.mapX, bendY - a.mapY);
+    const cardLen = Math.hypot(b.mapX - bendX, b.mapY - bendY);
+    if (diagLen <= 0 || cardLen <= 0) {
+      parts.push(`L ${fmt(b.mapX)} ${fmt(b.mapY)}`);
+      continue;
+    }
+
+    const uxDiag = (bendX - a.mapX) / diagLen;
+    const uyDiag = (bendY - a.mapY) / diagLen;
+    const uxCard = (b.mapX - bendX) / cardLen;
+    const uyCard = (b.mapY - bendY) / cardLen;
+
+    // Clamp the corner radius so the curve never overruns either segment.
+    const r = Math.min(bendRadius, diagLen * 0.5, cardLen * 0.5);
+
+    const beforeBendX = bendX - uxDiag * r;
+    const beforeBendY = bendY - uyDiag * r;
+    const afterBendX = bendX + uxCard * r;
+    const afterBendY = bendY + uyCard * r;
+
+    parts.push(`L ${fmt(beforeBendX)} ${fmt(beforeBendY)}`);
+    parts.push(
+      `Q ${fmt(bendX)} ${fmt(bendY)} ${fmt(afterBendX)} ${fmt(afterBendY)}`
+    );
+    parts.push(`L ${fmt(b.mapX)} ${fmt(b.mapY)}`);
+  }
+
+  return parts.join(' ');
+}
+
+function fmt(n) {
+  // Trim trailing zeros for compact path strings; SVG accepts plain decimals.
+  return Number.isFinite(n) ? Number(n.toFixed(2)).toString() : '0';
 }
 
 function syncNodeMarkers(group, points) {
@@ -553,10 +664,62 @@ function createOverlay(container) {
   svg.setAttribute('hidden', 'hidden');
   svg.style.pointerEvents = 'none';
 
-  const path = document.createElementNS(SVG_NS, 'polyline');
+  // <defs>: gradient (red -> black along the path) + arrowhead marker.
+  const defs = document.createElementNS(SVG_NS, 'defs');
+
+  const gradient = document.createElementNS(SVG_NS, 'linearGradient');
+  gradient.setAttribute('id', ARROW_GRADIENT_ID);
+  gradient.setAttribute('gradientUnits', 'userSpaceOnUse');
+  // x1/y1/x2/y2 are set per-render in updateOverlay to follow the path.
+  gradient.setAttribute('x1', '0');
+  gradient.setAttribute('y1', '0');
+  gradient.setAttribute('x2', '1');
+  gradient.setAttribute('y2', '0');
+
+  const stopStart = document.createElementNS(SVG_NS, 'stop');
+  stopStart.setAttribute('offset', '0%');
+  stopStart.setAttribute('stop-color', ARROW_COLOR_START);
+  stopStart.setAttribute('stop-opacity', '0.95');
+
+  const stopEnd = document.createElementNS(SVG_NS, 'stop');
+  stopEnd.setAttribute('offset', '100%');
+  stopEnd.setAttribute('stop-color', ARROW_COLOR_END);
+  stopEnd.setAttribute('stop-opacity', '1');
+
+  gradient.appendChild(stopStart);
+  gradient.appendChild(stopEnd);
+  defs.appendChild(gradient);
+
+  // Arrowhead marker. orient="auto" rotates with path tangent.
+  // viewBox 0..10, refX=8 lets the tip sit at the path end with a small
+  // overlap so it visually merges with the stroke.
+  const marker = document.createElementNS(SVG_NS, 'marker');
+  marker.setAttribute('id', ARROW_HEAD_ID);
+  marker.setAttribute('viewBox', '0 0 10 10');
+  marker.setAttribute('refX', '8');
+  marker.setAttribute('refY', '5');
+  marker.setAttribute('markerWidth', '4');
+  marker.setAttribute('markerHeight', '4');
+  marker.setAttribute('orient', 'auto-start-reverse');
+  marker.setAttribute('markerUnits', 'strokeWidth');
+
+  const headShape = document.createElementNS(SVG_NS, 'path');
+  // Wide-base arrowhead: a chunky chevron with rounded inset to match the
+  // reference screenshots (dark interior, light outline applied via CSS).
+  headShape.setAttribute('d', 'M 0 0 L 10 5 L 0 10 L 2.5 5 Z');
+  headShape.classList.add('vtt-measure-overlay__arrowhead');
+  marker.appendChild(headShape);
+  defs.appendChild(marker);
+
+  svg.appendChild(defs);
+
+  const path = document.createElementNS(SVG_NS, 'path');
   path.classList.add('vtt-measure-overlay__path');
   path.setAttribute('fill', 'none');
-  path.setAttribute('vector-effect', 'non-scaling-stroke');
+  path.setAttribute('stroke', `url(#${ARROW_GRADIENT_ID})`);
+  path.setAttribute('stroke-linecap', 'round');
+  path.setAttribute('stroke-linejoin', 'round');
+  path.setAttribute('marker-end', `url(#${ARROW_HEAD_ID})`);
   svg.appendChild(path);
 
   const nodes = document.createElementNS(SVG_NS, 'g');
@@ -577,7 +740,7 @@ function createOverlay(container) {
 
   container.appendChild(svg);
 
-  return { svg, path, nodes, labels, total };
+  return { svg, path, nodes, labels, total, gradient };
 }
 
 function syncOverlaySize(state) {

--- a/dnd/vtt/assets/js/ui/token-interactions.js
+++ b/dnd/vtt/assets/js/ui/token-interactions.js
@@ -407,9 +407,31 @@ export function createTokenInteractions({
           // pointer. updateTokenDrag re-applies this with translate3d.
           const rendered = renderedById.get(id);
           const scale = Number.isFinite(rendered?.scale) && rendered.scale > 0 ? rendered.scale : 1;
-          el.classList.add('is-dragging');
-          el.style.zIndex = '100000';
-          dragElements.set(id, { element: el, baseLeft, baseTop, scale });
+
+          // Ghost-drag UX: the original token stays pinned at its starting
+          // square (so the measurement arrow's tail anchors there), and a
+          // translucent clone follows the cursor as the drag preview. On
+          // drop, the ghost is removed and the real token teleports to the
+          // committed position via the existing renderTokens() pass.
+          let ghost = null;
+          const cloned = el.cloneNode(true);
+          if (cloned instanceof HTMLElement) {
+            // Strip identity attributes so DOM queries (`[data-placement-id]`,
+            // ID selectors, etc.) don't accidentally match the ghost.
+            cloned.removeAttribute('data-placement-id');
+            cloned.removeAttribute('id');
+            cloned.classList.add('vtt-token--drag-ghost');
+            cloned.classList.add('is-dragging');
+            cloned.style.zIndex = '100000';
+            cloned.style.pointerEvents = 'none';
+            cloned.style.transform = scale === 1
+              ? `translate3d(${baseLeft}px, ${baseTop}px, 0)`
+              : `translate3d(${baseLeft}px, ${baseTop}px, 0) scale(${scale})`;
+            tokenLayer.appendChild(cloned);
+            ghost = cloned;
+          }
+
+          dragElements.set(id, { element: el, ghost, baseLeft, baseTop, scale });
         }
       });
     }
@@ -505,7 +527,12 @@ export function createTokenInteractions({
         const left = lo + (pos.column ?? 0) * gridSize;
         const top = to + (pos.row ?? 0) * gridSize;
         const scale = Number.isFinite(cached.scale) && cached.scale > 0 ? cached.scale : 1;
-        cached.element.style.transform = scale === 1
+        // Move the ghost clone to follow the pointer; the original element
+        // stays anchored at its starting square. If the ghost couldn't be
+        // created for some reason, fall back to moving the original so
+        // the drag still functions.
+        const target = cached.ghost ?? cached.element;
+        target.style.transform = scale === 1
           ? `translate3d(${left}px, ${top}px, 0)`
           : `translate3d(${left}px, ${top}px, 0) scale(${scale})`;
       });
@@ -565,8 +592,13 @@ export function createTokenInteractions({
 
     // Clear CSS-transform drag elements before final render so renderTokens
     // applies authoritative positions from state without leftover transforms.
+    // In ghost-drag mode the original was never modified, but we still defensively
+    // strip is-dragging in case a fallback path applied it.
     if (dragElements) {
-      dragElements.forEach(({ element }) => {
+      dragElements.forEach(({ element, ghost }) => {
+        if (ghost && ghost.parentNode) {
+          ghost.parentNode.removeChild(ghost);
+        }
         element.classList.remove('is-dragging');
         element.style.zIndex = '';
       });


### PR DESCRIPTION
## Summary

Fixes four issues with the measurement tool and token drag UX so they reflect how D&D distance is actually counted and stay legible at any zoom.

- **Path follows king-move semantics.** The arrow used to draw a straight line even when distance was Chebyshev-counted, so the visual disagreed with the number. Now the path travels `min(|dx|,|dy|)` diagonal squares from the source, then `||dx|-|dy||` cardinal squares into the destination, with a smooth quadratic bend at the corner. Pure cardinal or pure 45° collapses to a straight line.
- **New arrow look.** `<polyline>` swapped for an SVG `<path>` with a red→black `linearGradient` (re-anchored to first→last point each render) and a chevron arrowhead `<marker>`. Stroke width = `gridSize × 0.32` so the arrow stays proportional at any zoom. Endpoint dots hidden in CSS (kept in DOM in case multi-waypoint mode wants them back).
- **Drag leaves the original token in place.** A translucent cloned ghost follows the cursor; on drop, the ghost is removed and the existing commit path re-renders the real token at the new square (visual "teleport"). The original anchors the measurement arrow's tail.
- **Distance HUD pinned to the viewport.** `.vtt-board__ruler` switched from `position: absolute` to `position: fixed` (plus `z-index` and `pointer-events: none`) so it stays visible regardless of map pan/zoom.

## Files changed

- `dnd/vtt/assets/js/ui/drag-ruler.js` — new `buildArrowPathD()`, `<defs>` with gradient + arrowhead marker, dynamic stroke width, gradient endpoints updated per render.
- `dnd/vtt/assets/js/ui/token-interactions.js` — `beginTokenDrag` clones a ghost; `updateTokenDrag` transforms the ghost; `endTokenDrag` removes it. Original element untouched during drag.
- `dnd/vtt/assets/css/board.css` — HUD `position: fixed`; arrow stroke styling moved off the path; `.vtt-token--drag-ghost` and `.vtt-measure-overlay__arrowhead` rules added; endpoint nodes hidden.

## Test plan

- [x] `npm test` — 488/488 passing
- [ ] Visual check: pure cardinal (e.g. 3 up) draws a straight line
- [ ] Visual check: pure 45° (e.g. 2 up + 2 right) draws a straight line
- [ ] Visual check: off-axis (e.g. 3 right + 1 up) leaves source diagonally, bends to horizontal into destination
- [ ] Visual check: arrow thickness scales correctly when grid size changes
- [ ] Visual check: gradient runs red at source → black at arrowhead
- [ ] Drag a token — original stays at its square, translucent ghost follows cursor, real token teleports on drop
- [ ] Drag is cancelled (e.g. Esc / right-click) — ghost vanishes, original unchanged
- [ ] Distance HUD remains visible at high zoom and after panning
- [ ] 2×2 token measurement anchors at footprint center (existing `measurementPointFromToken` logic, untouched)

## Reviewer notes

- Tuning knobs at the top of `drag-ruler.js`: `ARROW_STROKE_RATIO` (currently 0.32 of grid size), `ARROW_BEND_RADIUS_RATIO` (0.55), `ARROW_COLOR_START` / `ARROW_COLOR_END`. Adjust if the arrow head/bend look off at typical zoom.
- `position: fixed` only works as expected if no ancestor of `#vtt-distance-ruler` sets `transform`, `filter`, `perspective`, `contain: paint`, or `will-change: transform` (any of those create a containing block and re-anchor `fixed`). I didn't find one, but worth a smoke test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
