### PR TITLE
Snap players to their PC token's level on login

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -45,7 +45,10 @@
       "Bash(node --test \"dnd/vtt/assets/js/state/__tests__/map-levels-v2-normalization.test.mjs\")",
       "Bash(node -e \"import\\('./dnd/vtt/assets/js/state/normalize/map-levels.js'\\).then\\(m => console.log\\(Object.keys\\(m\\).sort\\(\\).join\\('\\\\n'\\)\\)\\)\")",
       "Bash(node --check \"dnd/vtt/assets/js/ui/board-interactions.js\")",
-      "Bash(git -C \"C:/Users/tasta/OneDrive/Documents/GitHub/gmscreen/.claude/worktrees/serene-shirley-0c90e8\" log --oneline -20)"
+      "Bash(git -C \"C:/Users/tasta/OneDrive/Documents/GitHub/gmscreen/.claude/worktrees/serene-shirley-0c90e8\" log --oneline -20)",
+      "Bash(node --test dnd/vtt/assets/js/state/__tests__/map-levels-v2-normalization.test.mjs)",
+      "Bash(node --test dnd/vtt/assets/js/state/__tests__/*.test.mjs)",
+      "Bash(node --test dnd/vtt/assets/js/services/__tests__/*.test.mjs dnd/vtt/assets/js/ui/__tests__/scene-manager-map-levels.test.mjs dnd/vtt/assets/js/ui/__tests__/map-level-renderer.test.mjs dnd/vtt/assets/js/ui/__tests__/token-levels.test.mjs)"
     ],
     "deny": []
   }

--- a/dnd/vtt/assets/js/bootstrap.js
+++ b/dnd/vtt/assets/js/bootstrap.js
@@ -21,6 +21,11 @@ import { mountMemoryMonitor } from './ui/memory-monitor.js'; // [REMOVABLE] Memo
 import { fetchScenes } from './services/scene-service.js';
 import { fetchTokens } from './services/token-service.js';
 import { fetchBoardState } from './services/board-state-service.js';
+import {
+  BASE_MAP_LEVEL_ID,
+  normalizeMapLevelsState,
+  resolvePcTokenLevelIdForUser,
+} from './state/normalize/map-levels.js';
 
 async function bootstrap() {
   const config = window.vttConfig ?? {};
@@ -171,6 +176,7 @@ async function hydrateFromServer(routes, userContext) {
               authorIsGm: false,
               authorRole: 'player',
             };
+            applyPcTokenLevelOverride(nextBoardState, currentState?.user?.name);
           }
           draft.boardState = nextBoardState;
         }
@@ -179,6 +185,54 @@ async function hydrateFromServer(routes, userContext) {
   } catch (error) {
     console.warn('[VTT] Failed to hydrate data', error);
   }
+}
+
+// On player login, snap the viewer to the level of their claimed PC token
+// so a stale `userLevelState[userId]` (mutated by a GM Activate while the
+// player was away) does not strand them on the wrong level. The override
+// only fires here, on page load — once it writes a fresh entry, the normal
+// resolver chain handles in-session navigation. We skip silently when the
+// player has zero or 2+ PC-named claims (the existing chain handles those).
+function applyPcTokenLevelOverride(nextBoardState, userName) {
+  const userKey = typeof userName === 'string' ? userName.trim().toLowerCase() : '';
+  if (!userKey) return;
+  const sceneId =
+    typeof nextBoardState?.activeSceneId === 'string' ? nextBoardState.activeSceneId : '';
+  if (!sceneId) return;
+  if (!nextBoardState.sceneState || typeof nextBoardState.sceneState !== 'object') {
+    nextBoardState.sceneState = {};
+  }
+  const sceneEntry =
+    nextBoardState.sceneState[sceneId] && typeof nextBoardState.sceneState[sceneId] === 'object'
+      ? nextBoardState.sceneState[sceneId]
+      : null;
+  if (!sceneEntry) return;
+  const placements = Array.isArray(nextBoardState.placements?.[sceneId])
+    ? nextBoardState.placements[sceneId]
+    : [];
+  const normalizedMapLevels = normalizeMapLevelsState(sceneEntry.mapLevels ?? null, {
+    sceneGrid: sceneEntry.grid ?? null,
+  });
+  const validLevelIds = [BASE_MAP_LEVEL_ID];
+  normalizedMapLevels.levels.forEach((level) => {
+    if (level && typeof level.id === 'string' && level.id) {
+      validLevelIds.push(level.id);
+    }
+  });
+  const pcLevelId = resolvePcTokenLevelIdForUser({
+    sceneState: sceneEntry,
+    userId: userKey,
+    placements,
+    validLevelIds,
+  });
+  if (!pcLevelId) return;
+  if (!sceneEntry.userLevelState || typeof sceneEntry.userLevelState !== 'object') {
+    sceneEntry.userLevelState = {};
+  }
+  sceneEntry.userLevelState[userKey] = {
+    levelId: pcLevelId,
+    _lastModified: Date.now(),
+  };
 }
 
 document.addEventListener('DOMContentLoaded', bootstrap);

--- a/dnd/vtt/assets/js/state/__tests__/map-levels-v2-normalization.test.mjs
+++ b/dnd/vtt/assets/js/state/__tests__/map-levels-v2-normalization.test.mjs
@@ -12,6 +12,7 @@ import {
   normalizeUserLevelStateEntry,
   normalizeUserLevelStateMap,
   resolveActiveLevelIdForUser,
+  resolvePcTokenLevelIdForUser,
   resolvePlacementLevelId,
 } from '../normalize/map-levels.js';
 import { normalizeSceneBoardState } from '../normalize/scene-board-state.js';
@@ -280,6 +281,135 @@ describe('Levels v2 — resolveActiveLevelIdForUser', () => {
         placements,
       }),
       BASE_MAP_LEVEL_ID,
+    );
+  });
+});
+
+describe('Login-time PC token resolver — resolvePcTokenLevelIdForUser', () => {
+  test('returns null without a userId or sceneState', () => {
+    assert.equal(resolvePcTokenLevelIdForUser({}), null);
+    assert.equal(resolvePcTokenLevelIdForUser({ userId: 'sharon' }), null);
+    assert.equal(
+      resolvePcTokenLevelIdForUser({ sceneState: { claimedTokens: {} } }),
+      null,
+    );
+  });
+
+  test('returns the level of a single PC-named claimed token', () => {
+    const sceneState = { claimedTokens: { 't1': 'sharon' } };
+    const placements = [
+      { id: 't1', name: 'Sharon Stormwind', levelId: 'map-level-a' },
+    ];
+    assert.equal(
+      resolvePcTokenLevelIdForUser({
+        sceneState,
+        userId: 'SHARON',
+        placements,
+        validLevelIds: ['level-0', 'map-level-a'],
+      }),
+      'map-level-a',
+    );
+  });
+
+  test('ignores claimed tokens whose name does not contain the PC alias', () => {
+    // e.g. a familiar/summon claimed by the player but not named after them.
+    const sceneState = { claimedTokens: { 't1': 'sharon', 't2': 'sharon' } };
+    const placements = [
+      { id: 't1', name: 'Inkfang the Familiar', levelId: 'map-level-a' },
+      { id: 't2', name: 'Sharon Stormwind', levelId: 'map-level-b' },
+    ];
+    assert.equal(
+      resolvePcTokenLevelIdForUser({
+        sceneState,
+        userId: 'sharon',
+        placements,
+        validLevelIds: ['level-0', 'map-level-a', 'map-level-b'],
+      }),
+      'map-level-b',
+    );
+  });
+
+  test('returns null when two PC-named tokens are claimed', () => {
+    const sceneState = { claimedTokens: { 't1': 'sharon', 't2': 'sharon' } };
+    const placements = [
+      { id: 't1', name: 'Sharon (illusion)', levelId: 'map-level-a' },
+      { id: 't2', name: 'Sharon Stormwind', levelId: 'map-level-b' },
+    ];
+    assert.equal(
+      resolvePcTokenLevelIdForUser({
+        sceneState,
+        userId: 'sharon',
+        placements,
+        validLevelIds: ['level-0', 'map-level-a', 'map-level-b'],
+      }),
+      null,
+    );
+  });
+
+  test('returns null when the only PC token is on an unknown level', () => {
+    const sceneState = { claimedTokens: { 't1': 'indigo' } };
+    const placements = [
+      { id: 't1', name: 'Indigo', levelId: 'map-level-deleted' },
+    ];
+    assert.equal(
+      resolvePcTokenLevelIdForUser({
+        sceneState,
+        userId: 'indigo',
+        placements,
+        validLevelIds: ['level-0', 'map-level-a'],
+      }),
+      null,
+    );
+  });
+
+  test('does not match a token claimed by another user', () => {
+    const sceneState = { claimedTokens: { 't1': 'sharon' } };
+    const placements = [
+      { id: 't1', name: 'Sharon Stormwind', levelId: 'map-level-a' },
+    ];
+    assert.equal(
+      resolvePcTokenLevelIdForUser({
+        sceneState,
+        userId: 'indigo',
+        placements,
+      }),
+      null,
+    );
+  });
+
+  test('matches the alias only on word boundaries (no substring hits)', () => {
+    // Guards against e.g. "Frunkster" matching "frunk" — board-interactions'
+    // matchProfileByName uses the same word-boundary rule.
+    const sceneState = { claimedTokens: { 't1': 'frunk' } };
+    const placements = [
+      { id: 't1', name: 'Frunkster Lookalike', levelId: 'map-level-a' },
+    ];
+    assert.equal(
+      resolvePcTokenLevelIdForUser({
+        sceneState,
+        userId: 'frunk',
+        placements,
+      }),
+      null,
+    );
+  });
+
+  test('returns the PC token level even when claims map has stale entries', () => {
+    // claim entries pointing at placements that no longer exist must not
+    // crash or count toward the match total.
+    const sceneState = {
+      claimedTokens: { 't1': 'zepha', 'gone': 'zepha' },
+    };
+    const placements = [
+      { id: 't1', name: 'Zepha Brightspark', levelId: 'map-level-a' },
+    ];
+    assert.equal(
+      resolvePcTokenLevelIdForUser({
+        sceneState,
+        userId: 'zepha',
+        placements,
+      }),
+      'map-level-a',
     );
   });
 });

--- a/dnd/vtt/assets/js/state/normalize/map-levels.js
+++ b/dnd/vtt/assets/js/state/normalize/map-levels.js
@@ -450,6 +450,70 @@ export function resolveActiveLevelIdForUser({
 }
 
 /**
+ * Login-time helper: resolve the level id of the user's claimed PC token
+ * for a scene, matching board-interactions' name-based PC inference. A
+ * placement is treated as a PC token when (a) it is claimed by `userId`
+ * in `sceneState.claimedTokens` and (b) its `name`, normalized to
+ * lowercased space-separated words, contains `userId` as a whole word
+ * (the same rule as `matchProfileByName` / auto-claim on first drag).
+ *
+ * Returns the matching placement's level id only when exactly one PC
+ * token exists for the user. With zero or two-plus PC matches we return
+ * `null` so the caller can fall back to the existing
+ * `resolveActiveLevelIdForUser` chain. This is intended to be called
+ * once on session start (see bootstrap.js) to overwrite a stale
+ * `userLevelState[userId]` entry — it is not a per-render resolver.
+ */
+export function resolvePcTokenLevelIdForUser({
+  sceneState = null,
+  userId = null,
+  placements = null,
+  validLevelIds = null,
+} = {}) {
+  const userKey = typeof userId === 'string' ? userId.trim().toLowerCase() : '';
+  if (!userKey || !sceneState || typeof sceneState !== 'object') {
+    return null;
+  }
+  const claims = sceneState.claimedTokens;
+  if (!claims || typeof claims !== 'object' || !Array.isArray(placements)) {
+    return null;
+  }
+  const validSet = Array.isArray(validLevelIds)
+    ? new Set(validLevelIds.filter((id) => typeof id === 'string' && id))
+    : null;
+  const isValidLevelId = (levelId) => {
+    if (typeof levelId !== 'string' || !levelId) {
+      return false;
+    }
+    if (!validSet || validSet.size === 0) {
+      return true;
+    }
+    return validSet.has(levelId);
+  };
+  const namePattern = new RegExp(`(^|\\s)${userKey}(\\s|$)`);
+
+  let matchedLevelId = null;
+  let matchCount = 0;
+  for (const placement of placements) {
+    if (!placement || typeof placement !== 'object') continue;
+    const placementId = typeof placement.id === 'string' ? placement.id : '';
+    if (!placementId) continue;
+    if (claims[placementId] !== userKey) continue;
+    const rawName = typeof placement.name === 'string' ? placement.name : '';
+    const normalizedName = rawName.toLowerCase().replace(/[^a-z0-9]+/g, ' ').trim();
+    if (!normalizedName || !namePattern.test(normalizedName)) continue;
+    const placementLevelId = resolvePlacementLevelId(placement);
+    if (!isValidLevelId(placementLevelId)) continue;
+    matchCount += 1;
+    if (matchCount > 1) {
+      return null;
+    }
+    matchedLevelId = placementLevelId;
+  }
+  return matchCount === 1 ? matchedLevelId : null;
+}
+
+/**
  * Levels v2: normalize the per-scene `claimedTokens` map. Keys are
  * placement ids, values are normalized profile ids. Invalid entries are
  * dropped silently.


### PR DESCRIPTION
A GM "Activate"-pulling players to a level mutates each player's saved userLevelState entry. If a player was away when that happened, they'd log back in on the wrong level. On login (bootstrap hydration) for non-GM users, find the user's single PC-named claimed token and overwrite their userLevelState for the active scene to that token's level. Two-plus PC-named claims or zero claims fall through to the existing resolver chain so in-session navigation still works.