### PR TITLE
Make map-level Auto/Always toggle visible and move Hide to a button

### DIFF
--- a/dnd/vtt/assets/css/settings.css
+++ b/dnd/vtt/assets/css/settings.css
@@ -954,72 +954,29 @@
   min-width: 0;
 }
 
-.scene-level__visibility,
-.scene-level__hide {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  flex: 0 0 auto;
-  gap: 0.25rem;
-}
-
-.scene-level__hide-label {
-  font-size: 0.7rem;
-  color: var(--vtt-text-secondary);
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-}
-
 .scene-level__display-mode {
   flex: 0 0 auto;
-  min-width: 3.4rem;
+  min-width: 3.6rem;
   font-size: 0.7rem;
   text-transform: uppercase;
   letter-spacing: 0.04em;
+  background: rgba(125, 200, 230, 0.14);
+  border-color: rgba(125, 200, 230, 0.45);
+  color: var(--vtt-text-primary);
 }
 
-.scene-level__checkbox {
-  appearance: none;
-  width: 28px;
-  height: 18px;
-  border-radius: var(--vtt-radius);
-  background: rgba(125, 200, 230, 0.16);
-  border: 1px solid rgba(125, 200, 230, 0.5);
-  position: relative;
-  cursor: pointer;
-  transition: background var(--vtt-transition), border-color var(--vtt-transition);
+.scene-level__display-mode:hover {
+  background: rgba(125, 200, 230, 0.26);
 }
 
-.scene-level__checkbox::after {
-  content: '';
-  position: absolute;
-  top: 3px;
-  left: 3px;
-  width: 10px;
-  height: 10px;
-  border-radius: calc(var(--vtt-radius) - 2px);
-  background: #e7f8ff;
-  transition: transform var(--vtt-transition), background var(--vtt-transition);
+.scene-level__display-mode[data-map-level-display-mode='always'] {
+  background: rgba(213, 155, 90, 0.32);
+  border-color: rgba(213, 155, 90, 0.7);
+  color: #fff;
 }
 
-.scene-level__checkbox:checked {
-  background: rgba(125, 200, 230, 0.38);
-  border-color: rgba(125, 200, 230, 0.88);
-}
-
-.scene-level__checkbox:checked::after {
-  transform: translateX(12px);
-  background: #f8fdff;
-}
-
-.scene-level__checkbox:disabled {
-  cursor: not-allowed;
-  opacity: 0.4;
-}
-
-.scene-level__checkbox:focus-visible {
-  outline: 2px solid rgba(186, 230, 253, 0.85);
-  outline-offset: 2px;
+.scene-level__display-mode[data-map-level-display-mode='always']:hover {
+  background: rgba(213, 155, 90, 0.42);
 }
 
 .scene-level__name {

--- a/dnd/vtt/assets/js/ui/__tests__/scene-manager-map-levels.test.mjs
+++ b/dnd/vtt/assets/js/ui/__tests__/scene-manager-map-levels.test.mjs
@@ -150,7 +150,7 @@ describe('scene manager map level controls', () => {
     assert.equal(Object.prototype.hasOwnProperty.call(level, 'visible'), false);
   });
 
-  test('Levels v3: scene markup renders the mode toggle button and the hide checkbox', () => {
+  test('Levels v3: scene markup renders the mode toggle button and the hide button', () => {
     const state = createInitialState({
       mapLevels: {
         activeLevelId: 'upper',
@@ -178,6 +178,9 @@ describe('scene manager map level controls', () => {
     assert.match(markup, /data-action="cycle-map-level-display-mode"/);
     assert.match(markup, /data-action="toggle-map-level-hide"/);
     assert.match(markup, /data-map-level-display-mode="always"/);
+    // Hide is a button now, not a checkbox.
+    assert.doesNotMatch(markup, /type="checkbox"[^>]*data-action="toggle-map-level-hide"/);
+    assert.doesNotMatch(markup, /scene-level__hide-checkbox/);
     // Old single visibility checkbox is gone.
     assert.doesNotMatch(markup, /data-action="toggle-map-level-visibility"/);
   });

--- a/dnd/vtt/assets/js/ui/scene-manager.js
+++ b/dnd/vtt/assets/js/ui/scene-manager.js
@@ -1263,28 +1263,17 @@ function renderMapLevelListItem(sceneId, mapLevelsState, level, index, levels, o
       <div class="scene-level__header">
         <button
           type="button"
-          class="btn btn--ghost btn--tiny scene-level__display-mode"
+          class="btn btn--tiny scene-level__display-mode${displayMode === 'always' ? ' is-active' : ''}"
           data-action="cycle-map-level-display-mode"
           data-scene-id="${sceneId}"
           data-map-level-id="${level.id}"
           data-map-level-display-mode="${displayMode}"
           aria-label="Map level display mode: ${modeLabel}. Click to toggle."
+          aria-pressed="${displayMode === 'always' ? 'true' : 'false'}"
           title="${escapeHtml(modeTitle)}"
         >
           ${modeLabel}
         </button>
-        <label class="scene-level__hide" title="Hide this level for everyone (overrides display mode).">
-          <input
-            type="checkbox"
-            class="scene-level__checkbox scene-level__hide-checkbox"
-            data-action="toggle-map-level-hide"
-            data-scene-id="${sceneId}"
-            data-map-level-id="${level.id}"
-            aria-label="${hidden ? 'Unhide map level' : 'Hide map level'}"
-            ${hidden ? 'checked' : ''}
-          />
-          <span class="scene-level__hide-label">Hide</span>
-        </label>
         <span class="scene-level__name" title="${name}">${name}</span>
         <span class="scene-level__map-state">${hasMap ? 'Map' : 'No Map'}</span>
       </div>
@@ -1356,6 +1345,17 @@ function renderMapLevelListItem(sceneId, mapLevelsState, level, index, levels, o
           ${canRaise ? '' : 'disabled'}
         >
           Raise
+        </button>
+        <button
+          type="button"
+          class="btn btn--ghost btn--tiny scene-level__hide"
+          data-action="toggle-map-level-hide"
+          data-scene-id="${sceneId}"
+          data-map-level-id="${level.id}"
+          aria-pressed="${hidden ? 'true' : 'false'}"
+          title="Hide this level for everyone (overrides display mode)."
+        >
+          ${hidden ? 'Unhide' : 'Hide'}
         </button>
         <button
           type="button"


### PR DESCRIPTION
The per-level row used .btn--ghost on the mode toggle, which zeroes out background and border, so "AUTO" rendered as plain text and looked like a label. The Hide checkbox next to it used the slider-toggle style, so the row read as a single 2-state switch flipping between Auto and Hide — users couldn't reach Always.

- Mode toggle now uses a non-ghost button with a real background/border in Auto and an accent fill in Always so the active state is obvious.
- Hide moves out of the header into the controls row as a ghost button alongside Upload/Rename/Cutouts/Lower/Raise/Delete; label flips to "Unhide" when hidden. Action name unchanged so the existing handler keeps working.
- Drop the now-unused .scene-level__checkbox slider styles and the header .scene-level__hide / .scene-level__hide-label rules.
- Update the markup test to assert Hide is a button, not a checkbox.