### PR TITLE
Per-level fog of war with cutout cascade and grid alignment fix

### DIFF
--- a/dnd/data/version.json
+++ b/dnd/data/version.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.7.29",
-    "last_updated": "2026-04-27 00:00:00",
-    "build_number": 36
+    "version": "1.8.0",
+    "last_updated": "2026-04-28 00:00:00",
+    "build_number": 37
 }

--- a/dnd/vtt/api/state.php
+++ b/dnd/vtt/api/state.php
@@ -2849,7 +2849,7 @@ function extractCombatUpdates(array $sceneStateUpdates): array
  * @param mixed $raw
  * @return array<string,mixed>|null
  */
-function normalizeFogOfWarPayload($raw): ?array
+function normalizeLevelFogEntry($raw): ?array
 {
     if (!is_array($raw)) {
         return null;
@@ -2879,6 +2879,52 @@ function normalizeFogOfWarPayload($raw): ?array
     return [
         'enabled' => $enabled,
         'revealedCells' => empty($revealedCells) ? new \stdClass() : $revealedCells,
+    ];
+}
+
+/**
+ * Per-level fog. New shape: { byLevel: { [levelId]: { enabled, revealedCells } } }.
+ * Legacy { enabled, revealedCells } at the top level migrates to Level 0.
+ *
+ * @param mixed $raw
+ * @return array<string,mixed>|null
+ */
+function normalizeFogOfWarPayload($raw): ?array
+{
+    if (!is_array($raw)) {
+        return null;
+    }
+
+    $byLevel = [];
+
+    if (isset($raw['byLevel']) && is_array($raw['byLevel'])) {
+        foreach ($raw['byLevel'] as $levelId => $levelRaw) {
+            if (!is_string($levelId)) {
+                continue;
+            }
+            $key = trim($levelId);
+            if ($key === '') {
+                continue;
+            }
+            $entry = normalizeLevelFogEntry($levelRaw);
+            if ($entry !== null) {
+                $byLevel[$key] = $entry;
+            }
+        }
+    }
+
+    if (empty($byLevel)) {
+        $legacy = normalizeLevelFogEntry($raw);
+        if ($legacy !== null) {
+            $hasCells = is_array($legacy['revealedCells']) && !empty($legacy['revealedCells']);
+            if (!empty($legacy['enabled']) || $hasCells) {
+                $byLevel['level-0'] = $legacy;
+            }
+        }
+    }
+
+    return [
+        'byLevel' => empty($byLevel) ? new \stdClass() : $byLevel,
     ];
 }
 

--- a/dnd/vtt/assets/js/bootstrap.js
+++ b/dnd/vtt/assets/js/bootstrap.js
@@ -140,28 +140,48 @@ async function hydrateFromServer(routes, userContext) {
             ...normalizedBoard,
           };
           // Re-merge fogOfWar from existing scene entries that had cells.
+          // Per-level shape: walk byLevel[levelId].revealedCells.
           if (existingSceneState && typeof existingSceneState === 'object' &&
               nextBoardState.sceneState && typeof nextBoardState.sceneState === 'object') {
             Object.keys(existingSceneState).forEach((sid) => {
               const existingFog = existingSceneState[sid]?.fogOfWar;
               if (!existingFog || typeof existingFog !== 'object') return;
-              const existingCells = existingFog.revealedCells;
-              if (!existingCells || typeof existingCells !== 'object' ||
-                  Object.keys(existingCells).length === 0) return;
+              const existingByLevel = existingFog.byLevel;
+              if (!existingByLevel || typeof existingByLevel !== 'object') return;
+
               const target = nextBoardState.sceneState[sid];
               if (!target || typeof target !== 'object') return;
               if (!target.fogOfWar || typeof target.fogOfWar !== 'object') {
                 target.fogOfWar = JSON.parse(JSON.stringify(existingFog));
-              } else {
-                if (!target.fogOfWar.revealedCells || typeof target.fogOfWar.revealedCells !== 'object') {
-                  target.fogOfWar.revealedCells = {};
+                return;
+              }
+              if (!target.fogOfWar.byLevel || typeof target.fogOfWar.byLevel !== 'object'
+                  || Array.isArray(target.fogOfWar.byLevel)) {
+                target.fogOfWar.byLevel = {};
+              }
+
+              Object.keys(existingByLevel).forEach((levelId) => {
+                const existingLevel = existingByLevel[levelId];
+                if (!existingLevel || typeof existingLevel !== 'object') return;
+                const existingCells = existingLevel.revealedCells;
+                if (!existingCells || typeof existingCells !== 'object'
+                    || Object.keys(existingCells).length === 0) return;
+
+                let targetLevel = target.fogOfWar.byLevel[levelId];
+                if (!targetLevel || typeof targetLevel !== 'object') {
+                  target.fogOfWar.byLevel[levelId] = JSON.parse(JSON.stringify(existingLevel));
+                  return;
+                }
+                if (!targetLevel.revealedCells || typeof targetLevel.revealedCells !== 'object'
+                    || Array.isArray(targetLevel.revealedCells)) {
+                  targetLevel.revealedCells = {};
                 }
                 Object.keys(existingCells).forEach((key) => {
-                  if (!(key in target.fogOfWar.revealedCells)) {
-                    target.fogOfWar.revealedCells[key] = true;
+                  if (!(key in targetLevel.revealedCells)) {
+                    targetLevel.revealedCells[key] = true;
                   }
                 });
-              }
+              });
             });
           }
           if (!currentIsGM) {

--- a/dnd/vtt/assets/js/state/__tests__/fog-array-coercion.test.mjs
+++ b/dnd/vtt/assets/js/state/__tests__/fog-array-coercion.test.mjs
@@ -7,6 +7,8 @@
  * arr["36,66"] = true creates an "expando property" that JSON.stringify()
  * silently drops (non-numeric keys on arrays are ignored). Since getState()
  * uses JSON.parse(JSON.stringify(state)), all fog cells vanish.
+ *
+ * Per-level shape: fogOfWar.byLevel[levelId] = { enabled, revealedCells }.
  */
 
 import { test, describe } from 'node:test';
@@ -24,15 +26,15 @@ import { mergeBoardStateSnapshot } from '../../ui/board-interactions.js';
 // store.js — normalizeFogOfWarEntry (via initializeState)
 // ---------------------------------------------------------------------------
 
-describe('store normalization: array revealedCells coercion', () => {
-  test('initializeState coerces revealedCells array to empty object', () => {
+describe('store normalization: legacy migration + array coercion', () => {
+  test('legacy { enabled, revealedCells } migrates to byLevel["level-0"]', () => {
     initializeState({
       boardState: {
         activeSceneId: 'scene-1',
         sceneState: {
           'scene-1': {
             grid: { size: 64, locked: false, visible: true },
-            fogOfWar: { enabled: true, revealedCells: [] },
+            fogOfWar: { enabled: true, revealedCells: { '5,5': true } },
           },
         },
       },
@@ -41,11 +43,38 @@ describe('store normalization: array revealedCells coercion', () => {
 
     const state = getState();
     const fog = state.boardState.sceneState['scene-1'].fogOfWar;
-    assert.ok(fog, 'fogOfWar should exist');
-    assert.equal(fog.enabled, true);
-    assert.ok(!Array.isArray(fog.revealedCells), 'revealedCells must not be an array');
-    assert.equal(typeof fog.revealedCells, 'object');
-    assert.deepEqual(fog.revealedCells, {}, 'empty array should become empty object');
+    assert.ok(fog && fog.byLevel, 'byLevel should exist');
+    const level0 = fog.byLevel['level-0'];
+    assert.ok(level0, 'legacy fog should migrate to Level 0');
+    assert.equal(level0.enabled, true);
+    assert.equal(level0.revealedCells['5,5'], true);
+  });
+
+  test('initializeState coerces byLevel revealedCells array to empty object', () => {
+    initializeState({
+      boardState: {
+        activeSceneId: 'scene-1',
+        sceneState: {
+          'scene-1': {
+            grid: { size: 64, locked: false, visible: true },
+            fogOfWar: {
+              byLevel: {
+                'level-0': { enabled: true, revealedCells: [] },
+              },
+            },
+          },
+        },
+      },
+      user: { isGM: true, name: 'GM' },
+    });
+
+    const state = getState();
+    const level0 = state.boardState.sceneState['scene-1'].fogOfWar.byLevel['level-0'];
+    assert.ok(level0, 'level-0 fog should exist');
+    assert.equal(level0.enabled, true);
+    assert.ok(!Array.isArray(level0.revealedCells), 'revealedCells must not be an array');
+    assert.equal(typeof level0.revealedCells, 'object');
+    assert.deepEqual(level0.revealedCells, {}, 'empty array should become empty object');
   });
 
   test('cells added after array coercion survive getState round-trip', () => {
@@ -55,29 +84,32 @@ describe('store normalization: array revealedCells coercion', () => {
         sceneState: {
           'scene-1': {
             grid: { size: 64, locked: false, visible: true },
-            fogOfWar: { enabled: true, revealedCells: [] },
+            fogOfWar: {
+              byLevel: {
+                'level-0': { enabled: true, revealedCells: [] },
+              },
+            },
           },
         },
       },
       user: { isGM: true, name: 'GM' },
     });
 
-    // Simulate applyFogChange adding cells
     updateState((draft) => {
-      const fog = draft.boardState.sceneState['scene-1'].fogOfWar;
-      if (!fog.revealedCells || typeof fog.revealedCells !== 'object' || Array.isArray(fog.revealedCells)) {
-        fog.revealedCells = {};
+      const level0 = draft.boardState.sceneState['scene-1'].fogOfWar.byLevel['level-0'];
+      if (!level0.revealedCells || typeof level0.revealedCells !== 'object'
+          || Array.isArray(level0.revealedCells)) {
+        level0.revealedCells = {};
       }
-      fog.revealedCells['36,66'] = true;
-      fog.revealedCells['0,0'] = true;
+      level0.revealedCells['36,66'] = true;
+      level0.revealedCells['0,0'] = true;
     });
 
     const state = getState();
-    const fog = state.boardState.sceneState['scene-1'].fogOfWar;
-    assert.equal(Object.keys(fog.revealedCells).length, 2,
-      'should have 2 revealed cells after adding to coerced object');
-    assert.equal(fog.revealedCells['36,66'], true);
-    assert.equal(fog.revealedCells['0,0'], true);
+    const level0 = state.boardState.sceneState['scene-1'].fogOfWar.byLevel['level-0'];
+    assert.equal(Object.keys(level0.revealedCells).length, 2);
+    assert.equal(level0.revealedCells['36,66'], true);
+    assert.equal(level0.revealedCells['0,0'], true);
   });
 
   test('JSON.parse(JSON.stringify()) preserves cells after coercion', () => {
@@ -87,7 +119,11 @@ describe('store normalization: array revealedCells coercion', () => {
         sceneState: {
           'scene-1': {
             grid: { size: 64, locked: false, visible: true },
-            fogOfWar: { enabled: true, revealedCells: [] },
+            fogOfWar: {
+              byLevel: {
+                'level-0': { enabled: true, revealedCells: [] },
+              },
+            },
           },
         },
       },
@@ -95,21 +131,20 @@ describe('store normalization: array revealedCells coercion', () => {
     });
 
     updateState((draft) => {
-      const fog = draft.boardState.sceneState['scene-1'].fogOfWar;
-      if (Array.isArray(fog.revealedCells)) fog.revealedCells = {};
-      fog.revealedCells['5,10'] = true;
-      fog.revealedCells['20,30'] = true;
+      const level0 = draft.boardState.sceneState['scene-1'].fogOfWar.byLevel['level-0'];
+      if (Array.isArray(level0.revealedCells)) level0.revealedCells = {};
+      level0.revealedCells['5,10'] = true;
+      level0.revealedCells['20,30'] = true;
     });
 
-    // This is exactly what getState() does internally
     const state = getState();
     const roundTripped = JSON.parse(JSON.stringify(state));
-    const fog = roundTripped.boardState.sceneState['scene-1'].fogOfWar;
+    const level0 = roundTripped.boardState.sceneState['scene-1'].fogOfWar.byLevel['level-0'];
 
-    assert.ok(!Array.isArray(fog.revealedCells), 'round-tripped revealedCells must not be array');
-    assert.equal(Object.keys(fog.revealedCells).length, 2);
-    assert.equal(fog.revealedCells['5,10'], true);
-    assert.equal(fog.revealedCells['20,30'], true);
+    assert.ok(!Array.isArray(level0.revealedCells), 'round-tripped revealedCells must not be array');
+    assert.equal(Object.keys(level0.revealedCells).length, 2);
+    assert.equal(level0.revealedCells['5,10'], true);
+    assert.equal(level0.revealedCells['20,30'], true);
   });
 });
 
@@ -119,25 +154,20 @@ describe('store normalization: array revealedCells coercion', () => {
 
 describe('original bug demonstration', () => {
   test('expando properties on arrays are lost by JSON.stringify', () => {
-    // This is exactly what happened before the fix
     const arr = [];
     arr['36,66'] = true;
     arr['0,0'] = true;
 
-    // Object.keys sees the expando properties
     assert.equal(Object.keys(arr).length, 2, 'Object.keys sees expando properties');
 
-    // But JSON.stringify silently drops them
     const json = JSON.stringify(arr);
     assert.equal(json, '[]', 'JSON.stringify drops non-numeric array keys');
 
-    // After round-trip, the data is gone
     const parsed = JSON.parse(json);
     assert.equal(Object.keys(parsed).length, 0, 'data is lost after round-trip');
   });
 
   test('plain objects preserve string keys through JSON round-trip', () => {
-    // This is the correct behavior after the fix
     const obj = {};
     obj['36,66'] = true;
     obj['0,0'] = true;
@@ -155,14 +185,18 @@ describe('original bug demonstration', () => {
 // mergeBoardStateSnapshot — mergeSceneStatePreservingGrid array coercion
 // ---------------------------------------------------------------------------
 
-describe('mergeBoardStateSnapshot: array revealedCells coercion', () => {
-  test('incoming array revealedCells is coerced to object during merge', () => {
+describe('mergeBoardStateSnapshot: per-level array revealedCells coercion', () => {
+  test('incoming array revealedCells on a level is coerced to object', () => {
     const existing = {
       activeSceneId: 'scene-1',
       sceneState: {
         'scene-1': {
           grid: { size: 64, locked: false, visible: true },
-          fogOfWar: { enabled: true, revealedCells: { '5,5': true } },
+          fogOfWar: {
+            byLevel: {
+              'level-0': { enabled: true, revealedCells: { '5,5': true } },
+            },
+          },
         },
       },
       placements: {},
@@ -175,9 +209,11 @@ describe('mergeBoardStateSnapshot: array revealedCells coercion', () => {
       sceneState: {
         'scene-1': {
           grid: { size: 64, locked: false, visible: true },
-          // Server returns [] for empty revealedCells (the PHP bug)
-          // This means the GM has re-fogged everything — no cells should be revealed
-          fogOfWar: { enabled: true, revealedCells: [] },
+          fogOfWar: {
+            byLevel: {
+              'level-0': { enabled: true, revealedCells: [] },
+            },
+          },
         },
       },
       placements: {},
@@ -186,24 +222,28 @@ describe('mergeBoardStateSnapshot: array revealedCells coercion', () => {
     };
 
     const merged = mergeBoardStateSnapshot(existing, incoming);
-    const fog = merged.sceneState['scene-1'].fogOfWar;
+    const level0 = merged.sceneState['scene-1'].fogOfWar.byLevel['level-0'];
 
-    assert.ok(!Array.isArray(fog.revealedCells),
+    assert.ok(!Array.isArray(level0.revealedCells),
       'merged revealedCells must not be an array');
-    assert.equal(typeof fog.revealedCells, 'object');
-    // Server state is authoritative — empty incoming means GM re-fogged everything.
-    // Previously this used a union merge which prevented fog from being added back.
-    assert.deepStrictEqual(fog.revealedCells, {},
-      'empty incoming revealedCells means all cells are fogged');
+    assert.equal(typeof level0.revealedCells, 'object');
+    // Incoming is authoritative for that level — empty incoming means GM re-fogged
+    // everything on Level 0.
+    assert.deepStrictEqual(level0.revealedCells, {});
   });
 
-  test('both sides have array revealedCells — result is always object', () => {
+  test('per-level merge: existing levels not in incoming are preserved', () => {
     const existing = {
       activeSceneId: 'scene-1',
       sceneState: {
         'scene-1': {
           grid: { size: 64, locked: false, visible: true },
-          fogOfWar: { enabled: true, revealedCells: [] },
+          fogOfWar: {
+            byLevel: {
+              'level-0': { enabled: true, revealedCells: { '1,1': true } },
+              'level-A': { enabled: true, revealedCells: { '2,2': true } },
+            },
+          },
         },
       },
       placements: {},
@@ -216,7 +256,12 @@ describe('mergeBoardStateSnapshot: array revealedCells coercion', () => {
       sceneState: {
         'scene-1': {
           grid: { size: 64, locked: false, visible: true },
-          fogOfWar: { enabled: true, revealedCells: [] },
+          fogOfWar: {
+            // Only level-0 in incoming — level-A should be preserved from existing.
+            byLevel: {
+              'level-0': { enabled: true, revealedCells: { '1,1': true, '3,3': true } },
+            },
+          },
         },
       },
       placements: {},
@@ -225,14 +270,14 @@ describe('mergeBoardStateSnapshot: array revealedCells coercion', () => {
     };
 
     const merged = mergeBoardStateSnapshot(existing, incoming);
-    const fog = merged.sceneState['scene-1'].fogOfWar;
-
-    assert.ok(!Array.isArray(fog.revealedCells),
-      'revealedCells must be a plain object even when both sides are arrays');
-    assert.deepEqual(fog.revealedCells, {});
+    const byLevel = merged.sceneState['scene-1'].fogOfWar.byLevel;
+    assert.deepStrictEqual(byLevel['level-0'].revealedCells, { '1,1': true, '3,3': true },
+      'level-0 should reflect incoming');
+    assert.ok(byLevel['level-A'], 'level-A should survive partial save');
+    assert.deepStrictEqual(byLevel['level-A'].revealedCells, { '2,2': true });
   });
 
-  test('new map with no fog data gets correct structure after merge', () => {
+  test('new scene with byLevel arrays gets correct structure after merge', () => {
     const existing = {
       activeSceneId: 'new-scene',
       sceneState: {},
@@ -246,7 +291,11 @@ describe('mergeBoardStateSnapshot: array revealedCells coercion', () => {
       sceneState: {
         'new-scene': {
           grid: { size: 64, locked: false, visible: true },
-          fogOfWar: { enabled: true, revealedCells: [] },
+          fogOfWar: {
+            byLevel: {
+              'level-0': { enabled: true, revealedCells: [] },
+            },
+          },
         },
       },
       placements: {},
@@ -255,10 +304,10 @@ describe('mergeBoardStateSnapshot: array revealedCells coercion', () => {
     };
 
     const merged = mergeBoardStateSnapshot(existing, incoming);
-    const fog = merged.sceneState['new-scene'].fogOfWar;
+    const level0 = merged.sceneState['new-scene'].fogOfWar.byLevel['level-0'];
 
-    assert.ok(fog, 'fogOfWar should exist');
-    assert.ok(!Array.isArray(fog.revealedCells),
+    assert.ok(level0, 'level-0 fog should exist');
+    assert.ok(!Array.isArray(level0.revealedCells),
       'revealedCells on new map must be a plain object');
   });
 });

--- a/dnd/vtt/assets/js/state/normalize/fog.js
+++ b/dnd/vtt/assets/js/state/normalize/fog.js
@@ -1,11 +1,11 @@
-export function normalizeFogOfWarEntry(raw) {
+import { BASE_MAP_LEVEL_ID } from './map-levels.js';
+
+function normalizeLevelFogEntry(raw) {
   if (!raw || typeof raw !== 'object') {
     return null;
   }
-
   const enabled = Boolean(raw.enabled);
   const revealedCells = {};
-
   if (raw.revealedCells && typeof raw.revealedCells === 'object' && !Array.isArray(raw.revealedCells)) {
     Object.keys(raw.revealedCells).forEach((key) => {
       const parts = key.split(',');
@@ -18,8 +18,39 @@ export function normalizeFogOfWarEntry(raw) {
       }
     });
   }
-
   return { enabled, revealedCells };
+}
+
+export function normalizeFogOfWarEntry(raw) {
+  if (!raw || typeof raw !== 'object') {
+    return null;
+  }
+
+  const byLevel = {};
+
+  // New shape: fogOfWar.byLevel[levelId] = { enabled, revealedCells }
+  if (raw.byLevel && typeof raw.byLevel === 'object' && !Array.isArray(raw.byLevel)) {
+    Object.keys(raw.byLevel).forEach((levelId) => {
+      const id = typeof levelId === 'string' ? levelId.trim() : '';
+      if (!id) return;
+      const entry = normalizeLevelFogEntry(raw.byLevel[levelId]);
+      if (entry) {
+        byLevel[id] = entry;
+      }
+    });
+  }
+
+  // Legacy migration: top-level { enabled, revealedCells } → byLevel[BASE_MAP_LEVEL_ID].
+  // Only apply when no byLevel data is already present, so a partially-migrated
+  // object never has the old fields override the new ones.
+  if (Object.keys(byLevel).length === 0) {
+    const legacy = normalizeLevelFogEntry(raw);
+    if (legacy && (legacy.enabled || Object.keys(legacy.revealedCells).length > 0)) {
+      byLevel[BASE_MAP_LEVEL_ID] = legacy;
+    }
+  }
+
+  return { byLevel };
 }
 
 /**
@@ -41,16 +72,23 @@ export function captureFogOfWarSnapshot(boardState) {
   Object.keys(sceneState).forEach((sceneId) => {
     const entry = sceneState[sceneId];
     if (entry && typeof entry === 'object' && entry.fogOfWar && typeof entry.fogOfWar === 'object') {
-      // Deep copy so the snapshot is immune to later mutations or replacements
       snap.set(sceneId, JSON.parse(JSON.stringify(entry.fogOfWar)));
     }
   });
   return snap;
 }
 
+function cellCount(levelEntry) {
+  if (!levelEntry || typeof levelEntry !== 'object') return 0;
+  const cells = levelEntry.revealedCells;
+  if (!cells || typeof cells !== 'object' || Array.isArray(cells)) return 0;
+  return Object.keys(cells).length;
+}
+
 /**
  * Verify that each scene entry still has its fogOfWar data. If it was dropped
  * (e.g. the entry was rebuilt as a new object), re-attach the captured reference.
+ * Operates per-level so a partial replacement does not erase other levels' fog.
  */
 export function restoreFogOfWarSnapshot(boardState, snap) {
   if (!snap || !snap.size) return;
@@ -63,21 +101,33 @@ export function restoreFogOfWarSnapshot(boardState, snap) {
     if (!entry || typeof entry !== 'object') return;
 
     if (!entry.fogOfWar || typeof entry.fogOfWar !== 'object') {
-      // Entry lost its fogOfWar entirely — restore it.
       entry.fogOfWar = fogOfWar;
       return;
     }
 
-    // Entry still has a fogOfWar object.  Make sure revealedCells were not
-    // replaced with an empty object when the snapshot had actual cells.
-    const snapCells = fogOfWar.revealedCells;
-    const entryCells = entry.fogOfWar.revealedCells;
-    if (
-      snapCells && typeof snapCells === 'object' &&
-      Object.keys(snapCells).length > 0 &&
-      (!entryCells || typeof entryCells !== 'object' || Object.keys(entryCells).length === 0)
-    ) {
-      entry.fogOfWar.revealedCells = snapCells;
+    if (!entry.fogOfWar.byLevel || typeof entry.fogOfWar.byLevel !== 'object'
+        || Array.isArray(entry.fogOfWar.byLevel)) {
+      entry.fogOfWar.byLevel = {};
     }
+
+    const snapByLevel = fogOfWar?.byLevel;
+    if (!snapByLevel || typeof snapByLevel !== 'object') return;
+
+    Object.keys(snapByLevel).forEach((levelId) => {
+      const snapLevel = snapByLevel[levelId];
+      const snapCount = cellCount(snapLevel);
+      if (snapCount === 0) return;
+
+      const currentLevel = entry.fogOfWar.byLevel[levelId];
+      if (!currentLevel || cellCount(currentLevel) === 0) {
+        // Preserve the enabled flag from currentLevel if it's set, since the
+        // snapshot may predate a toggle change. Only the cells are restored.
+        if (currentLevel && typeof currentLevel === 'object') {
+          currentLevel.revealedCells = JSON.parse(JSON.stringify(snapLevel.revealedCells));
+        } else {
+          entry.fogOfWar.byLevel[levelId] = JSON.parse(JSON.stringify(snapLevel));
+        }
+      }
+    });
   });
 }

--- a/dnd/vtt/assets/js/ui/__tests__/board-state-poller.test.mjs
+++ b/dnd/vtt/assets/js/ui/__tests__/board-state-poller.test.mjs
@@ -613,21 +613,23 @@ test('mergeBoardStateSnapshot preserves grid for scenes not in incoming', async 
 test('mergeBoardStateSnapshot preserves fogOfWar when incoming has no fogOfWar', async () => {
   const { mergeBoardStateSnapshot } = await import('../board-interactions.js');
 
-  // Existing state has fogOfWar with revealed cells
   const existing = {
     activeSceneId: 'scene-1',
     sceneState: {
       'scene-1': {
         grid: { size: 64, locked: false, visible: true },
         fogOfWar: {
-          enabled: true,
-          revealedCells: { '0,0': true, '1,1': true, '3,5': true },
+          byLevel: {
+            'level-0': {
+              enabled: true,
+              revealedCells: { '0,0': true, '1,1': true, '3,5': true },
+            },
+          },
         },
       },
     },
   };
 
-  // Incoming state has no fogOfWar data
   const incoming = {
     activeSceneId: 'scene-1',
     sceneState: {
@@ -639,49 +641,44 @@ test('mergeBoardStateSnapshot preserves fogOfWar when incoming has no fogOfWar',
 
   const merged = mergeBoardStateSnapshot(existing, incoming);
 
-  // fogOfWar should be preserved from existing state
-  assert.ok(
-    merged.sceneState['scene-1'].fogOfWar,
-    'fogOfWar should be preserved when incoming has no fogOfWar'
-  );
-  assert.equal(
-    merged.sceneState['scene-1'].fogOfWar.enabled,
-    true,
-    'fogOfWar.enabled should be preserved from existing'
-  );
+  const level0 = merged.sceneState['scene-1'].fogOfWar?.byLevel?.['level-0'];
+  assert.ok(level0, 'level-0 fog should be preserved when incoming has no fogOfWar');
+  assert.equal(level0.enabled, true);
   assert.deepStrictEqual(
-    merged.sceneState['scene-1'].fogOfWar.revealedCells,
+    level0.revealedCells,
     { '0,0': true, '1,1': true, '3,5': true },
-    'fogOfWar.revealedCells should be preserved from existing'
   );
 });
 
 test('mergeBoardStateSnapshot uses incoming fogOfWar when present', async () => {
   const { mergeBoardStateSnapshot } = await import('../board-interactions.js');
 
-  // Existing state has old fogOfWar data
   const existing = {
     activeSceneId: 'scene-1',
     sceneState: {
       'scene-1': {
         grid: { size: 64, locked: false, visible: true },
         fogOfWar: {
-          enabled: true,
-          revealedCells: { '0,0': true },
+          byLevel: {
+            'level-0': { enabled: true, revealedCells: { '0,0': true } },
+          },
         },
       },
     },
   };
 
-  // Incoming has updated fogOfWar
   const incoming = {
     activeSceneId: 'scene-1',
     sceneState: {
       'scene-1': {
         grid: { size: 64, locked: false, visible: true },
         fogOfWar: {
-          enabled: true,
-          revealedCells: { '0,0': true, '2,2': true, '4,4': true },
+          byLevel: {
+            'level-0': {
+              enabled: true,
+              revealedCells: { '0,0': true, '2,2': true, '4,4': true },
+            },
+          },
         },
       },
     },
@@ -689,32 +686,32 @@ test('mergeBoardStateSnapshot uses incoming fogOfWar when present', async () => 
 
   const merged = mergeBoardStateSnapshot(existing, incoming);
 
-  // Should use incoming fogOfWar since it has the data
   assert.deepStrictEqual(
-    merged.sceneState['scene-1'].fogOfWar.revealedCells,
+    merged.sceneState['scene-1'].fogOfWar.byLevel['level-0'].revealedCells,
     { '0,0': true, '2,2': true, '4,4': true },
-    'should use incoming fogOfWar when it has data'
   );
 });
 
 test('mergeBoardStateSnapshot preserves fogOfWar during a partial sceneState save', async () => {
   const { mergeBoardStateSnapshot } = await import('../board-interactions.js');
 
-  // Simulate: user has fog setup, then a delta save changes a different sceneState field
   const existing = {
     activeSceneId: 'scene-1',
     sceneState: {
       'scene-1': {
         grid: { size: 64, locked: false, visible: true },
         fogOfWar: {
-          enabled: true,
-          revealedCells: { '1,1': true, '2,2': true, '3,3': true },
+          byLevel: {
+            'level-0': {
+              enabled: true,
+              revealedCells: { '1,1': true, '2,2': true, '3,3': true },
+            },
+          },
         },
       },
     },
   };
 
-  // Delta save: no fogOfWar included
   const incoming = {
     activeSceneId: 'scene-1',
     sceneState: {
@@ -726,13 +723,12 @@ test('mergeBoardStateSnapshot preserves fogOfWar during a partial sceneState sav
 
   const merged = mergeBoardStateSnapshot(existing, incoming);
 
-  // fogOfWar MUST be preserved
-  assert.ok(merged.sceneState['scene-1'].fogOfWar, 'fogOfWar must survive partial sceneState save');
-  assert.equal(merged.sceneState['scene-1'].fogOfWar.enabled, true);
+  const level0 = merged.sceneState['scene-1'].fogOfWar?.byLevel?.['level-0'];
+  assert.ok(level0, 'level-0 fog must survive partial sceneState save');
+  assert.equal(level0.enabled, true);
   assert.deepStrictEqual(
-    merged.sceneState['scene-1'].fogOfWar.revealedCells,
+    level0.revealedCells,
     { '1,1': true, '2,2': true, '3,3': true },
-    'all revealed cells must survive partial sceneState save'
   );
 });
 
@@ -744,36 +740,31 @@ test('mergeBoardStateSnapshot preserves fogOfWar for scenes not in incoming', as
     sceneState: {
       'scene-1': {
         grid: { size: 64, locked: false, visible: true },
-        fogOfWar: { enabled: true, revealedCells: { '5,5': true } },
+        fogOfWar: { byLevel: { 'level-0': { enabled: true, revealedCells: { '5,5': true } } } },
       },
       'scene-2': {
         grid: { size: 96, locked: false, visible: true },
-        fogOfWar: { enabled: true, revealedCells: { '10,10': true } },
+        fogOfWar: { byLevel: { 'level-0': { enabled: true, revealedCells: { '10,10': true } } } },
       },
     },
   };
 
-  // Incoming only has scene-1 data (e.g., delta save)
   const incoming = {
     activeSceneId: 'scene-1',
     sceneState: {
       'scene-1': {
         grid: { size: 64, locked: false, visible: true },
-        fogOfWar: { enabled: true, revealedCells: { '5,5': true } },
+        fogOfWar: { byLevel: { 'level-0': { enabled: true, revealedCells: { '5,5': true } } } },
       },
     },
   };
 
   const merged = mergeBoardStateSnapshot(existing, incoming);
 
-  // Scene-2 should be fully preserved (not in incoming)
   assert.ok(merged.sceneState['scene-2'], 'scene-2 should be preserved');
-  assert.ok(merged.sceneState['scene-2'].fogOfWar, 'scene-2 fogOfWar should be preserved');
-  assert.deepStrictEqual(
-    merged.sceneState['scene-2'].fogOfWar.revealedCells,
-    { '10,10': true },
-    'scene-2 fogOfWar revealedCells should be preserved'
-  );
+  const level0 = merged.sceneState['scene-2'].fogOfWar?.byLevel?.['level-0'];
+  assert.ok(level0, 'scene-2 level-0 fog should be preserved');
+  assert.deepStrictEqual(level0.revealedCells, { '10,10': true });
 });
 
 // ---------------------------------------------------------------------------

--- a/dnd/vtt/assets/js/ui/__tests__/fog-cascade.test.mjs
+++ b/dnd/vtt/assets/js/ui/__tests__/fog-cascade.test.mjs
@@ -1,0 +1,153 @@
+/**
+ * Unit tests for the fog-of-war cutout cascade.
+ *
+ * When the GM reveals a cell on a level that has a cutout at that
+ * coordinate, the reveal cascades down to the next level beneath. If that
+ * level also has a cutout there, it keeps cascading. The cascade is
+ * one-way: re-fogging on the higher level does NOT un-cascade.
+ */
+
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { cascadeReveals, levelHasCutoutAt } from '../fog-of-war.js';
+
+describe('levelHasCutoutAt', () => {
+  test('returns true for a cell inside a cutout rect', () => {
+    const level = {
+      cutouts: [{ column: 5, row: 5, width: 3, height: 3 }],
+    };
+    assert.equal(levelHasCutoutAt(level, 5, 5), true);
+    assert.equal(levelHasCutoutAt(level, 7, 7), true, 'last cell of 3x3 should match');
+  });
+
+  test('returns false for a cell outside every cutout', () => {
+    const level = {
+      cutouts: [{ column: 5, row: 5, width: 3, height: 3 }],
+    };
+    assert.equal(levelHasCutoutAt(level, 8, 5), false);
+    assert.equal(levelHasCutoutAt(level, 5, 8), false);
+    assert.equal(levelHasCutoutAt(level, 4, 5), false);
+  });
+
+  test('returns false when cutouts is missing or empty', () => {
+    assert.equal(levelHasCutoutAt({}, 0, 0), false);
+    assert.equal(levelHasCutoutAt({ cutouts: [] }, 0, 0), false);
+    assert.equal(levelHasCutoutAt(null, 0, 0), false);
+  });
+});
+
+describe('cascadeReveals', () => {
+  function buildViewModel({ levelACutouts = [], levelBCutouts = [] } = {}) {
+    return [
+      // Level 0 (base) — no cutouts. zIndex -1.
+      { id: 'level-0', zIndex: -1, cutouts: [] },
+      // Level A (above 0). zIndex 0.
+      { id: 'level-A', zIndex: 0, cutouts: levelACutouts },
+      // Level B (above A). zIndex 1.
+      { id: 'level-B', zIndex: 1, cutouts: levelBCutouts },
+    ];
+  }
+
+  test('reveal on a level with no cutout at that cell does not cascade', () => {
+    const viewModel = buildViewModel({
+      levelACutouts: [{ column: 0, row: 0, width: 1, height: 1 }],
+    });
+    const byLevel = {
+      'level-A': { enabled: true, revealedCells: { '5,5': true } },
+    };
+    cascadeReveals(byLevel, viewModel, 'level-A', ['5,5']);
+    assert.equal(byLevel['level-0'], undefined, 'level-0 should not get a fog entry');
+  });
+
+  test('reveal cascades one level down through a cutout', () => {
+    const viewModel = buildViewModel({
+      levelACutouts: [{ column: 5, row: 5, width: 1, height: 1 }],
+    });
+    const byLevel = {
+      'level-A': { enabled: true, revealedCells: { '5,5': true } },
+    };
+    cascadeReveals(byLevel, viewModel, 'level-A', ['5,5']);
+    assert.ok(byLevel['level-0'], 'level-0 should get a fog entry');
+    assert.equal(byLevel['level-0'].revealedCells['5,5'], true);
+    assert.equal(byLevel['level-0'].enabled, false,
+      'cascading should not flip enabled (per-level toggle is independent)');
+  });
+
+  test('reveal cascades through multiple stacked cutouts', () => {
+    const viewModel = buildViewModel({
+      levelBCutouts: [{ column: 3, row: 4, width: 1, height: 1 }],
+      levelACutouts: [{ column: 3, row: 4, width: 1, height: 1 }],
+    });
+    const byLevel = {
+      'level-B': { enabled: true, revealedCells: { '3,4': true } },
+    };
+    cascadeReveals(byLevel, viewModel, 'level-B', ['3,4']);
+    assert.equal(byLevel['level-A'].revealedCells['3,4'], true);
+    assert.equal(byLevel['level-0'].revealedCells['3,4'], true);
+  });
+
+  test('cascade stops where the cutout column ends', () => {
+    // Level B has a cutout at (3,4), Level A does NOT.
+    const viewModel = buildViewModel({
+      levelBCutouts: [{ column: 3, row: 4, width: 1, height: 1 }],
+      levelACutouts: [],
+    });
+    const byLevel = {
+      'level-B': { enabled: true, revealedCells: { '3,4': true } },
+    };
+    cascadeReveals(byLevel, viewModel, 'level-B', ['3,4']);
+    assert.equal(byLevel['level-A'].revealedCells['3,4'], true,
+      'first hop reaches level-A');
+    assert.equal(byLevel['level-0'], undefined,
+      'level-0 should not be reached when level-A has no cutout');
+  });
+
+  test('cascade preserves existing reveals on lower levels (no overwrite)', () => {
+    const viewModel = buildViewModel({
+      levelACutouts: [{ column: 5, row: 5, width: 1, height: 1 }],
+    });
+    const byLevel = {
+      'level-A': { enabled: true, revealedCells: { '5,5': true } },
+      'level-0': { enabled: true, revealedCells: { '0,0': true } },
+    };
+    cascadeReveals(byLevel, viewModel, 'level-A', ['5,5']);
+    assert.equal(byLevel['level-0'].revealedCells['0,0'], true,
+      'pre-existing reveal on level-0 should remain');
+    assert.equal(byLevel['level-0'].revealedCells['5,5'], true,
+      'cascaded reveal added to level-0');
+  });
+
+  test('multi-cell selection cascades each cell independently', () => {
+    const viewModel = buildViewModel({
+      // Level A has a cutout only at (5,5), not at (6,6).
+      levelACutouts: [{ column: 5, row: 5, width: 1, height: 1 }],
+    });
+    const byLevel = {
+      'level-A': { enabled: true, revealedCells: { '5,5': true, '6,6': true } },
+    };
+    cascadeReveals(byLevel, viewModel, 'level-A', ['5,5', '6,6']);
+    assert.equal(byLevel['level-0']?.revealedCells['5,5'], true,
+      '(5,5) cascades through cutout');
+    assert.equal(byLevel['level-0']?.revealedCells['6,6'], undefined,
+      '(6,6) does not cascade — no cutout there');
+  });
+
+  test('rect cutouts cascade across all cells inside them', () => {
+    // Level B has a 3x2 cutout at (10,10).
+    const viewModel = buildViewModel({
+      levelBCutouts: [{ column: 10, row: 10, width: 3, height: 2 }],
+    });
+    const byLevel = {
+      'level-B': {
+        enabled: true,
+        revealedCells: { '10,10': true, '12,11': true, '20,20': true },
+      },
+    };
+    cascadeReveals(byLevel, viewModel, 'level-B', ['10,10', '12,11', '20,20']);
+    assert.equal(byLevel['level-A'].revealedCells['10,10'], true);
+    assert.equal(byLevel['level-A'].revealedCells['12,11'], true);
+    assert.equal(byLevel['level-A'].revealedCells['20,20'], undefined,
+      '(20,20) is outside the cutout');
+  });
+});

--- a/dnd/vtt/assets/js/ui/__tests__/fog-store-integration.test.mjs
+++ b/dnd/vtt/assets/js/ui/__tests__/fog-store-integration.test.mjs
@@ -1,6 +1,8 @@
 /**
- * Integration test: fog revealedCells through the REAL store (not mock).
- * This tests whether the store's updateState + getState round-trip preserves fog data.
+ * Integration test: per-level fog revealedCells through the REAL store.
+ * Verifies that updateState + getState round-trip preserves fog data.
+ *
+ * Per-level shape: fogOfWar.byLevel[levelId] = { enabled, revealedCells }.
  */
 
 import { test, describe } from 'node:test';
@@ -13,89 +15,118 @@ import {
   subscribe,
 } from '../../state/store.js';
 
-describe('fog revealedCells through real store', () => {
-  test('cells survive updateState + getState round-trip', () => {
-    initializeState({
-      boardState: {
-        activeSceneId: 'scene-1',
-        sceneState: {
-          'scene-1': {
-            grid: { size: 64, locked: false, visible: true },
-            fogOfWar: { enabled: true, revealedCells: {} },
+const LEVEL_0 = 'level-0';
+
+function initWithLevel0Fog(extraInit = {}) {
+  initializeState({
+    boardState: {
+      activeSceneId: 'scene-1',
+      sceneState: {
+        'scene-1': {
+          grid: { size: 64, locked: false, visible: true },
+          fogOfWar: {
+            byLevel: {
+              [LEVEL_0]: { enabled: true, revealedCells: {} },
+            },
           },
         },
       },
-      user: { isGM: true, name: 'GM' },
-    });
+    },
+    user: { isGM: true, name: 'GM' },
+    ...extraInit,
+  });
+}
 
-    // Simulate applyFogChange: add cells inside updateState
+describe('fog revealedCells through real store (per-level)', () => {
+  test('cells on level-0 survive updateState + getState round-trip', () => {
+    initWithLevel0Fog();
+
     updateState((draft) => {
-      const fog = draft.boardState.sceneState['scene-1'].fogOfWar;
-      fog.revealedCells['5,5'] = true;
-      fog.revealedCells['6,6'] = true;
-      fog.revealedCells['10,20'] = true;
+      const level = draft.boardState.sceneState['scene-1'].fogOfWar.byLevel[LEVEL_0];
+      level.revealedCells['5,5'] = true;
+      level.revealedCells['6,6'] = true;
+      level.revealedCells['10,20'] = true;
     });
 
     const state = getState();
-    const fog = state.boardState.sceneState['scene-1'].fogOfWar;
-    assert.equal(fog.enabled, true);
-    assert.equal(Object.keys(fog.revealedCells).length, 3, 'should have 3 revealed cells');
-    assert.equal(fog.revealedCells['5,5'], true);
-    assert.equal(fog.revealedCells['6,6'], true);
-    assert.equal(fog.revealedCells['10,20'], true);
+    const level = state.boardState.sceneState['scene-1'].fogOfWar.byLevel[LEVEL_0];
+    assert.equal(level.enabled, true);
+    assert.equal(Object.keys(level.revealedCells).length, 3);
+    assert.equal(level.revealedCells['5,5'], true);
+    assert.equal(level.revealedCells['6,6'], true);
+    assert.equal(level.revealedCells['10,20'], true);
   });
 
-  test('cells survive multiple updateState calls', () => {
+  test('cells on different levels are independent', () => {
     initializeState({
       boardState: {
         activeSceneId: 'scene-1',
         sceneState: {
           'scene-1': {
             grid: { size: 64, locked: false, visible: true },
-            fogOfWar: { enabled: true, revealedCells: {} },
+            fogOfWar: {
+              byLevel: {
+                [LEVEL_0]: { enabled: true, revealedCells: {} },
+                'level-A': { enabled: true, revealedCells: {} },
+              },
+            },
           },
         },
       },
       user: { isGM: true, name: 'GM' },
     });
 
-    // First batch
     updateState((draft) => {
-      const fog = draft.boardState.sceneState['scene-1'].fogOfWar;
+      const byLevel = draft.boardState.sceneState['scene-1'].fogOfWar.byLevel;
+      byLevel[LEVEL_0].revealedCells['1,1'] = true;
+      byLevel['level-A'].revealedCells['2,2'] = true;
+    });
+
+    const state = getState();
+    const byLevel = state.boardState.sceneState['scene-1'].fogOfWar.byLevel;
+    assert.equal(Object.keys(byLevel[LEVEL_0].revealedCells).length, 1);
+    assert.equal(byLevel[LEVEL_0].revealedCells['1,1'], true);
+    assert.equal(byLevel['level-A'].revealedCells['1,1'], undefined,
+      'level-A should not have level-0 cell');
+    assert.equal(Object.keys(byLevel['level-A'].revealedCells).length, 1);
+    assert.equal(byLevel['level-A'].revealedCells['2,2'], true);
+  });
+
+  test('cells survive multiple updateState calls', () => {
+    initWithLevel0Fog();
+
+    updateState((draft) => {
+      const level = draft.boardState.sceneState['scene-1'].fogOfWar.byLevel[LEVEL_0];
       for (let c = 0; c < 5; c++) {
         for (let r = 0; r < 5; r++) {
-          fog.revealedCells[c + ',' + r] = true;
+          level.revealedCells[c + ',' + r] = true;
         }
       }
     });
 
     let state = getState();
     assert.equal(
-      Object.keys(state.boardState.sceneState['scene-1'].fogOfWar.revealedCells).length,
+      Object.keys(state.boardState.sceneState['scene-1'].fogOfWar.byLevel[LEVEL_0].revealedCells).length,
       25,
-      'first batch: 25 cells'
     );
 
-    // Second batch (simulating another user selection)
     updateState((draft) => {
-      const fog = draft.boardState.sceneState['scene-1'].fogOfWar;
+      const level = draft.boardState.sceneState['scene-1'].fogOfWar.byLevel[LEVEL_0];
       for (let c = 10; c < 15; c++) {
         for (let r = 10; r < 16; r++) {
-          fog.revealedCells[c + ',' + r] = true;
+          level.revealedCells[c + ',' + r] = true;
         }
       }
     });
 
     state = getState();
     assert.equal(
-      Object.keys(state.boardState.sceneState['scene-1'].fogOfWar.revealedCells).length,
+      Object.keys(state.boardState.sceneState['scene-1'].fogOfWar.byLevel[LEVEL_0].revealedCells).length,
       55,
-      'after second batch: 55 cells total'
     );
   });
 
-  test('cells survive when scene entry is created during toggleFog then modified', () => {
-    // Start with NO sceneState entry for the scene (like a fresh map)
+  test('cells survive when scene entry is created during toggle then modified', () => {
     initializeState({
       boardState: {
         activeSceneId: 'scene-new',
@@ -104,63 +135,48 @@ describe('fog revealedCells through real store', () => {
       user: { isGM: true, name: 'GM' },
     });
 
-    // Simulate toggleFogForScene creating the entry
+    // Simulate toggleFogForLevel creating the entry
     updateState((draft) => {
       if (!draft.boardState.sceneState) draft.boardState.sceneState = {};
       if (!draft.boardState.sceneState['scene-new']) {
         draft.boardState.sceneState['scene-new'] = { grid: { size: 64, locked: false, visible: true } };
       }
-      if (!draft.boardState.sceneState['scene-new'].fogOfWar) {
-        draft.boardState.sceneState['scene-new'].fogOfWar = { enabled: false, revealedCells: {} };
+      const sceneEntry = draft.boardState.sceneState['scene-new'];
+      if (!sceneEntry.fogOfWar) {
+        sceneEntry.fogOfWar = { byLevel: {} };
       }
-      draft.boardState.sceneState['scene-new'].fogOfWar.enabled = true;
+      if (!sceneEntry.fogOfWar.byLevel[LEVEL_0]) {
+        sceneEntry.fogOfWar.byLevel[LEVEL_0] = { enabled: false, revealedCells: {} };
+      }
+      sceneEntry.fogOfWar.byLevel[LEVEL_0].enabled = true;
     });
 
-    // Verify toggle worked
     let state = getState();
-    assert.ok(state.boardState.sceneState['scene-new'], 'scene entry should exist');
-    assert.equal(state.boardState.sceneState['scene-new'].fogOfWar.enabled, true);
+    assert.ok(state.boardState.sceneState['scene-new']);
+    assert.equal(state.boardState.sceneState['scene-new'].fogOfWar.byLevel[LEVEL_0].enabled, true);
 
-    // Now simulate applyFogChange
     updateState((draft) => {
-      const fog = draft.boardState.sceneState['scene-new'].fogOfWar;
-      if (!fog.revealedCells) fog.revealedCells = {};
+      const level = draft.boardState.sceneState['scene-new'].fogOfWar.byLevel[LEVEL_0];
+      if (!level.revealedCells) level.revealedCells = {};
       for (let c = 0; c < 6; c++) {
         for (let r = 0; r < 5; r++) {
-          fog.revealedCells[c + ',' + r] = true;
+          level.revealedCells[c + ',' + r] = true;
         }
       }
     });
 
     state = getState();
-    const fog = state.boardState.sceneState['scene-new'].fogOfWar;
-    assert.equal(fog.enabled, true);
-    assert.equal(
-      Object.keys(fog.revealedCells).length,
-      30,
-      'should have 30 revealed cells after applyFogChange'
-    );
+    const level = state.boardState.sceneState['scene-new'].fogOfWar.byLevel[LEVEL_0];
+    assert.equal(level.enabled, true);
+    assert.equal(Object.keys(level.revealedCells).length, 30);
   });
 
   test('cells survive when subscriber triggers nested updateState', () => {
-    initializeState({
-      boardState: {
-        activeSceneId: 'scene-1',
-        sceneState: {
-          'scene-1': {
-            grid: { size: 64, locked: false, visible: true },
-            fogOfWar: { enabled: true, revealedCells: {} },
-          },
-        },
-      },
-      user: { isGM: true, name: 'GM' },
-    });
+    initWithLevel0Fog();
 
-    // Add a subscriber that triggers a nested updateState (like combat sync would)
     let subscriberCallCount = 0;
-    const unsubscribe = subscribe((state) => {
+    const unsubscribe = subscribe(() => {
       subscriberCallCount++;
-      // On the first notification, trigger a nested updateState that modifies metadata
       if (subscriberCallCount === 1) {
         updateState((draft) => {
           if (!draft.boardState.metadata) draft.boardState.metadata = {};
@@ -169,132 +185,24 @@ describe('fog revealedCells through real store', () => {
       }
     });
 
-    // Add fog cells
     updateState((draft) => {
-      const fog = draft.boardState.sceneState['scene-1'].fogOfWar;
-      fog.revealedCells['5,5'] = true;
-      fog.revealedCells['6,6'] = true;
+      const level = draft.boardState.sceneState['scene-1'].fogOfWar.byLevel[LEVEL_0];
+      level.revealedCells['5,5'] = true;
+      level.revealedCells['6,6'] = true;
     });
 
     const state = getState();
-    const fog = state.boardState.sceneState['scene-1'].fogOfWar;
-    assert.equal(
-      Object.keys(fog.revealedCells).length,
-      2,
-      'fog cells should survive nested updateState from subscriber'
-    );
+    const level = state.boardState.sceneState['scene-1'].fogOfWar.byLevel[LEVEL_0];
+    assert.equal(Object.keys(level.revealedCells).length, 2);
 
     unsubscribe();
   });
 
-  test('cells survive when subscriber replaces boardState (simulating poller merge)', () => {
-    initializeState({
-      boardState: {
-        activeSceneId: 'scene-1',
-        sceneState: {
-          'scene-1': {
-            grid: { size: 64, locked: false, visible: true },
-            fogOfWar: { enabled: true, revealedCells: {} },
-          },
-        },
-      },
-      user: { isGM: true, name: 'GM' },
-    });
+  test('cells survive when subscriber naively replaces boardState (snapshot/restore)', () => {
+    initWithLevel0Fog();
 
-    // Add a subscriber that replaces draft.boardState (like the poller does)
     let subscriberCallCount = 0;
-    const unsubscribe = subscribe((clonedState) => {
-      subscriberCallCount++;
-      if (subscriberCallCount === 1) {
-        // Simulate the poller's updater: draft.boardState = mergedSnapshot
-        updateState((draft) => {
-          // This simulates what mergeBoardStateSnapshot does:
-          // it creates a new boardState object but preserves fog data
-          const existing = draft.boardState;
-          const incoming = {
-            activeSceneId: 'scene-1',
-            sceneState: {
-              'scene-1': {
-                grid: { size: 64, locked: false, visible: true },
-                // Server doesn't have fog data yet (save hasn't reached server)
-              },
-            },
-            placements: {},
-          };
-
-          // Simulate mergeSceneStatePreservingGrid: clone incoming, preserve grid + fogOfWar from existing
-          const mergedSceneState = {};
-          const existingSceneState = existing.sceneState || {};
-          const incomingSceneState = incoming.sceneState || {};
-          const allSceneIds = new Set([...Object.keys(existingSceneState), ...Object.keys(incomingSceneState)]);
-          allSceneIds.forEach((sceneId) => {
-            const existingEntry = existingSceneState[sceneId];
-            const incomingEntry = incomingSceneState[sceneId];
-            if (!incomingEntry) {
-              mergedSceneState[sceneId] = JSON.parse(JSON.stringify(existingEntry));
-              return;
-            }
-            const mergedEntry = JSON.parse(JSON.stringify(incomingEntry));
-            if (existingEntry?.grid) {
-              mergedEntry.grid = JSON.parse(JSON.stringify(existingEntry.grid));
-            }
-            if (existingEntry?.fogOfWar) {
-              if (!mergedEntry.fogOfWar) {
-                mergedEntry.fogOfWar = JSON.parse(JSON.stringify(existingEntry.fogOfWar));
-              }
-            }
-            mergedSceneState[sceneId] = mergedEntry;
-          });
-
-          // REPLACE draft.boardState entirely (like the poller does)
-          draft.boardState = {
-            activeSceneId: incoming.activeSceneId,
-            placements: incoming.placements || existing.placements,
-            sceneState: mergedSceneState,
-            overlay: existing.overlay,
-          };
-        });
-      }
-    });
-
-    // Add fog cells
-    updateState((draft) => {
-      const fog = draft.boardState.sceneState['scene-1'].fogOfWar;
-      fog.revealedCells['5,5'] = true;
-      fog.revealedCells['6,6'] = true;
-      fog.revealedCells['7,7'] = true;
-    });
-
-    const state = getState();
-    const fog = state.boardState?.sceneState?.['scene-1']?.fogOfWar;
-    assert.ok(fog, 'fogOfWar should exist');
-    assert.equal(fog.enabled, true);
-    assert.equal(
-      Object.keys(fog.revealedCells).length,
-      3,
-      'fog cells should survive poller-like boardState replacement in subscriber'
-    );
-
-    unsubscribe();
-  });
-
-  test('cells survive when subscriber replaces boardState WITHOUT fog merge (was a bug)', () => {
-    initializeState({
-      boardState: {
-        activeSceneId: 'scene-1',
-        sceneState: {
-          'scene-1': {
-            grid: { size: 64, locked: false, visible: true },
-            fogOfWar: { enabled: true, revealedCells: {} },
-          },
-        },
-      },
-      user: { isGM: true, name: 'GM' },
-    });
-
-    // This subscriber naively replaces boardState (no fog preservation)
-    let subscriberCallCount = 0;
-    const unsubscribe = subscribe((clonedState) => {
+    const unsubscribe = subscribe(() => {
       subscriberCallCount++;
       if (subscriberCallCount === 1) {
         updateState((draft) => {
@@ -305,7 +213,11 @@ describe('fog revealedCells through real store', () => {
             sceneState: {
               'scene-1': {
                 grid: { size: 64, locked: false, visible: true },
-                fogOfWar: { enabled: true, revealedCells: {} }, // empty!
+                fogOfWar: {
+                  byLevel: {
+                    [LEVEL_0]: { enabled: true, revealedCells: {} }, // empty!
+                  },
+                },
               },
             },
           };
@@ -313,24 +225,19 @@ describe('fog revealedCells through real store', () => {
       }
     });
 
-    // Add fog cells
     updateState((draft) => {
-      const fog = draft.boardState.sceneState['scene-1'].fogOfWar;
-      fog.revealedCells['5,5'] = true;
-      fog.revealedCells['6,6'] = true;
+      const level = draft.boardState.sceneState['scene-1'].fogOfWar.byLevel[LEVEL_0];
+      level.revealedCells['5,5'] = true;
+      level.revealedCells['6,6'] = true;
     });
 
     const state = getState();
-    const fog = state.boardState?.sceneState?.['scene-1']?.fogOfWar;
-    assert.ok(fog, 'fogOfWar should exist');
-    // After the fix: the deep-copy snapshot + post-notify() restore should
-    // protect fog cells even when a subscriber naively replaces boardState.
-    assert.equal(fog.enabled, true);
-    assert.equal(
-      Object.keys(fog.revealedCells).length,
-      2,
-      'fog cells should survive naive boardState replacement in subscriber'
-    );
+    const level = state.boardState?.sceneState?.['scene-1']?.fogOfWar?.byLevel?.[LEVEL_0];
+    assert.ok(level, 'level-0 fog should exist');
+    assert.equal(level.enabled, true);
+    // The snapshot/restore in normalize/fog.js should restore the cells.
+    assert.equal(Object.keys(level.revealedCells).length, 2,
+      'cells should survive naive boardState replacement via snapshot/restore');
 
     unsubscribe();
   });

--- a/dnd/vtt/assets/js/ui/board-interactions.js
+++ b/dnd/vtt/assets/js/ui/board-interactions.js
@@ -2752,12 +2752,19 @@ export function mountBoardInteractions(store, routes = {}) {
             // data reflects the GM's latest changes. Using a union here
             // would prevent the GM from adding fog back because deleted
             // cells would be restored from the player's existing state.
+            // Per-level shape: { byLevel: { [levelId]: { enabled, revealedCells } } }.
             const incomingFog = state.fogOfWar && typeof state.fogOfWar === 'object'
-              ? state.fogOfWar : { enabled: false, revealedCells: {} };
-            // Coerce arrays from PHP's json_encode (empty {} → []) to plain objects
-            if (Array.isArray(incomingFog.revealedCells)) {
-              incomingFog.revealedCells = {};
+              ? state.fogOfWar : { byLevel: {} };
+            if (!incomingFog.byLevel || typeof incomingFog.byLevel !== 'object'
+                || Array.isArray(incomingFog.byLevel)) {
+              incomingFog.byLevel = {};
             }
+            Object.keys(incomingFog.byLevel).forEach((lvlId) => {
+              const entry = incomingFog.byLevel[lvlId];
+              if (entry && typeof entry === 'object' && Array.isArray(entry.revealedCells)) {
+                entry.revealedCells = {};
+              }
+            });
             draft.boardState.sceneState[sceneId].fogOfWar = incomingFog;
           }
         });
@@ -3708,6 +3715,7 @@ export function mountBoardInteractions(store, routes = {}) {
     boardApi,
     viewState,
     isGm: Boolean(userState.isGM),
+    getActiveLevelId: (state, sceneId) => getViewerLevelIdForCurrentUser(state, sceneId),
   });
 
   // Expose a helper so fog-of-war.js can mark scene state dirty for saving
@@ -5281,10 +5289,11 @@ export function mountBoardInteractions(store, routes = {}) {
     const trackerEntries = [];
     const activeCombatantIds = new Set();
     const groupColorAssignments = getCombatGroupColorAssignments();
-    // Pre-compute fog checker once (null when fog inactive or GM viewing)
-    const isCellFogged = gmViewing ? null : createFogChecker(state);
     const tokenLevelState = getActiveSceneTokenLevelState(state);
     const viewerLevelId = activeSceneKey ? getViewerLevelIdForCurrentUser(state, activeSceneKey) : null;
+    // Pre-compute fog checker once (null when fog inactive or GM viewing).
+    // Per-level fog: gate on the viewer's current level.
+    const isCellFogged = gmViewing ? null : createFogChecker(state, viewerLevelId);
     // Levels v2 (§5.4): the per-scene `claimedTokens` map drives the colored
     // ring on PC tokens. Look the scene entry up once outside the loop.
     const activeSceneEntry = activeSceneKey
@@ -5543,10 +5552,10 @@ export function mountBoardInteractions(store, routes = {}) {
     let auraCount = 0;
 
     const gmViewing = isGmUser();
-    const isCellFogged = gmViewing ? null : createFogChecker(state);
     const tokenLevelState = getActiveSceneTokenLevelState(state);
     const auraSceneKey = state?.boardState?.activeSceneId ?? null;
     const auraViewerLevelId = auraSceneKey ? getViewerLevelIdForCurrentUser(state, auraSceneKey) : null;
+    const isCellFogged = gmViewing ? null : createFogChecker(state, auraViewerLevelId);
 
     placements.forEach((placement) => {
       const normalized = normalizePlacementForRender(placement);
@@ -9952,8 +9961,8 @@ export function mountBoardInteractions(store, routes = {}) {
           }
         }
 
-        // For non-GM users, skip tokens hidden by fog of war
-        if (!gmViewing && isPositionFogged(state, pointCell.column, pointCell.row)) {
+        // For non-GM users, skip tokens hidden by fog of war on the viewer's level.
+        if (!gmViewing && isPositionFogged(state, pointCell.column, pointCell.row, viewerLevelId)) {
           continue;
         }
 

--- a/dnd/vtt/assets/js/ui/fog-of-war.js
+++ b/dnd/vtt/assets/js/ui/fog-of-war.js
@@ -1,18 +1,33 @@
 /**
- * Fog of War module.
+ * Fog of War module — per-level.
  *
- * Renders a grid-aligned darkness overlay on a <canvas> element that sits
- * above the token layer. The GM sees a translucent overlay; players see
- * opaque black.  PC-folder tokens automatically reveal their grid cells.
+ * Each level in a scene has its own fog layer:
  *
- * Data is stored per-scene in boardState.sceneState[sceneId].fogOfWar:
- *   { enabled: boolean, revealedCells: { "col,row": true, ... } }
+ *   boardState.sceneState[sceneId].fogOfWar = {
+ *     byLevel: {
+ *       [levelId]: { enabled: boolean, revealedCells: { "col,row": true } }
+ *     }
+ *   }
+ *
+ * The viewer sees fog for whichever level they're currently on. The GM panel
+ * (Enabled toggle, Select Area, Clear Fog, Add Fog) acts on whichever level
+ * the GM is currently viewing.
+ *
+ * Cutout cascade: when fog is revealed on a square that sits over a cutout,
+ * the same square is auto-revealed on the level immediately below — and if
+ * that level also has a cutout there, it cascades further down. "Add Fog"
+ * does NOT cascade (one-way).
  */
 
 import {
   PLAYER_VISIBLE_TOKEN_FOLDER,
   normalizePlayerTokenFolderName,
 } from '../state/store.js';
+import {
+  BASE_MAP_LEVEL_ID,
+  resolvePlacementLevelId,
+  buildLevelViewModel,
+} from '../state/normalize/map-levels.js';
 
 // ── Constants ────────────────────────────────────────────────────
 
@@ -23,7 +38,7 @@ const SELECTION_FILL = 'rgba(70,160,255,0.25)';
 const SELECTION_STROKE = 'rgba(70,160,255,0.8)';
 
 // ── Debug logging (check F12 console) ────────────────────────────
-const FOG_DEBUG = false; // set to false to silence fog diagnostics
+const FOG_DEBUG = false;
 function fogLog(...args) {
   if (FOG_DEBUG) console.log('[FOG DEBUG]', ...args);
 }
@@ -40,44 +55,34 @@ let selCtx = null;
 let panelEl = null;
 
 let boardApi = null;
-let viewStateRef = null;  // reference to the live viewState object
+let viewStateRef = null;
 let isGm = false;
+
+// Resolves the viewer/editor's active level for a given scene. Set at mount.
+let getActiveLevelId = () => BASE_MAP_LEVEL_ID;
 
 // Fog-select interaction state
 let fogSelectActive = false;
-let selectionStart = null;   // {col, row} grid coords of anchor corner
-let selectionEnd = null;     // {col, row} grid coords of drag corner
-let selectedCells = new Set(); // set of "col,row" strings currently highlighted
+let selectionStart = null;
+let selectionEnd = null;
+let selectedCells = new Set();
 let pointerDownForFog = false;
 
 // ── Public API ───────────────────────────────────────────────────
 
-/**
- * Mount the fog-of-war system.  Called once at startup from bootstrap/board-interactions.
- */
 export function mountFogOfWar(options = {}) {
   boardApi = options.boardApi ?? null;
   viewStateRef = options.viewState ?? null;
   isGm = Boolean(options.isGm);
+  if (typeof options.getActiveLevelId === 'function') {
+    getActiveLevelId = options.getActiveLevelId;
+  }
 
   fogCanvas = document.getElementById('vtt-fog-layer');
   selCanvas = document.getElementById('vtt-fog-selection-layer');
 
   if (fogCanvas) fogCtx = fogCanvas.getContext('2d');
   if (selCanvas) selCtx = selCanvas.getContext('2d');
-
-  fogLog('mountFogOfWar:', {
-    isGm,
-    hasBoardApi: !!boardApi,
-    hasViewState: !!viewStateRef,
-    hasFogCanvas: !!fogCanvas,
-    hasFogCtx: !!fogCtx,
-    hasSelCanvas: !!selCanvas,
-    hasSelCtx: !!selCtx,
-  });
-
-  if (!selCanvas) fogWarn('vtt-fog-selection-layer element NOT found in DOM');
-  if (!fogCanvas) fogWarn('vtt-fog-layer element NOT found in DOM');
 
   if (isGm) {
     mountPanel();
@@ -86,7 +91,7 @@ export function mountFogOfWar(options = {}) {
 }
 
 /**
- * Re-render the fog overlay.  Called whenever the board state changes.
+ * Re-render the fog overlay for the viewer's current level.
  */
 export function renderFog(state) {
   if (!fogCanvas || !fogCtx) return;
@@ -94,31 +99,23 @@ export function renderFog(state) {
   const activeSceneId = state?.boardState?.activeSceneId ?? null;
   if (!activeSceneId) {
     clearCanvas(fogCtx, fogCanvas);
-    return;
-  }
-
-  const fogState = getFogState(state, activeSceneId);
-  if (!fogState || !fogState.enabled) {
-    fogLog('renderFog: fog OFF for scene', activeSceneId, '— fogState:', fogState);
-    clearCanvas(fogCtx, fogCanvas);
     syncPanelToggle(false);
     return;
   }
 
-  syncPanelToggle(true);
+  const activeLevelId = resolveActiveLevelId(state, activeSceneId);
+  const levelFog = getLevelFog(state, activeSceneId, activeLevelId);
+  const enabled = Boolean(levelFog && levelFog.enabled);
+
+  syncPanelToggle(enabled);
 
   const view = viewStateRef ?? {};
-  const gridSize = Math.max(8, Number.isFinite(view.gridSize) ? view.gridSize : 64);
   const mapW = Number.isFinite(view.mapPixelSize?.width) ? view.mapPixelSize.width : 0;
   const mapH = Number.isFinite(view.mapPixelSize?.height) ? view.mapPixelSize.height : 0;
   if (mapW <= 0 || mapH <= 0) {
     clearCanvas(fogCtx, fogCanvas);
     return;
   }
-
-  const offsets = view.gridOffsets ?? {};
-  const offsetLeft = Number.isFinite(offsets.left) ? offsets.left : 0;
-  const offsetTop = Number.isFinite(offsets.top) ? offsets.top : 0;
 
   // Size the canvas to the map
   if (fogCanvas.width !== mapW || fogCanvas.height !== mapH) {
@@ -128,19 +125,52 @@ export function renderFog(state) {
   fogCanvas.style.width = mapW + 'px';
   fogCanvas.style.height = mapH + 'px';
 
-  const cols = Math.ceil((mapW - offsetLeft) / gridSize);
-  const rows = Math.ceil((mapH - offsetTop) / gridSize);
+  if (!enabled) {
+    fogCtx.clearRect(0, 0, mapW, mapH);
+    return;
+  }
 
-  const revealed = fogState.revealedCells ?? {};
+  const gridSize = Math.max(8, Number.isFinite(view.gridSize) ? view.gridSize : 64);
+  const offsets = view.gridOffsets ?? {};
+  const offsetLeft = Number.isFinite(offsets.left) ? offsets.left : 0;
+  const offsetTop = Number.isFinite(offsets.top) ? offsets.top : 0;
+  const offsetRight = Number.isFinite(offsets.right) ? offsets.right : 0;
+  const offsetBottom = Number.isFinite(offsets.bottom) ? offsets.bottom : 0;
 
-  // Build set of cells auto-revealed by PC tokens
-  const pcCells = buildPcRevealedCells(state, activeSceneId);
+  const innerWidth = Math.max(0, mapW - offsetLeft - offsetRight);
+  const innerHeight = Math.max(0, mapH - offsetTop - offsetBottom);
+  const cols = Math.floor(innerWidth / gridSize);
+  const rows = Math.floor(innerHeight / gridSize);
+
+  const gridRight = offsetLeft + cols * gridSize;
+  const gridBottom = offsetTop + rows * gridSize;
+
+  const revealed = levelFog.revealedCells ?? {};
+  const pcCells = buildPcRevealedCells(state, activeSceneId, activeLevelId);
 
   const alpha = isGm ? GM_FOG_ALPHA : PLAYER_FOG_ALPHA;
 
   fogCtx.clearRect(0, 0, mapW, mapH);
   fogCtx.fillStyle = `rgba(${FOG_COLOR},${alpha})`;
 
+  // Border bands — anything outside the gridded area is unreachable, so it
+  // always reads as fogged. Painting these covers the previously-visible
+  // strips at the top/left/right/bottom of the map when a non-zero grid
+  // origin shifts the addressable grid inward.
+  if (offsetLeft > 0) {
+    fogCtx.fillRect(0, 0, offsetLeft, mapH);
+  }
+  if (gridRight < mapW) {
+    fogCtx.fillRect(gridRight, 0, mapW - gridRight, mapH);
+  }
+  if (offsetTop > 0) {
+    fogCtx.fillRect(offsetLeft, 0, gridRight - offsetLeft, offsetTop);
+  }
+  if (gridBottom < mapH) {
+    fogCtx.fillRect(offsetLeft, gridBottom, gridRight - offsetLeft, mapH - gridBottom);
+  }
+
+  // Addressable cells.
   for (let c = 0; c < cols; c++) {
     for (let r = 0; r < rows; r++) {
       const key = c + ',' + r;
@@ -157,16 +187,12 @@ export function renderFog(state) {
  * Render the selection highlight overlay (separate canvas).
  */
 export function renderFogSelection() {
-  if (!selCanvas || !selCtx) {
-    fogWarn('renderFogSelection: missing canvas/ctx — selCanvas:', !!selCanvas, 'selCtx:', !!selCtx);
-    return;
-  }
+  if (!selCanvas || !selCtx) return;
 
   const view = viewStateRef ?? {};
   const mapW = Number.isFinite(view.mapPixelSize?.width) ? view.mapPixelSize.width : 0;
   const mapH = Number.isFinite(view.mapPixelSize?.height) ? view.mapPixelSize.height : 0;
   if (mapW <= 0 || mapH <= 0) {
-    fogWarn('renderFogSelection: mapPixelSize invalid — clearing canvas. mapW:', mapW, 'mapH:', mapH);
     clearCanvas(selCtx, selCanvas);
     return;
   }
@@ -205,44 +231,44 @@ export function renderFogSelection() {
 }
 
 /**
- * Returns true if a placement at the given grid position is hidden by fog
- * for a non-GM user.  Used by board-interactions to block token clicks.
+ * Returns true if a placement at the given grid position on the given level
+ * is hidden by fog for a non-GM user. Used to block token clicks.
  */
-export function isPositionFogged(state, col, row) {
+export function isPositionFogged(state, col, row, levelId) {
   if (isGm) return false;
 
   const activeSceneId = state?.boardState?.activeSceneId ?? null;
   if (!activeSceneId) return false;
 
-  const fogState = getFogState(state, activeSceneId);
-  if (!fogState || !fogState.enabled) return false;
+  const lvlId = levelId || resolveActiveLevelId(state, activeSceneId);
+  const levelFog = getLevelFog(state, activeSceneId, lvlId);
+  if (!levelFog || !levelFog.enabled) return false;
 
   const key = Math.floor(col) + ',' + Math.floor(row);
-  const revealed = fogState.revealedCells ?? {};
-  if (revealed[key]) return false;
+  if (levelFog.revealedCells && levelFog.revealedCells[key]) return false;
 
-  // Check PC auto-reveal
-  const pcCells = buildPcRevealedCells(state, activeSceneId);
+  const pcCells = buildPcRevealedCells(state, activeSceneId, lvlId);
   if (pcCells.has(key)) return false;
 
   return true;
 }
 
 /**
- * Create a fog-check function with pre-computed data for efficient batch
- * checks (e.g. during token rendering).  Returns null when fog is inactive.
+ * Pre-compute a fog checker for a given level for use during batch rendering.
+ * Returns null when fog is inactive on that level.
  */
-export function createFogChecker(state) {
+export function createFogChecker(state, levelId) {
   if (isGm) return null;
 
   const activeSceneId = state?.boardState?.activeSceneId ?? null;
   if (!activeSceneId) return null;
 
-  const fogState = getFogState(state, activeSceneId);
-  if (!fogState || !fogState.enabled) return null;
+  const lvlId = levelId || resolveActiveLevelId(state, activeSceneId);
+  const levelFog = getLevelFog(state, activeSceneId, lvlId);
+  if (!levelFog || !levelFog.enabled) return null;
 
-  const revealed = fogState.revealedCells ?? {};
-  const pcCells = buildPcRevealedCells(state, activeSceneId);
+  const revealed = levelFog.revealedCells ?? {};
+  const pcCells = buildPcRevealedCells(state, activeSceneId, lvlId);
 
   return (col, row) => {
     const key = Math.floor(col) + ',' + Math.floor(row);
@@ -250,55 +276,92 @@ export function createFogChecker(state) {
   };
 }
 
-/**
- * Returns true if fog-select mode is currently active.
- */
 export function isFogSelectActive() {
   return fogSelectActive;
 }
 
 /**
- * Toggle fog enabled/disabled for the given scene.
+ * Toggle fog enabled/disabled for a specific level within a scene.
  */
-export function toggleFogForScene(sceneId, enabled, options = {}) {
-  fogLog('toggleFogForScene:', sceneId, 'enabled:', enabled);
-  if (!boardApi || !sceneId) return;
-
+export function toggleFogForLevel(sceneId, levelId, enabled, options = {}) {
+  if (!boardApi || !sceneId || !levelId) return;
   const markDirty = options.markSceneStateDirty;
 
   boardApi.updateState((draft) => {
-    if (!draft.boardState.sceneState) {
-      draft.boardState.sceneState = {};
-    }
-    if (!draft.boardState.sceneState[sceneId]) {
-      draft.boardState.sceneState[sceneId] = { grid: { size: 64, locked: false, visible: true } };
-    }
-    if (!draft.boardState.sceneState[sceneId].fogOfWar) {
-      draft.boardState.sceneState[sceneId].fogOfWar = { enabled: false, revealedCells: {} };
-    }
-    draft.boardState.sceneState[sceneId].fogOfWar.enabled = Boolean(enabled);
-    // When enabling, start fully fogged (revealedCells stays as-is or empty)
+    const sceneEntry = ensureSceneEntry(draft, sceneId);
+    const levelEntry = ensureLevelFogEntry(sceneEntry, levelId);
+    levelEntry.enabled = Boolean(enabled);
   });
 
   if (typeof markDirty === 'function') markDirty(sceneId);
 }
 
 /**
- * Get the current fog state for a scene.
+ * Get the fog state for a specific level within a scene.
  */
+export function getFogStateForLevel(state, sceneId, levelId) {
+  return getLevelFog(state, sceneId, levelId);
+}
+
+// Back-compat alias kept for any callers still using the old name.
 export function getFogStateForScene(state, sceneId) {
-  return getFogState(state, sceneId);
+  const lvlId = resolveActiveLevelId(state, sceneId);
+  return getLevelFog(state, sceneId, lvlId);
 }
 
 // ── Internal helpers ─────────────────────────────────────────────
 
-function getFogState(state, sceneId) {
-  if (!sceneId) return null;
+function resolveActiveLevelId(state, sceneId) {
+  try {
+    const id = getActiveLevelId(state, sceneId);
+    return typeof id === 'string' && id ? id : BASE_MAP_LEVEL_ID;
+  } catch (e) {
+    return BASE_MAP_LEVEL_ID;
+  }
+}
+
+function getLevelFog(state, sceneId, levelId) {
+  if (!sceneId || !levelId) return null;
   const sceneState = state?.boardState?.sceneState;
   if (!sceneState || typeof sceneState !== 'object') return null;
   const entry = sceneState[sceneId];
   if (!entry || typeof entry !== 'object') return null;
-  return entry.fogOfWar ?? null;
+  const fog = entry.fogOfWar;
+  if (!fog || typeof fog !== 'object') return null;
+  const byLevel = fog.byLevel;
+  if (!byLevel || typeof byLevel !== 'object') return null;
+  const levelEntry = byLevel[levelId];
+  if (!levelEntry || typeof levelEntry !== 'object') return null;
+  return levelEntry;
+}
+
+function ensureSceneEntry(draft, sceneId) {
+  if (!draft.boardState.sceneState) draft.boardState.sceneState = {};
+  if (!draft.boardState.sceneState[sceneId] || typeof draft.boardState.sceneState[sceneId] !== 'object') {
+    draft.boardState.sceneState[sceneId] = { grid: { size: 64, locked: false, visible: true } };
+  }
+  const entry = draft.boardState.sceneState[sceneId];
+  if (!entry.fogOfWar || typeof entry.fogOfWar !== 'object') {
+    entry.fogOfWar = { byLevel: {} };
+  }
+  if (!entry.fogOfWar.byLevel || typeof entry.fogOfWar.byLevel !== 'object'
+      || Array.isArray(entry.fogOfWar.byLevel)) {
+    entry.fogOfWar.byLevel = {};
+  }
+  return entry;
+}
+
+function ensureLevelFogEntry(sceneEntry, levelId) {
+  const byLevel = sceneEntry.fogOfWar.byLevel;
+  if (!byLevel[levelId] || typeof byLevel[levelId] !== 'object') {
+    byLevel[levelId] = { enabled: false, revealedCells: {} };
+  }
+  const levelEntry = byLevel[levelId];
+  if (!levelEntry.revealedCells || typeof levelEntry.revealedCells !== 'object'
+      || Array.isArray(levelEntry.revealedCells)) {
+    levelEntry.revealedCells = {};
+  }
+  return levelEntry;
 }
 
 function clearCanvas(ctx, canvas) {
@@ -307,11 +370,13 @@ function clearCanvas(ctx, canvas) {
 }
 
 /**
- * Build a Set of "col,row" keys for cells occupied by PC-folder tokens.
+ * PC tokens auto-reveal the cells they occupy. With per-level fog this only
+ * applies to the level the PC is on — a PC on Level 3 does not reveal
+ * Level 2's fog beneath them.
  */
-function buildPcRevealedCells(state, activeSceneId) {
+function buildPcRevealedCells(state, activeSceneId, levelId) {
   const cells = new Set();
-  if (!state || !activeSceneId) return cells;
+  if (!state || !activeSceneId || !levelId) return cells;
 
   const placements = state.boardState?.placements?.[activeSceneId];
   if (!Array.isArray(placements)) return cells;
@@ -320,7 +385,6 @@ function buildPcRevealedCells(state, activeSceneId) {
   const playerFolderKey = normalizePlayerTokenFolderName(PLAYER_VISIBLE_TOKEN_FOLDER);
   if (!playerFolderKey) return cells;
 
-  // Build a set of folder IDs that match the PC folder name
   const pcFolderIds = new Set();
   (tokens.folders ?? []).forEach((folder) => {
     if (!folder || typeof folder !== 'object') return;
@@ -330,14 +394,12 @@ function buildPcRevealedCells(state, activeSceneId) {
     }
   });
 
-  // Build a set of token IDs that belong to PC folders
   const pcTokenIds = new Set();
   (tokens.items ?? []).forEach((token) => {
     if (!token || typeof token !== 'object') return;
     if (token.folderId && pcFolderIds.has(token.folderId)) {
       pcTokenIds.add(token.id);
     }
-    // Also check inline folder name
     if (token.folder && typeof token.folder.name === 'string') {
       if (normalizePlayerTokenFolderName(token.folder.name) === playerFolderKey) {
         pcTokenIds.add(token.id);
@@ -347,8 +409,9 @@ function buildPcRevealedCells(state, activeSceneId) {
 
   placements.forEach((placement) => {
     if (!placement || typeof placement !== 'object') return;
+    if (resolvePlacementLevelId(placement) !== levelId) return;
+
     const tokenId = typeof placement.tokenId === 'string' ? placement.tokenId : '';
-    // Check if this placement's token is in a PC folder
     const isPc = pcTokenIds.has(tokenId) || placement.combatTeam === 'ally';
     if (!isPc) return;
 
@@ -367,6 +430,92 @@ function buildPcRevealedCells(state, activeSceneId) {
   return cells;
 }
 
+// ── Cutout cascade ───────────────────────────────────────────────
+
+/**
+ * Build the per-scene level view model: ordered list of levels (Level 0
+ * first, then stored levels by zIndex ascending) including their cutouts.
+ */
+function getLevelViewModel(state, sceneId) {
+  if (!sceneId) return [];
+  const sceneEntry = state?.boardState?.sceneState?.[sceneId];
+  const sceneList = state?.scenes?.items ?? [];
+  const sceneDef = sceneList.find((s) => s && s.id === sceneId) ?? null;
+  return buildLevelViewModel({
+    baseMapUrl: sceneDef?.mapUrl ?? null,
+    mapLevels: sceneEntry?.mapLevels ?? null,
+    sceneGrid: sceneEntry?.grid ?? null,
+  });
+}
+
+export function levelHasCutoutAt(level, col, row) {
+  if (!level || !Array.isArray(level.cutouts)) return false;
+  return level.cutouts.some((cutout) => {
+    if (!cutout || typeof cutout !== 'object') return false;
+    const cCol = Math.floor(Number(cutout.column ?? 0));
+    const cRow = Math.floor(Number(cutout.row ?? 0));
+    const cW = Math.max(1, Math.floor(Number(cutout.width ?? 1)));
+    const cH = Math.max(1, Math.floor(Number(cutout.height ?? 1)));
+    return col >= cCol && col < cCol + cW && row >= cRow && row < cRow + cH;
+  });
+}
+
+/**
+ * For a given level, return the level immediately below it (highest zIndex
+ * less than this level's zIndex). Returns null if there is no level below.
+ */
+function levelDirectlyBelow(viewModel, levelId) {
+  const current = viewModel.find((lvl) => lvl && lvl.id === levelId);
+  if (!current) return null;
+  const currentZ = Number.isFinite(current.zIndex) ? current.zIndex : 0;
+  let best = null;
+  let bestZ = -Infinity;
+  viewModel.forEach((lvl) => {
+    if (!lvl || lvl.id === levelId) return;
+    const z = Number.isFinite(lvl.zIndex) ? lvl.zIndex : 0;
+    if (z < currentZ && z > bestZ) {
+      best = lvl;
+      bestZ = z;
+    }
+  });
+  return best;
+}
+
+/**
+ * For each (col, row) reveal happening on `originLevelId`, walk down through
+ * cutouts and write reveals into each lower level whose own column over the
+ * cell is gated by a cutout. Mutates `byLevel` in place.
+ */
+export function cascadeReveals(byLevel, viewModel, originLevelId, cellKeys) {
+  if (!Array.isArray(viewModel) || viewModel.length === 0) return;
+  if (!cellKeys || cellKeys.length === 0) return;
+
+  cellKeys.forEach((key) => {
+    const [cStr, rStr] = key.split(',');
+    const col = parseInt(cStr, 10);
+    const row = parseInt(rStr, 10);
+    if (!Number.isFinite(col) || !Number.isFinite(row)) return;
+
+    let currentLevel = viewModel.find((lvl) => lvl && lvl.id === originLevelId);
+    while (currentLevel && levelHasCutoutAt(currentLevel, col, row)) {
+      const below = levelDirectlyBelow(viewModel, currentLevel.id);
+      if (!below) break;
+
+      if (!byLevel[below.id] || typeof byLevel[below.id] !== 'object') {
+        byLevel[below.id] = { enabled: false, revealedCells: {} };
+      }
+      const target = byLevel[below.id];
+      if (!target.revealedCells || typeof target.revealedCells !== 'object'
+          || Array.isArray(target.revealedCells)) {
+        target.revealedCells = {};
+      }
+      target.revealedCells[key] = true;
+
+      currentLevel = below;
+    }
+  });
+}
+
 // ── Panel (GM only) ──────────────────────────────────────────────
 
 function mountPanel() {
@@ -376,7 +525,6 @@ function mountPanel() {
     document.getElementById('vtt-app')?.appendChild(panelEl);
   }
 
-  // Launcher button
   const launcher = document.querySelector('[data-settings-launch="fog"]');
   const syncLauncherActive = (open) => {
     if (!launcher) return;
@@ -392,21 +540,20 @@ function mountPanel() {
     });
   }
 
-  // Close button
   panelEl.querySelector('[data-fog-close]')?.addEventListener('click', () => {
     panelEl.hidden = true;
     syncLauncherActive(false);
     deactivateFogSelect();
   });
 
-  // Toggle switch
   const toggleInput = panelEl.querySelector('[data-fog-toggle]');
   if (toggleInput) {
     toggleInput.addEventListener('change', () => {
       const state = boardApi?.getState?.() ?? {};
       const sceneId = state.boardState?.activeSceneId;
       if (!sceneId) return;
-      toggleFogForScene(sceneId, toggleInput.checked, {
+      const levelId = resolveActiveLevelId(state, sceneId);
+      toggleFogForLevel(sceneId, levelId, toggleInput.checked, {
         markSceneStateDirty: boardApi._markSceneStateDirty,
       });
       if (typeof boardApi._persistBoardState === 'function') {
@@ -415,10 +562,8 @@ function mountPanel() {
     });
   }
 
-  // Select button
   panelEl.querySelector('[data-fog-select]')?.addEventListener('click', () => {
     fogSelectActive = !fogSelectActive;
-    fogLog('Select Area toggled:', fogSelectActive);
     updateSelectButtonState();
     if (!fogSelectActive) {
       clearFogSelection();
@@ -426,12 +571,10 @@ function mountPanel() {
     updateActionButtonStates();
   });
 
-  // Clear Fog button
   panelEl.querySelector('[data-fog-clear]')?.addEventListener('click', () => {
     applyFogChange(false);
   });
 
-  // Add Fog button
   panelEl.querySelector('[data-fog-add]')?.addEventListener('click', () => {
     applyFogChange(true);
   });
@@ -450,7 +593,7 @@ function createPanelElement() {
       <button type="button" class="vtt-fog-panel__close" data-fog-close>&times;</button>
     </div>
     <div class="vtt-fog-panel__toggle-row">
-      <span class="vtt-fog-panel__toggle-label">Enabled</span>
+      <span class="vtt-fog-panel__toggle-label">Enabled (this level)</span>
       <label class="vtt-fog-toggle">
         <input type="checkbox" data-fog-toggle />
         <span class="vtt-fog-toggle__slider"></span>
@@ -523,60 +666,37 @@ function clearFogSelection() {
 }
 
 /**
- * Apply fog change (reveal or cover) to all selected cells.
+ * Apply fog change (reveal or cover) to all selected cells on the GM's
+ * current level. Revealing cascades through cutouts to lower levels;
+ * covering does NOT cascade.
  */
 function applyFogChange(addFog) {
-  fogLog('applyFogChange called — addFog:', addFog, 'selectedCells:', selectedCells.size);
-  if (selectedCells.size === 0) {
-    fogWarn('applyFogChange: no cells selected — aborting');
-    return;
-  }
+  if (selectedCells.size === 0) return;
 
   const state = boardApi?.getState?.() ?? {};
   const sceneId = state.boardState?.activeSceneId;
-  if (!sceneId) {
-    fogWarn('applyFogChange: no activeSceneId — aborting');
-    return;
-  }
+  if (!sceneId) return;
 
-  fogLog('applyFogChange: scene:', sceneId, 'cells:', Array.from(selectedCells).slice(0, 10).join('; '),
-    selectedCells.size > 10 ? `... (${selectedCells.size} total)` : '');
-
+  const levelId = resolveActiveLevelId(state, sceneId);
   const cellKeys = Array.from(selectedCells);
+  const viewModel = getLevelViewModel(state, sceneId);
 
   boardApi.updateState((draft) => {
-    if (!draft.boardState.sceneState) draft.boardState.sceneState = {};
-    if (!draft.boardState.sceneState[sceneId]) {
-      draft.boardState.sceneState[sceneId] = { grid: { size: 64, locked: false, visible: true } };
-    }
-    if (!draft.boardState.sceneState[sceneId].fogOfWar) {
-      draft.boardState.sceneState[sceneId].fogOfWar = { enabled: true, revealedCells: {} };
-    }
-
-    const fog = draft.boardState.sceneState[sceneId].fogOfWar;
-    if (!fog.revealedCells || typeof fog.revealedCells !== 'object' || Array.isArray(fog.revealedCells)) {
-      fog.revealedCells = {};
-    }
+    const sceneEntry = ensureSceneEntry(draft, sceneId);
+    const levelEntry = ensureLevelFogEntry(sceneEntry, levelId);
 
     cellKeys.forEach((key) => {
       if (addFog) {
-        delete fog.revealedCells[key];
+        delete levelEntry.revealedCells[key];
       } else {
-        fog.revealedCells[key] = true;
+        levelEntry.revealedCells[key] = true;
       }
     });
 
-    fogLog('applyFogChange: after update — fog.enabled:', fog.enabled,
-      'revealedCells count:', Object.keys(fog.revealedCells).length);
+    if (!addFog) {
+      cascadeReveals(sceneEntry.fogOfWar.byLevel, viewModel, levelId, cellKeys);
+    }
   });
-
-  // Verify the state was actually updated
-  const afterState = boardApi?.getState?.() ?? {};
-  const afterFog = afterState.boardState?.sceneState?.[sceneId]?.fogOfWar;
-  fogLog('applyFogChange: post-update verification — fogState:', afterFog ? {
-    enabled: afterFog.enabled,
-    revealedCount: afterFog.revealedCells ? Object.keys(afterFog.revealedCells).length : 0,
-  } : null);
 
   if (typeof boardApi._markSceneStateDirty === 'function') {
     boardApi._markSceneStateDirty(sceneId);
@@ -592,12 +712,8 @@ function applyFogChange(addFog) {
 
 function mountFogSelectInteraction() {
   const mapSurface = document.getElementById('vtt-map-surface');
-  if (!mapSurface) {
-    fogWarn('mountFogSelectInteraction: vtt-map-surface not found — fog selection will not work');
-    return;
-  }
+  if (!mapSurface) return;
 
-  fogLog('mountFogSelectInteraction: attaching pointerdown/move/up/cancel on', mapSurface.id);
   mapSurface.addEventListener('pointerdown', handleFogPointerDown, false);
   mapSurface.addEventListener('pointermove', handleFogPointerMove, false);
   mapSurface.addEventListener('pointerup', handleFogPointerUp, false);
@@ -605,25 +721,12 @@ function mountFogSelectInteraction() {
 }
 
 function handleFogPointerDown(event) {
-  fogLog('pointerdown on map surface — fogSelectActive:', fogSelectActive, 'button:', event.button);
   if (!fogSelectActive) return;
-  // Only handle left-click for fog selection
   if (event.button !== 0) return;
 
   const gridPos = pointerToGridCell(event);
-  fogLog('pointerToGridCell result:', gridPos);
-  if (!gridPos) {
-    fogWarn('pointerToGridCell returned null — selection aborted. viewState:', JSON.stringify({
-      scale: viewStateRef?.scale,
-      translation: viewStateRef?.translation,
-      gridSize: viewStateRef?.gridSize,
-      gridOffsets: viewStateRef?.gridOffsets,
-      mapPixelSize: viewStateRef?.mapPixelSize,
-    }));
-    return;
-  }
+  if (!gridPos) return;
 
-  // Prevent the default board interactions from also firing
   event.stopPropagation();
   event.preventDefault();
 
@@ -631,7 +734,6 @@ function handleFogPointerDown(event) {
   selectionStart = gridPos;
   selectionEnd = gridPos;
   updateSelectedCellsFromRect();
-  fogLog('selectedCells after pointerdown:', selectedCells.size, 'cells');
   renderFogSelection();
   updateActionButtonStates();
 }
@@ -648,11 +750,9 @@ function handleFogPointerMove(event) {
   updateActionButtonStates();
 }
 
-function handleFogPointerUp(event) {
+function handleFogPointerUp() {
   if (!pointerDownForFog) return;
   pointerDownForFog = false;
-
-  // Keep selection visible so user can click Clear/Add buttons
   updateActionButtonStates();
 }
 
@@ -662,9 +762,6 @@ function handleFogPointerCancel() {
   clearFogSelection();
 }
 
-/**
- * Convert a pointer event to grid cell {col, row}.
- */
 function pointerToGridCell(event) {
   const mapSurface = document.getElementById('vtt-map-surface');
   if (!mapSurface) return null;
@@ -695,9 +792,6 @@ function pointerToGridCell(event) {
   return { col, row };
 }
 
-/**
- * Fill selectedCells from the rectangle defined by selectionStart → selectionEnd.
- */
 function updateSelectedCellsFromRect() {
   selectedCells.clear();
   if (!selectionStart || !selectionEnd) return;
@@ -714,31 +808,4 @@ function updateSelectedCellsFromRect() {
       }
     }
   }
-}
-
-// ── Normalize fog data (used by store.js) ────────────────────────
-
-export function normalizeFogOfWarState(raw) {
-  if (!raw || typeof raw !== 'object') {
-    return null;
-  }
-
-  const enabled = Boolean(raw.enabled);
-  const revealedCells = {};
-
-  if (raw.revealedCells && typeof raw.revealedCells === 'object') {
-    Object.keys(raw.revealedCells).forEach((key) => {
-      // Validate key format: "col,row" where both are non-negative integers
-      const parts = key.split(',');
-      if (parts.length === 2) {
-        const col = parseInt(parts[0], 10);
-        const row = parseInt(parts[1], 10);
-        if (Number.isFinite(col) && Number.isFinite(row) && col >= 0 && row >= 0) {
-          revealedCells[col + ',' + row] = true;
-        }
-      }
-    });
-  }
-
-  return { enabled, revealedCells };
 }

--- a/dnd/vtt/assets/js/ui/scene-manager.js
+++ b/dnd/vtt/assets/js/ui/scene-manager.js
@@ -693,7 +693,7 @@ function ensureSceneBoardStateEntry(boardState, sceneId, fallbackGrid = null) {
   const entry = {
     grid: normalizeGridConfig(fallbackGrid ?? {}),
     mapLevels: createEmptyMapLevelsState(),
-    fogOfWar: { enabled: true, revealedCells: {} },
+    fogOfWar: { byLevel: {} },
   };
   boardState.sceneState[key] = entry;
   return entry;

--- a/dnd/vtt/assets/js/utils/__tests__/merge-helpers.test.mjs
+++ b/dnd/vtt/assets/js/utils/__tests__/merge-helpers.test.mjs
@@ -118,12 +118,25 @@ test('mergeSceneStatePreservingGrid: breaks equal combat sequence ties by timest
   assert.equal(freshMerge.s.combat.phase, 'fresh');
 });
 
-test('mergeSceneStatePreservingGrid: coerces array revealedCells to object', () => {
-  const existing = { s: { fogOfWar: { revealedCells: { '1,1': true } } } };
-  const incoming = { s: { fogOfWar: { revealedCells: [] } } };
+test('mergeSceneStatePreservingGrid: coerces array revealedCells to object (per-level)', () => {
+  const existing = {
+    s: {
+      fogOfWar: {
+        byLevel: { 'level-0': { enabled: true, revealedCells: { '1,1': true } } },
+      },
+    },
+  };
+  const incoming = {
+    s: {
+      fogOfWar: {
+        byLevel: { 'level-0': { enabled: true, revealedCells: [] } },
+      },
+    },
+  };
   const merged = mergeSceneStatePreservingGrid(existing, incoming);
-  assert.equal(Array.isArray(merged.s.fogOfWar.revealedCells), false);
-  assert.equal(typeof merged.s.fogOfWar.revealedCells, 'object');
+  const level0 = merged.s.fogOfWar.byLevel['level-0'];
+  assert.equal(Array.isArray(level0.revealedCells), false);
+  assert.equal(typeof level0.revealedCells, 'object');
 });
 
 test('mergeBoardStateSnapshot: returns existing when incoming is not an object', () => {

--- a/dnd/vtt/assets/js/utils/merge-helpers.js
+++ b/dnd/vtt/assets/js/utils/merge-helpers.js
@@ -207,18 +207,50 @@ export function mergeSceneStatePreservingGrid(existingSceneState, incomingSceneS
 
     // fogOfWar: trust incoming (server) as authoritative so the GM can
     // re-add fog. Only fall back to existing when incoming has none.
+    // Per-level shape: { byLevel: { [levelId]: { enabled, revealedCells } } }.
+    // We merge by level so a save touching one level does not drop others.
     if (existingEntry && typeof existingEntry === 'object' && existingEntry.fogOfWar &&
         typeof existingEntry.fogOfWar === 'object') {
+      const existingFog = existingEntry.fogOfWar;
       if (!mergedEntry.fogOfWar || typeof mergedEntry.fogOfWar !== 'object') {
-        mergedEntry.fogOfWar = JSON.parse(JSON.stringify(existingEntry.fogOfWar));
-      } else if (Array.isArray(mergedEntry.fogOfWar.revealedCells)) {
-        // PHP encodes empty {} as [] — coerce back to a plain object.
-        mergedEntry.fogOfWar.revealedCells = {};
+        mergedEntry.fogOfWar = JSON.parse(JSON.stringify(existingFog));
+      } else {
+        if (!mergedEntry.fogOfWar.byLevel || typeof mergedEntry.fogOfWar.byLevel !== 'object'
+            || Array.isArray(mergedEntry.fogOfWar.byLevel)) {
+          mergedEntry.fogOfWar.byLevel = {};
+        }
+        const existingByLevel = (existingFog.byLevel && typeof existingFog.byLevel === 'object'
+          && !Array.isArray(existingFog.byLevel))
+          ? existingFog.byLevel
+          : {};
+        Object.keys(existingByLevel).forEach((levelId) => {
+          const incomingLevel = mergedEntry.fogOfWar.byLevel[levelId];
+          const incomingHasContent = incomingLevel && typeof incomingLevel === 'object'
+            && (incomingLevel.enabled
+              || (incomingLevel.revealedCells
+                && typeof incomingLevel.revealedCells === 'object'
+                && !Array.isArray(incomingLevel.revealedCells)
+                && Object.keys(incomingLevel.revealedCells).length > 0));
+          if (!incomingHasContent) {
+            mergedEntry.fogOfWar.byLevel[levelId] = JSON.parse(JSON.stringify(existingByLevel[levelId]));
+          }
+        });
       }
     }
 
-    if (mergedEntry.fogOfWar && Array.isArray(mergedEntry.fogOfWar.revealedCells)) {
-      mergedEntry.fogOfWar.revealedCells = {};
+    // Coerce PHP-encoded [] back to {} for revealedCells on every level.
+    if (mergedEntry.fogOfWar && typeof mergedEntry.fogOfWar === 'object') {
+      if (Array.isArray(mergedEntry.fogOfWar.byLevel)) {
+        mergedEntry.fogOfWar.byLevel = {};
+      }
+      if (mergedEntry.fogOfWar.byLevel && typeof mergedEntry.fogOfWar.byLevel === 'object') {
+        Object.keys(mergedEntry.fogOfWar.byLevel).forEach((levelId) => {
+          const entry = mergedEntry.fogOfWar.byLevel[levelId];
+          if (entry && typeof entry === 'object' && Array.isArray(entry.revealedCells)) {
+            entry.revealedCells = {};
+          }
+        });
+      }
     }
 
     merged[sceneId] = mergedEntry;

--- a/dnd/vtt/bootstrap.php
+++ b/dnd/vtt/bootstrap.php
@@ -151,19 +151,49 @@ function getVttBootstrapConfig(?array $authContext = null): array
     $tokens = loadVttTokens();
     $boardState = loadVttJson('board-state.json');
 
-    // Normalize fogOfWar.revealedCells to ensure it's always a JSON object, not an array.
+    // Normalize fogOfWar revealedCells to ensure they're always JSON objects, not arrays.
     // PHP's json_encode() turns empty PHP arrays into [] (JSON array) instead of {} (JSON object).
     // JavaScript treats [] as an Array, so setting arr["36,66"] = true creates an expando property
     // that JSON.stringify() silently drops (non-numeric keys on arrays are ignored).
+    // Per-level shape: fogOfWar.byLevel[levelId] = { enabled, revealedCells }.
     if (is_array($boardState) && isset($boardState['sceneState']) && is_array($boardState['sceneState'])) {
         foreach ($boardState['sceneState'] as &$scene) {
-            if (is_array($scene) && isset($scene['fogOfWar']) && is_array($scene['fogOfWar'])) {
-                if (!isset($scene['fogOfWar']['revealedCells'])
-                    || !is_array($scene['fogOfWar']['revealedCells'])
-                    || empty($scene['fogOfWar']['revealedCells'])) {
-                    $scene['fogOfWar']['revealedCells'] = new \stdClass();
-                }
+            if (!is_array($scene) || !isset($scene['fogOfWar']) || !is_array($scene['fogOfWar'])) {
+                continue;
             }
+            $fog = &$scene['fogOfWar'];
+
+            // Migrate legacy { enabled, revealedCells } at the top level into byLevel['level-0'].
+            $hasLegacy = array_key_exists('enabled', $fog) || array_key_exists('revealedCells', $fog);
+            $hasByLevel = isset($fog['byLevel']) && is_array($fog['byLevel']);
+            if ($hasLegacy && !$hasByLevel) {
+                $legacyCells = (isset($fog['revealedCells']) && is_array($fog['revealedCells']))
+                    ? $fog['revealedCells']
+                    : [];
+                $fog['byLevel'] = [
+                    'level-0' => [
+                        'enabled' => !empty($fog['enabled']),
+                        'revealedCells' => empty($legacyCells) ? new \stdClass() : $legacyCells,
+                    ],
+                ];
+                unset($fog['enabled'], $fog['revealedCells']);
+                $hasByLevel = true;
+            }
+
+            if ($hasByLevel) {
+                foreach ($fog['byLevel'] as &$levelEntry) {
+                    if (!is_array($levelEntry)) continue;
+                    if (!isset($levelEntry['revealedCells'])
+                        || !is_array($levelEntry['revealedCells'])
+                        || empty($levelEntry['revealedCells'])) {
+                        $levelEntry['revealedCells'] = new \stdClass();
+                    }
+                }
+                unset($levelEntry);
+            } else {
+                $fog['byLevel'] = new \stdClass();
+            }
+            unset($fog);
         }
         unset($scene);
     }


### PR DESCRIPTION
Each map level now has its own independent fog layer. The GM panel's toggle / Select Area / Clear / Add buttons act on the GM's currently viewed level only, and the viewer (player or GM) sees fog for their own current level. New levels start with fog disabled.

Cutout cascade: when fog is revealed on a square that sits over a cutout, the reveal auto-propagates to the level immediately below, and keeps cascading through any stacked cutouts down to Level 0. Cascade is one-way — re-fogging on the higher level does not un-cascade.

Storage shape: sceneState[sceneId].fogOfWar.byLevel[levelId] = { enabled, revealedCells }. Legacy { enabled, revealedCells } at the top of fogOfWar auto-migrates to Level 0 on first read (client + server).

Also fixes a long-standing alignment bug where the fog overlay was misaligned whenever a non-zero grid origin shifted the addressable grid inward: the fog cell loop only used left/top insets, ignoring right/ bottom, and never painted the unaddressable strips outside the grid. The cell count is now bounded by both insets and the four border bands are filled with full fog so there are no unfogged frames around the gridded area.

PC auto-reveal is now scoped to the PC's own level — a PC standing on Level 3 no longer reveals squares beneath them on Level 2.

Sync safety:
- Snapshot/restore in normalize/fog.js walks per-level so a partial save on one level can't erase another.
- Merge helpers preserve untouched levels through partial sceneState saves.
- PHP coercion in bootstrap.php and state.php walks byLevel and coerces each level's empty [] back to {} (PHP json_encode's array-vs-object hazard).

Test suite: 514/514 passing. Added fog-cascade.test.mjs covering single-hop, multi-hop, cascade-stops-at-no-cutout, multi-cell, and rectangular cutouts. Updated existing fog tests for the new shape.