### PR TITLE
Auto-populate GM active level on login and scene activation

### DIFF
--- a/dnd/vtt/assets/js/bootstrap.js
+++ b/dnd/vtt/assets/js/bootstrap.js
@@ -25,6 +25,7 @@ import {
   BASE_MAP_LEVEL_ID,
   normalizeMapLevelsState,
   resolvePcTokenLevelIdForUser,
+  resolveTopmostLevelId,
 } from './state/normalize/map-levels.js';
 
 async function bootstrap() {
@@ -197,6 +198,8 @@ async function hydrateFromServer(routes, userContext) {
               authorRole: 'player',
             };
             applyPcTokenLevelOverride(nextBoardState, currentState?.user?.name);
+          } else {
+            applyGmActiveLevelOverride(nextBoardState, currentState?.user?.name);
           }
           draft.boardState = nextBoardState;
         }
@@ -252,6 +255,65 @@ function applyPcTokenLevelOverride(nextBoardState, userName) {
   sceneEntry.userLevelState[userKey] = {
     levelId: pcLevelId,
     _lastModified: Date.now(),
+  };
+}
+
+// On GM login, ensure `userLevelState[gm]` for the active scene names a
+// valid level. The fog renderer and the top-right level indicator both
+// resolve through this entry; when it is missing they fall back to
+// Level 0, so fog edits made on what visually looks like Level 1 land on
+// Level 0 instead. We preserve any saved entry so the GM resumes where
+// they left off, and only default to the topmost level when no prior
+// entry exists or it points at a level that has since been deleted.
+function applyGmActiveLevelOverride(nextBoardState, userName) {
+  const userKey = typeof userName === 'string' ? userName.trim().toLowerCase() : '';
+  if (!userKey) return;
+  const sceneId =
+    typeof nextBoardState?.activeSceneId === 'string' ? nextBoardState.activeSceneId : '';
+  if (!sceneId) return;
+  if (!nextBoardState.sceneState || typeof nextBoardState.sceneState !== 'object') {
+    nextBoardState.sceneState = {};
+  }
+  const sceneEntry =
+    nextBoardState.sceneState[sceneId] && typeof nextBoardState.sceneState[sceneId] === 'object'
+      ? nextBoardState.sceneState[sceneId]
+      : null;
+  if (!sceneEntry) return;
+
+  const normalizedMapLevels = normalizeMapLevelsState(sceneEntry.mapLevels ?? null, {
+    sceneGrid: sceneEntry.grid ?? null,
+  });
+  const validLevelIds = new Set([BASE_MAP_LEVEL_ID]);
+  normalizedMapLevels.levels.forEach((level) => {
+    if (level && typeof level.id === 'string' && level.id) {
+      validLevelIds.add(level.id);
+    }
+  });
+
+  const existing =
+    sceneEntry.userLevelState && typeof sceneEntry.userLevelState === 'object'
+      ? sceneEntry.userLevelState[userKey]
+      : null;
+  const existingLevelId =
+    existing && typeof existing === 'object' && typeof existing.levelId === 'string'
+      ? existing.levelId.trim()
+      : '';
+  if (existingLevelId && validLevelIds.has(existingLevelId)) {
+    return;
+  }
+
+  const topmostLevelId = resolveTopmostLevelId({
+    baseMapUrl: nextBoardState.mapUrl ?? null,
+    mapLevels: sceneEntry.mapLevels ?? null,
+    sceneGrid: sceneEntry.grid ?? null,
+  });
+  if (!sceneEntry.userLevelState || typeof sceneEntry.userLevelState !== 'object') {
+    sceneEntry.userLevelState = {};
+  }
+  sceneEntry.userLevelState[userKey] = {
+    levelId: topmostLevelId,
+    source: 'manual',
+    updatedAt: Date.now(),
   };
 }
 

--- a/dnd/vtt/assets/js/state/__tests__/map-levels-v2-normalization.test.mjs
+++ b/dnd/vtt/assets/js/state/__tests__/map-levels-v2-normalization.test.mjs
@@ -14,6 +14,7 @@ import {
   resolveActiveLevelIdForUser,
   resolvePcTokenLevelIdForUser,
   resolvePlacementLevelId,
+  resolveTopmostLevelId,
 } from '../normalize/map-levels.js';
 import { normalizeSceneBoardState } from '../normalize/scene-board-state.js';
 
@@ -100,6 +101,32 @@ describe('Levels v2 — buildLevelViewModel', () => {
     assert.equal(levelIdExistsInViewModel('a', view), true);
     assert.equal(levelIdExistsInViewModel('missing', view), false);
     assert.equal(levelIdExistsInViewModel('', view), false);
+  });
+});
+
+describe('Levels v2 — resolveTopmostLevelId', () => {
+  test('returns the highest-zIndex stored level id', () => {
+    assert.equal(
+      resolveTopmostLevelId({
+        baseMapUrl: '/m.png',
+        mapLevels: {
+          levels: [
+            { id: 'low', zIndex: 0 },
+            { id: 'top', zIndex: 5 },
+            { id: 'mid', zIndex: 2 },
+          ],
+        },
+      }),
+      'top'
+    );
+  });
+
+  test('falls back to BASE_MAP_LEVEL_ID when no stored levels exist', () => {
+    assert.equal(
+      resolveTopmostLevelId({ baseMapUrl: null, mapLevels: { levels: [] } }),
+      BASE_MAP_LEVEL_ID
+    );
+    assert.equal(resolveTopmostLevelId({}), BASE_MAP_LEVEL_ID);
   });
 });
 

--- a/dnd/vtt/assets/js/state/normalize/map-levels.js
+++ b/dnd/vtt/assets/js/state/normalize/map-levels.js
@@ -295,6 +295,22 @@ export function buildLevelViewModel({ baseMapUrl = null, mapLevels = null, scene
 }
 
 /**
+ * Levels v2 helper: return the id of the topmost (highest zIndex) level
+ * in a scene. Falls back to `BASE_MAP_LEVEL_ID` when no stored levels
+ * exist. Used to default the GM's active level on login / scene
+ * activation when no prior `userLevelState` entry is saved.
+ */
+export function resolveTopmostLevelId({ baseMapUrl = null, mapLevels = null, sceneGrid = null } = {}) {
+  const viewModel = buildLevelViewModel({ baseMapUrl, mapLevels, sceneGrid });
+  if (!Array.isArray(viewModel) || viewModel.length === 0) {
+    return BASE_MAP_LEVEL_ID;
+  }
+  const last = viewModel[viewModel.length - 1];
+  const id = last && typeof last.id === 'string' ? last.id : '';
+  return id || BASE_MAP_LEVEL_ID;
+}
+
+/**
  * Levels v2 helper: validate a level id against a built view model.
  * Returns the id if it exists in the view model, otherwise null.
  */

--- a/dnd/vtt/assets/js/ui/scene-manager.js
+++ b/dnd/vtt/assets/js/ui/scene-manager.js
@@ -11,6 +11,7 @@ import {
   MAP_LEVEL_MAX_LEVELS,
   createEmptyMapLevelsState,
   normalizeMapLevelsState,
+  resolveTopmostLevelId,
 } from '../state/normalize/map-levels.js';
 
 export function renderSceneList(routes, store) {
@@ -132,6 +133,9 @@ export function renderSceneList(routes, store) {
       const scene = sceneState.items.find((item) => item.id === sceneId);
       if (!scene) return;
 
+      const isGM = Boolean(currentState?.user?.isGM);
+      const gmName = typeof currentState?.user?.name === 'string' ? currentState.user.name : '';
+
       stateApi.updateState?.((draft) => {
         ensureSceneDraft(draft);
         const boardDraft = ensureBoardStateDraft(draft);
@@ -155,6 +159,15 @@ export function renderSceneList(routes, store) {
         // This ensures consistency between the scene definition and the board state
         if (boardDraft.sceneState && boardDraft.sceneState[scene.id]) {
           boardDraft.sceneState[scene.id].grid = sceneGrid;
+        }
+        if (isGM) {
+          // Ensure the GM's per-user level entry is populated for the
+          // activated scene. Without this, fog edits and the level
+          // indicator silently fall back to Level 0 until the GM
+          // presses an up/down arrow. Preserve any saved entry so the
+          // GM resumes where they left off; default to the topmost
+          // level only when no valid entry exists.
+          ensureGmActiveLevelEntry(boardDraft, scene.id, gmName);
         }
       });
 
@@ -701,6 +714,50 @@ function ensureSceneBoardStateEntry(boardState, sceneId, fallbackGrid = null) {
 
 function normalizeGridConfig(raw = {}) {
   return normalizeGridState(raw);
+}
+
+function ensureGmActiveLevelEntry(boardDraft, sceneId, userName) {
+  const userKey = typeof userName === 'string' ? userName.trim().toLowerCase() : '';
+  if (!userKey || !sceneId || !boardDraft) return;
+  const sceneEntry =
+    boardDraft.sceneState && boardDraft.sceneState[sceneId] && typeof boardDraft.sceneState[sceneId] === 'object'
+      ? boardDraft.sceneState[sceneId]
+      : null;
+  if (!sceneEntry) return;
+
+  const validLevelIds = new Set([BASE_MAP_LEVEL_ID]);
+  const storedLevels = Array.isArray(sceneEntry.mapLevels?.levels) ? sceneEntry.mapLevels.levels : [];
+  storedLevels.forEach((level) => {
+    if (level && typeof level.id === 'string' && level.id) {
+      validLevelIds.add(level.id);
+    }
+  });
+
+  const existing =
+    sceneEntry.userLevelState && typeof sceneEntry.userLevelState === 'object'
+      ? sceneEntry.userLevelState[userKey]
+      : null;
+  const existingLevelId =
+    existing && typeof existing === 'object' && typeof existing.levelId === 'string'
+      ? existing.levelId.trim()
+      : '';
+  if (existingLevelId && validLevelIds.has(existingLevelId)) {
+    return;
+  }
+
+  const topmostLevelId = resolveTopmostLevelId({
+    baseMapUrl: boardDraft.mapUrl ?? null,
+    mapLevels: sceneEntry.mapLevels ?? null,
+    sceneGrid: sceneEntry.grid ?? null,
+  });
+  if (!sceneEntry.userLevelState || typeof sceneEntry.userLevelState !== 'object') {
+    sceneEntry.userLevelState = {};
+  }
+  sceneEntry.userLevelState[userKey] = {
+    levelId: topmostLevelId,
+    source: 'manual',
+    updatedAt: Date.now(),
+  };
 }
 
 const mapLevelSeed = Date.now();


### PR DESCRIPTION
Fog edits and the level indicator both resolve through userLevelState[gm], which was only written when the GM clicked the up/down arrows. On a fresh login or scene activation that field was missing, so the resolver fell back to level-0 — fog edits visually made on Level 1 silently landed on Level 0. Now the field is filled on hydration and on scene activate, preserving any saved entry and defaulting to the topmost level only when none exists.