### PR TITLE
Pass viewer level into cutout-editor preview render

### DIFF
--- a/dnd/data/version.json
+++ b/dnd/data/version.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.8.0",
-    "last_updated": "2026-04-28 00:00:00",
-    "build_number": 37
+    "version": "1.8.1",
+    "last_updated": "2026-05-01 00:00:00",
+    "build_number": 38
 }

--- a/dnd/vtt/assets/js/ui/board-interactions.js
+++ b/dnd/vtt/assets/js/ui/board-interactions.js
@@ -15615,7 +15615,17 @@ function createMapLevelCutoutTool() {
     }
 
     level.cutouts = cloneCutouts(draftCutouts);
-    mapLevelRenderer.sync(mapLevels, { sceneGrid: state.grid ?? sceneGrid, view: viewState });
+    // Pass the GM's actual viewer level so the renderer's Auto-mode filter
+    // matches `syncMapLevelsForState`. Falling back to `mapLevels.activeLevelId`
+    // (the legacy field, last set when a level was created) would render every
+    // stored level — leaking upper-level images and masks down onto lower
+    // viewer levels while the editor is open.
+    const viewerLevelId = getViewerLevelIdForCurrentUser(state, activeSceneId);
+    mapLevelRenderer.sync(mapLevels, {
+      sceneGrid: state.grid ?? sceneGrid,
+      view: viewState,
+      activeLevelId: viewerLevelId,
+    });
   }
 
   function resolveCutoutPixelRect(cutout) {


### PR DESCRIPTION
The cutout editor's `applyPreviewMask` synced the map-level renderer without forwarding the GM's per-user viewer level. The renderer fell back to `mapLevels.activeLevelId` — the legacy field that's only written by level create/upload/delete paths and points at whichever level was last touched (typically the topmost). With the wrong viewer-zIndex, `getRenderableMapLevels` skipped the Auto-mode filter for every higher level, so opening the editor (or any state change that re-fired `notifyMapLevelsChange` while open) would re-render every stored level. Upper-level images and cutout masks visually leaked onto whatever level the GM was actually viewing — looking like Level 3's cutouts had been copied onto Levels 1 and 2.

Resolve the viewer level via `getViewerLevelIdForCurrentUser` (same helper `syncMapLevelsForState` uses) and pass it through to `mapLevelRenderer.sync`, so the editor's preview render filters the stack identically to the normal render path.

516/516 JS tests pass.