### PR TITLE
perf(vtt): skip combat-tracker rebuild on selection-only renders

### DIFF
--- a/dnd/vtt/assets/js/ui/board-interactions.js
+++ b/dnd/vtt/assets/js/ui/board-interactions.js
@@ -3149,7 +3149,7 @@ export function mountBoardInteractions(store, routes = {}) {
             })
           : false;
         if (selectionChanged) {
-          renderTokens(boardApi.getState?.() ?? {}, tokenLayer, viewState);
+          renderTokens(boardApi.getState?.() ?? {}, tokenLayer, viewState, { skipTracker: true });
         }
         prepareTokenDrag(event, placement);
         templateTool.clearSelection();
@@ -3157,7 +3157,7 @@ export function mountBoardInteractions(store, routes = {}) {
         // Empty space clicked - start selection box for drag-to-select
         const isAdditive = event.shiftKey;
         if (!isAdditive && clearSelection()) {
-          renderTokens(boardApi.getState?.() ?? {}, tokenLayer, viewState);
+          renderTokens(boardApi.getState?.() ?? {}, tokenLayer, viewState, { skipTracker: true });
         }
         templateTool.clearSelection();
         clearDragCandidate();
@@ -3181,7 +3181,7 @@ export function mountBoardInteractions(store, routes = {}) {
             ? updateSelection(placement.id, { additive: false })
             : false;
           if (selectionChanged) {
-            renderTokens(boardApi.getState?.() ?? {}, tokenLayer, viewState);
+            renderTokens(boardApi.getState?.() ?? {}, tokenLayer, viewState, { skipTracker: true });
           }
           templateTool.clearSelection();
           clearDragCandidate();
@@ -5216,7 +5216,7 @@ export function mountBoardInteractions(store, routes = {}) {
     return Math.min(Math.max(value, min), max);
   }
 
-  function renderTokens(state = {}, layer, view) {
+  function renderTokens(state = {}, layer, view, options = {}) {
     if (!layer) {
       updateCombatTracker([], { activeIds: [], skipCache: true, skipPrune: true });
       return;
@@ -5515,7 +5515,13 @@ export function mountBoardInteractions(store, routes = {}) {
       renderedPlacements = [];
     }
 
-    updateCombatTracker(trackerEntries, { activeIds: activeCombatantIds });
+    // Selection-only renders pass skipTracker to avoid the tracker rebuild,
+    // which would otherwise call pruneCombatGroups → syncCombatStateToStore
+    // → persistBoardStateSnapshot. Selection has no effect on the tracker,
+    // so the rebuild is pure cost; the next state-driven render rebuilds it.
+    if (!options.skipTracker) {
+      updateCombatTracker(trackerEntries, { activeIds: activeCombatantIds });
+    }
 
     // Skip aura rendering during active drag for performance; auras snap on drop
     if (!viewState.dragState) {

--- a/dnd/vtt/assets/js/ui/token-interactions.js
+++ b/dnd/vtt/assets/js/ui/token-interactions.js
@@ -230,7 +230,7 @@ export function createTokenInteractions({
     });
 
     notifySelectionChanged();
-    renderTokens(boardApi.getState?.() ?? {}, tokenLayer, viewState);
+    renderTokens(boardApi.getState?.() ?? {}, tokenLayer, viewState, { skipTracker: true });
   }
 
   function cancelSelectionBox() {


### PR DESCRIPTION
Selection clicks (left-click, right-click, empty-space click, selection box) call renderTokens directly outside the applyStateToBoard pipeline. Inside renderTokens, updateCombatTracker → renderCombatTracker calls pruneCombatGroups → syncCombatStateToStore → persistBoardStateSnapshot. Because the call originates outside applyStateToBoard, isApplyingState is false and the sync guard does not fire, so every selection click triggers a server save attempt. The save then 409s against the current version, and the conflict-recovery path applies a full snapshot which fires another full render — turning a click into a multi-step sync storm.

Profiling (DevTools Performance tab) showed INP of 761 ms with a single token and 2,130 ms with ~10 tokens, almost entirely Scripting time. Painting cost was negligible (28-43 ms), confirming the lag is JS work, not graphics.

Add an `options.skipTracker` flag to renderTokens that the four selection-change call sites pass to skip the tracker rebuild. Selection state has no effect on tracker output, so the rebuild is pure cost on those paths. State-driven renders (apply pipeline, drag commit, fog updates, scene loads) keep rebuilding the tracker as before, so prune and sync still happen on real state changes.

No changes to sync logic, save logic, conflict handling, or the isApplyingState/suppressCombatStateSync guards.