### PR TITLE
perf(vtt): skip tracker rebuild in commitDragPreview's final render

### DIFF
--- a/dnd/vtt/assets/js/ui/token-interactions.js
+++ b/dnd/vtt/assets/js/ui/token-interactions.js
@@ -881,7 +881,13 @@ export function createTokenInteractions({
         : `Moved ${movedCount} ${noun}.`;
     }
 
-    renderTokens(boardApi.getState?.() ?? {}, tokenLayer, viewState);
+    // Tracker was already rebuilt by applyStateToBoard during the boardApi
+    // .updateState call above (and again if processPlacementFalls fired its
+    // own update). Rebuilding it again here would re-run pruneCombatGroups
+    // outside the isApplyingState guard, which calls syncCombatStateToStore
+    // → persistBoardStateSnapshot, producing a redundant save and the 409
+    // recovery cascade observed in profiling. Skip the tracker rebuild.
+    renderTokens(boardApi.getState?.() ?? {}, tokenLayer, viewState, { skipTracker: true });
 
     if (fallenIds.length && typeof triggerTokenFallAnimations === 'function') {
       triggerTokenFallAnimations(fallenIds);


### PR DESCRIPTION
Drop-the-token profiling (DevTools Performance) showed the original selection-click fix only addressed pointerdown — pointerup (drag commit) still produced a ~3,500 ms scripting cascade. Tracing the flame chart identified the second renderTokens call at the end of commitDragPreview as the trigger.

The flow is: commitDragPreview calls boardApi.updateState, whose subscriber applyStateToBoard runs synchronously and rebuilds the tracker (syncCombatStateToStore is correctly guarded by isApplyingState here). processPlacementFalls may run its own updateState, triggering another apply + tracker rebuild. Then commitDragPreview returns to its final renderTokens — but isApplyingState is now false, so the tracker rebuild this time calls syncCombatStateToStore → persistBoardStateSnapshot, which conflicts with the still-in-flight save from the original move, producing a 409 and the applyBoardStateConflictSnapshot recovery cascade.

Pass skipTracker on this trailing render. The tracker has already been rebuilt at least once by applyStateToBoard during the same call, so the second rebuild is purely redundant — and the only path that actually fires the unguarded sync.

No changes to sync logic, save logic, or any guards.