### PR TITLE
chore(vtt): add .htaccess to force revalidation of JS files

### DIFF
--- a/dnd/vtt/assets/js/.htaccess
+++ b/dnd/vtt/assets/js/.htaccess
@@ -1,0 +1,17 @@
+# Force browsers and intermediate caches (e.g. GoDaddy's edge cache,
+# CDN layers) to revalidate every JS file on each request. The browser
+# still keeps a cached copy for speed, but it asks the server "is this
+# still current?" via If-Modified-Since/ETag before using it. If the
+# server returns 304 Not Modified, the cache is reused; if the file
+# changed, the new version is fetched. Net effect: code changes go live
+# immediately without renames or version-bumping inner ES module imports.
+#
+# Why this is needed: the entry-point bootstrap.js gets ?v=$assetVersion
+# cache-busting, but ES module imports inside it (./ui/board-interactions.js,
+# ./ui/token-interactions.js, etc.) do NOT inherit query strings, so
+# nested imports were getting indefinitely cached at the GoDaddy layer.
+<IfModule mod_headers.c>
+    <FilesMatch "\.js$">
+        Header set Cache-Control "no-cache, must-revalidate, max-age=0"
+    </FilesMatch>
+</IfModule>


### PR DESCRIPTION
ES module imports do not inherit query strings from their loader, so the existing ?v=$assetVersion cache-busting on bootstrap.js had no effect on the nested imports (board-interactions.js, token-interactions.js, etc.). Result: GoDaddy's edge cache and the browser were holding onto stale copies indefinitely, even after deploys updated the files on disk.

Add Cache-Control: no-cache, must-revalidate, max-age=0 for all JS files under dnd/vtt/assets/js/. The browser still keeps a cached copy for speed but asks the server (via If-Modified-Since / ETag) whether it is still current; the server returns 304 Not Modified when unchanged or the new bytes when it changed. Net cost: a small revalidation request per JS file on each page load. Net benefit: code changes go live as soon as they hit the server, with no renames or version-bumping for inner imports.

Note: this does not invalidate already-cached entries — those expire on their own schedule. The fix takes effect for all future requests once deployed.