### PR TITLE
perf(vtt): avoid full state clone for isGmUser hot-path checks

### DIFF
--- a/dnd/vtt/assets/js/bootstrap.js
+++ b/dnd/vtt/assets/js/bootstrap.js
@@ -1,6 +1,8 @@
 import {
   initializeState,
   getState,
+  getIsGm,
+  getUserName,
   subscribe,
   updateState,
   restrictTokensToPlayerView,
@@ -61,7 +63,7 @@ async function bootstrap() {
     user: userContext,
   });
 
-  const storeApi = { getState, subscribe, updateState };
+  const storeApi = { getState, getIsGm, getUserName, subscribe, updateState };
 
   mountSettingsPanel(routes, storeApi, userContext);
   const chatParticipants = Array.isArray(config.chatParticipants) ? config.chatParticipants : [];

--- a/dnd/vtt/assets/js/state/store.js
+++ b/dnd/vtt/assets/js/state/store.js
@@ -103,6 +103,14 @@ export function getState() {
   return JSON.parse(JSON.stringify(state));
 }
 
+export function getIsGm() {
+  return state.user?.isGM === true;
+}
+
+export function getUserName() {
+  return typeof state.user?.name === 'string' ? state.user.name : '';
+}
+
 export function subscribe(listener) {
   listeners.add(listener);
   return () => listeners.delete(listener);

--- a/dnd/vtt/assets/js/ui/board-interactions.js
+++ b/dnd/vtt/assets/js/ui/board-interactions.js
@@ -9035,6 +9035,9 @@ export function mountBoardInteractions(store, routes = {}) {
   }
 
   function isGmUser() {
+    if (typeof boardApi.getIsGm === 'function') {
+      return boardApi.getIsGm() === true;
+    }
     const state = boardApi.getState?.();
     return Boolean(state?.user?.isGM);
   }
@@ -9059,8 +9062,13 @@ export function mountBoardInteractions(store, routes = {}) {
   }
 
   function getCurrentUserId() {
-    const state = boardApi.getState?.();
-    const rawName = typeof state?.user?.name === 'string' ? state.user.name : '';
+    let rawName = '';
+    if (typeof boardApi.getUserName === 'function') {
+      rawName = boardApi.getUserName() || '';
+    } else {
+      const state = boardApi.getState?.();
+      rawName = typeof state?.user?.name === 'string' ? state.user.name : '';
+    }
     const normalized = rawName.trim().toLowerCase();
     return normalized || null;
   }


### PR DESCRIPTION
isGmUser() and getCurrentUserId() called boardApi.getState(), which JSON.parse(JSON.stringify(state))s the entire app state on every call. Per-token-per-frame render code (e.g. shouldHideEnemyHitPointValues) called isGmUser many times per drag, making isGmUser+getState ~88% of JS self time during a token drag profile.

Add getIsGm() and getUserName() to the store that read state.user primitives directly (no clone), expose them through storeApi, and use them in the two hot-path callers. The getState() fallback is kept so existing test mocks that only stub getState continue to work.