### PR TITLE
Fix End Combat reverting to active=true via stale store subscriber

### DIFF
--- a/dnd/vtt/assets/js/ui/board-interactions.js
+++ b/dnd/vtt/assets/js/ui/board-interactions.js
@@ -1225,7 +1225,6 @@ export function mountBoardInteractions(store, routes = {}) {
       '[VTT] Re-asserting GM combat intent after stale-version conflict',
       `(attempt ${combatConflictRetryAttempts}).`
     );
-    console.log('[COMBAT-VAR] reassertIntent: combatActive ->', intent.active, 'was', combatActive);
     combatActive = intent.active;
     combatRound = intent.round;
     startingCombatTeam = intent.startingTeam;
@@ -1832,9 +1831,6 @@ export function mountBoardInteractions(store, routes = {}) {
     startCombatButton.classList.remove('btn--soon');
     startCombatButton.addEventListener('click', (event) => {
       event.preventDefault();
-      console.log('[COMBAT-BTN] click; buttonText=', startCombatButton.textContent.trim(),
-        'localCombatActive=', combatActive, 'isGM=', isGmUser(),
-        'combatStateVersion=', combatStateVersion);
       if (!isGmUser()) {
         return;
       }
@@ -7972,19 +7968,16 @@ export function mountBoardInteractions(store, routes = {}) {
   }
 
   function handleStartCombat() {
-    console.log('[COMBAT-START-FN] entry; combatActive=', combatActive);
     if (combatActive) {
       handleEndCombat();
       return;
     }
-    console.warn('[COMBAT-START-FN] running START path because combatActive is FALSE');
 
     stopAllyTurnTimer();
     clearTurnBorderFlash();
     pendingTurnTransition = null;
     activeTeam = null;
     markCombatEncounterStateDirty();
-    console.log('[COMBAT-VAR] handleStartCombat: combatActive -> true');
     combatActive = true;
     combatRound = 1;
     combatConflictRetryAttempts = 0;
@@ -8028,9 +8021,7 @@ export function mountBoardInteractions(store, routes = {}) {
   }
 
   function handleEndCombat() {
-    console.log('[COMBAT-END-FN] entry; combatActive=', combatActive);
     if (!combatActive) {
-      console.warn('[COMBAT-END-FN] BAILED: combatActive is already false');
       return;
     }
 
@@ -8055,7 +8046,6 @@ export function mountBoardInteractions(store, routes = {}) {
     }
 
     markCombatEncounterStateDirty();
-    console.log('[COMBAT-VAR] handleEndCombat: combatActive -> false');
     combatActive = false;
     combatRound = 0;
     combatConflictRetryAttempts = 0;
@@ -8073,13 +8063,20 @@ export function mountBoardInteractions(store, routes = {}) {
     clearTurnBorderFlash();
     clearHesitationBanner();
     resetTurnEffects();
-    resetTriggeredActionsForActiveScene();
     setMaliceCount(0, { sync: false });
     updateStartCombatButton();
     refreshCombatTracker();
     updateCombatModeIndicators();
     releaseTurnLock();
+    // Sync the End Combat snapshot to the store BEFORE any other
+    // boardApi.updateState() runs. Otherwise the store subscriber
+    // (applyStateToBoard → applyCombatStateFromBoardState) reads the
+    // pre-End-Combat snapshot still sitting in the store and reverts
+    // the local combatActive flag back to true. The next snapshot we
+    // build then carries active=true and persists a Start-Combat-shaped
+    // payload, defeating the End Combat click.
     syncCombatStateToStore();
+    resetTriggeredActionsForActiveScene();
     if (status) {
       status.textContent = 'Combat ended.';
     }
@@ -8154,10 +8151,6 @@ export function mountBoardInteractions(store, routes = {}) {
     try {
       const previousActive = activeCombatantId;
       const wasCombatActive = combatActive;
-      if (combatActive !== normalized.active) {
-        console.log('[COMBAT-VAR] applyFromBoardState: combatActive', combatActive, '->', normalized.active,
-          'normalized.sequence=', normalized.sequence, 'localVersion=', combatStateVersion);
-      }
       combatActive = normalized.active;
       combatRound = normalized.round;
       if (isGmUser()) {
@@ -8385,9 +8378,6 @@ export function mountBoardInteractions(store, routes = {}) {
       // Also update local in-memory state to match the snapshot we're saving.
       // This prevents UI from using stale local state when refresh loop runs.
       if (localStatePatch.applyActive) {
-        if (combatActive !== localStatePatch.active) {
-          console.log('[COMBAT-VAR] localStatePatch: combatActive', combatActive, '->', localStatePatch.active);
-        }
         combatActive = localStatePatch.active;
       }
       if (localStatePatch.applyRound) {


### PR DESCRIPTION
handleEndCombat flipped the local combatActive flag, then called resetTriggeredActionsForActiveScene before syncCombatStateToStore. That triggered triggers boardApi.updateState() to mutate placement flags, which synchronously fired the store subscriber. The subscriber ran applyCombatStateFromBoardState, which read the pre-End-Combat combat snapshot still sitting in the store and overwrote combatActive back to true. The subsequent syncCombatStateToStore then captured a Start-Combat-shaped snapshot (active=true, round=1, teams set) and persisted it, defeating the End Combat click entirely.

Move syncCombatStateToStore() to run before
resetTriggeredActionsForActiveScene() so the End Combat snapshot lands in the store first, preventing the subscriber from re-applying stale state. Also removes the temporary diagnostic logging added in 0511733.