### PR TITLE
Improve VTT wall templates

### DIFF
--- a/dnd/data/version.json
+++ b/dnd/data/version.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.8.10",
-    "last_updated": "2026-05-07 00:00:00",
-    "build_number": 47
+    "version": "1.8.11",
+    "last_updated": "2026-05-07 06:53:45",
+    "build_number": 48
 }

--- a/dnd/vtt/assets/css/board.css
+++ b/dnd/vtt/assets/css/board.css
@@ -1870,81 +1870,148 @@
 }
 
 .vtt-template--wall {
-  --vtt-template-color: rgba(120, 53, 15, 0.92);
-  --vtt-wall-surface: linear-gradient(145deg, rgba(184, 115, 51, 0.95) 0%, rgba(76, 40, 16, 0.98) 90%);
-  --vtt-wall-border: rgba(59, 28, 10, 0.85);
-  --vtt-wall-highlight: linear-gradient(135deg, rgba(248, 220, 180, 0.5) 0%, rgba(120, 63, 21, 0.25) 100%);
-  --vtt-wall-shadow-inset: rgba(69, 26, 3, 0.65);
-  --vtt-wall-shadow-outer: rgba(45, 19, 5, 0.55);
-  --vtt-wall-shadow-selected-inset: rgba(120, 63, 21, 0.65);
-  --vtt-wall-shadow-selected-outer: rgba(68, 36, 10, 0.5);
+  --vtt-template-color: rgba(107, 114, 128, 0.92);
+  --vtt-wall-base: #6b7280;
+  --vtt-wall-mid: #4b5563;
+  --vtt-wall-dark: #1f2937;
+  --vtt-wall-light: #d1d5db;
+  --vtt-wall-border: rgba(17, 24, 39, 0.78);
+  --vtt-wall-shadow-inset: rgba(17, 24, 39, 0.42);
+  --vtt-wall-shadow-outer: rgba(15, 23, 42, 0.35);
+  --vtt-wall-shadow-selected-inset: rgba(31, 41, 55, 0.55);
+  --vtt-wall-shadow-selected-outer: rgba(148, 163, 184, 0.45);
+  --vtt-wall-texture:
+    linear-gradient(90deg, rgba(17, 24, 39, 0.35) 1px, transparent 1px),
+    linear-gradient(0deg, rgba(17, 24, 39, 0.28) 1px, transparent 1px),
+    linear-gradient(135deg, var(--vtt-wall-light) 0%, var(--vtt-wall-base) 42%, var(--vtt-wall-dark) 100%);
+  --vtt-wall-detail:
+    radial-gradient(circle at 20% 30%, rgba(255, 255, 255, 0.18) 0 7%, transparent 8%),
+    radial-gradient(circle at 72% 66%, rgba(0, 0, 0, 0.18) 0 8%, transparent 9%);
 }
 
-/* Wall color variants - 6 colors with dark/light */
+.vtt-template--wall[data-wall-color="stone"],
 .vtt-template--wall[data-wall-color="gray"] {
+  --vtt-template-color: rgba(107, 114, 128, 0.92);
+  --vtt-wall-base: #6b7280;
+  --vtt-wall-mid: #4b5563;
+  --vtt-wall-dark: #1f2937;
+  --vtt-wall-light: #d1d5db;
+  --vtt-wall-border: rgba(31, 41, 55, 0.82);
+  --vtt-wall-texture:
+    linear-gradient(90deg, rgba(31, 41, 55, 0.45) 2px, transparent 2px),
+    linear-gradient(0deg, rgba(31, 41, 55, 0.36) 2px, transparent 2px),
+    linear-gradient(135deg, #c4c9d1 0%, #737b87 45%, #303844 100%);
+  --vtt-wall-detail:
+    radial-gradient(ellipse at 18% 22%, rgba(255, 255, 255, 0.2) 0 7%, transparent 8%),
+    radial-gradient(ellipse at 74% 72%, rgba(15, 23, 42, 0.22) 0 9%, transparent 10%),
+    linear-gradient(30deg, transparent 0 47%, rgba(17, 24, 39, 0.22) 48% 51%, transparent 52% 100%);
+}
+
+.vtt-template--wall[data-wall-color="dirt"],
+.vtt-template--wall[data-wall-color="brown"],
+.vtt-template--wall[data-wall-color="green"] {
+  --vtt-template-color: rgba(120, 72, 31, 0.92);
+  --vtt-wall-base: #7c4a22;
+  --vtt-wall-mid: #5a3418;
+  --vtt-wall-dark: #2f1b0b;
+  --vtt-wall-light: #b98750;
+  --vtt-wall-border: rgba(48, 30, 12, 0.86);
+  --vtt-wall-texture:
+    radial-gradient(circle at 18% 26%, rgba(35, 20, 8, 0.45) 0 5%, transparent 6%),
+    radial-gradient(circle at 70% 60%, rgba(189, 139, 80, 0.35) 0 6%, transparent 7%),
+    linear-gradient(145deg, #a06a3c 0%, #6b3f1f 52%, #301b0d 100%);
+  --vtt-wall-detail:
+    radial-gradient(circle at 35% 75%, rgba(0, 0, 0, 0.24) 0 4%, transparent 5%),
+    radial-gradient(circle at 82% 28%, rgba(246, 214, 166, 0.18) 0 3%, transparent 4%);
+}
+
+.vtt-template--wall[data-wall-color="metal"],
+.vtt-template--wall[data-wall-color="purple"] {
   --vtt-template-color: rgba(100, 116, 139, 0.92);
-  --vtt-wall-surface: linear-gradient(145deg, rgba(148, 163, 184, 0.95) 0%, rgba(71, 85, 105, 0.98) 90%);
-  --vtt-wall-border: rgba(51, 65, 85, 0.85);
-  --vtt-wall-highlight: linear-gradient(135deg, rgba(226, 232, 240, 0.5) 0%, rgba(100, 116, 139, 0.25) 100%);
-  --vtt-wall-shadow-inset: rgba(51, 65, 85, 0.65);
-  --vtt-wall-shadow-outer: rgba(30, 41, 59, 0.55);
-  --vtt-wall-shadow-selected-inset: rgba(71, 85, 105, 0.65);
-  --vtt-wall-shadow-selected-outer: rgba(51, 65, 85, 0.5);
+  --vtt-wall-base: #8b98a8;
+  --vtt-wall-mid: #5f6f82;
+  --vtt-wall-dark: #27313f;
+  --vtt-wall-light: #e2e8f0;
+  --vtt-wall-border: rgba(30, 41, 59, 0.86);
+  --vtt-wall-texture:
+    repeating-linear-gradient(115deg, rgba(255, 255, 255, 0.32) 0 6px, rgba(15, 23, 42, 0.18) 7px 12px, transparent 13px 22px),
+    linear-gradient(145deg, #d8dee8 0%, #6f7d8e 48%, #2e3947 100%);
+  --vtt-wall-detail:
+    radial-gradient(circle at 18% 20%, rgba(15, 23, 42, 0.38) 0 5%, transparent 6%),
+    radial-gradient(circle at 82% 80%, rgba(255, 255, 255, 0.32) 0 4%, transparent 5%);
+}
+
+.vtt-template--wall[data-wall-color="ice"],
+.vtt-template--wall[data-wall-color="blue"],
+.vtt-template--wall[data-wall-color="cyan"] {
+  --vtt-template-color: rgba(103, 185, 214, 0.92);
+  --vtt-wall-base: #78cce6;
+  --vtt-wall-mid: #4aa3c3;
+  --vtt-wall-dark: #1d5f78;
+  --vtt-wall-light: #effcff;
+  --vtt-wall-border: rgba(23, 91, 115, 0.74);
+  --vtt-wall-texture:
+    linear-gradient(35deg, transparent 0 40%, rgba(255, 255, 255, 0.5) 41% 44%, transparent 45% 100%),
+    linear-gradient(125deg, transparent 0 54%, rgba(16, 94, 122, 0.24) 55% 57%, transparent 58% 100%),
+    linear-gradient(145deg, #f4fdff 0%, #86d8ee 46%, #2b7f99 100%);
+  --vtt-wall-detail:
+    radial-gradient(ellipse at 24% 24%, rgba(255, 255, 255, 0.42) 0 8%, transparent 9%),
+    radial-gradient(ellipse at 80% 72%, rgba(29, 95, 120, 0.24) 0 9%, transparent 10%);
+}
+
+.vtt-template--wall[data-wall-color="fire"],
+.vtt-template--wall[data-wall-color="red"] {
+  --vtt-template-color: rgba(220, 38, 38, 0.92);
+  --vtt-wall-base: #ef4444;
+  --vtt-wall-mid: #f97316;
+  --vtt-wall-dark: #7f1d1d;
+  --vtt-wall-light: #fde68a;
+  --vtt-wall-border: rgba(127, 29, 29, 0.86);
+  --vtt-wall-texture:
+    radial-gradient(ellipse at 24% 78%, rgba(254, 240, 138, 0.8) 0 10%, transparent 11%),
+    radial-gradient(ellipse at 64% 58%, rgba(249, 115, 22, 0.75) 0 14%, transparent 15%),
+    linear-gradient(12deg, #7f1d1d 0%, #dc2626 36%, #f97316 66%, #fde68a 100%);
+  --vtt-wall-detail:
+    linear-gradient(100deg, transparent 0 34%, rgba(255, 214, 102, 0.42) 35% 40%, transparent 41% 100%),
+    linear-gradient(72deg, transparent 0 56%, rgba(127, 29, 29, 0.36) 57% 62%, transparent 63% 100%);
+}
+
+/* Backward-compatible names for walls saved before the material picker existed. */
+.vtt-template--wall[data-wall-color="brown"] {
+  --vtt-template-color: rgba(120, 72, 31, 0.92);
+  --vtt-wall-base: #7c4a22;
+  --vtt-wall-mid: #5a3418;
+  --vtt-wall-dark: #2f1b0b;
+  --vtt-wall-light: #b98750;
+  --vtt-wall-border: rgba(48, 30, 12, 0.86);
+  --vtt-wall-texture:
+    radial-gradient(circle at 18% 26%, rgba(35, 20, 8, 0.45) 0 5%, transparent 6%),
+    radial-gradient(circle at 70% 60%, rgba(189, 139, 80, 0.35) 0 6%, transparent 7%),
+    linear-gradient(145deg, #a06a3c 0%, #6b3f1f 52%, #301b0d 100%);
+  --vtt-wall-detail:
+    radial-gradient(circle at 35% 75%, rgba(0, 0, 0, 0.24) 0 4%, transparent 5%),
+    radial-gradient(circle at 82% 28%, rgba(246, 214, 166, 0.18) 0 3%, transparent 4%);
+}
+
+.vtt-template--wall[data-wall-color="gray"] {
+  --vtt-template-color: rgba(107, 114, 128, 0.92);
 }
 
 .vtt-template--wall[data-wall-color="red"] {
-  --vtt-template-color: rgba(153, 27, 27, 0.92);
-  --vtt-wall-surface: linear-gradient(145deg, rgba(185, 28, 28, 0.95) 0%, rgba(127, 29, 29, 0.98) 90%);
-  --vtt-wall-border: rgba(69, 10, 10, 0.85);
-  --vtt-wall-highlight: linear-gradient(135deg, rgba(254, 202, 202, 0.5) 0%, rgba(153, 27, 27, 0.25) 100%);
-  --vtt-wall-shadow-inset: rgba(69, 10, 10, 0.65);
-  --vtt-wall-shadow-outer: rgba(50, 7, 7, 0.55);
-  --vtt-wall-shadow-selected-inset: rgba(127, 29, 29, 0.65);
-  --vtt-wall-shadow-selected-outer: rgba(69, 10, 10, 0.5);
+  --vtt-template-color: rgba(220, 38, 38, 0.92);
 }
 
 .vtt-template--wall[data-wall-color="green"] {
-  --vtt-template-color: rgba(22, 101, 52, 0.92);
-  --vtt-wall-surface: linear-gradient(145deg, rgba(34, 197, 94, 0.95) 0%, rgba(21, 128, 61, 0.98) 90%);
-  --vtt-wall-border: rgba(20, 83, 45, 0.85);
-  --vtt-wall-highlight: linear-gradient(135deg, rgba(187, 247, 208, 0.5) 0%, rgba(22, 163, 74, 0.25) 100%);
-  --vtt-wall-shadow-inset: rgba(20, 83, 45, 0.65);
-  --vtt-wall-shadow-outer: rgba(5, 46, 22, 0.55);
-  --vtt-wall-shadow-selected-inset: rgba(21, 128, 61, 0.65);
-  --vtt-wall-shadow-selected-outer: rgba(20, 83, 45, 0.5);
+  --vtt-template-color: rgba(120, 72, 31, 0.92);
 }
 
-.vtt-template--wall[data-wall-color="blue"] {
-  --vtt-template-color: rgba(30, 64, 175, 0.92);
-  --vtt-wall-surface: linear-gradient(145deg, rgba(59, 130, 246, 0.95) 0%, rgba(29, 78, 216, 0.98) 90%);
-  --vtt-wall-border: rgba(30, 58, 138, 0.85);
-  --vtt-wall-highlight: linear-gradient(135deg, rgba(191, 219, 254, 0.5) 0%, rgba(59, 130, 246, 0.25) 100%);
-  --vtt-wall-shadow-inset: rgba(30, 58, 138, 0.65);
-  --vtt-wall-shadow-outer: rgba(23, 37, 84, 0.55);
-  --vtt-wall-shadow-selected-inset: rgba(29, 78, 216, 0.65);
-  --vtt-wall-shadow-selected-outer: rgba(30, 58, 138, 0.5);
+.vtt-template--wall[data-wall-color="blue"],
+.vtt-template--wall[data-wall-color="cyan"] {
+  --vtt-template-color: rgba(103, 185, 214, 0.92);
 }
 
 .vtt-template--wall[data-wall-color="purple"] {
-  --vtt-template-color: rgba(107, 33, 168, 0.92);
-  --vtt-wall-surface: linear-gradient(145deg, rgba(168, 85, 247, 0.95) 0%, rgba(126, 34, 206, 0.98) 90%);
-  --vtt-wall-border: rgba(88, 28, 135, 0.85);
-  --vtt-wall-highlight: linear-gradient(135deg, rgba(233, 213, 255, 0.5) 0%, rgba(147, 51, 234, 0.25) 100%);
-  --vtt-wall-shadow-inset: rgba(88, 28, 135, 0.65);
-  --vtt-wall-shadow-outer: rgba(59, 7, 100, 0.55);
-  --vtt-wall-shadow-selected-inset: rgba(126, 34, 206, 0.65);
-  --vtt-wall-shadow-selected-outer: rgba(88, 28, 135, 0.5);
-}
-
-.vtt-template--wall[data-wall-color="cyan"] {
-  --vtt-template-color: rgba(14, 116, 144, 0.92);
-  --vtt-wall-surface: linear-gradient(145deg, rgba(6, 182, 212, 0.95) 0%, rgba(8, 145, 178, 0.98) 90%);
-  --vtt-wall-border: rgba(21, 94, 117, 0.85);
-  --vtt-wall-highlight: linear-gradient(135deg, rgba(165, 243, 252, 0.5) 0%, rgba(34, 211, 238, 0.25) 100%);
-  --vtt-wall-shadow-inset: rgba(21, 94, 117, 0.65);
-  --vtt-wall-shadow-outer: rgba(8, 51, 68, 0.55);
-  --vtt-wall-shadow-selected-inset: rgba(8, 145, 178, 0.65);
-  --vtt-wall-shadow-selected-outer: rgba(21, 94, 117, 0.5);
+  --vtt-template-color: rgba(100, 116, 139, 0.92);
 }
 
 .vtt-template__shape--wall {
@@ -1964,9 +2031,19 @@
 
 .vtt-wall__tile {
   position: absolute;
-  background: transparent;
-  border: none;
-  box-shadow: none;
+  overflow: hidden;
+  background:
+    var(--vtt-wall-detail),
+    var(--vtt-wall-texture);
+  background-size:
+    100% 100%,
+    calc(var(--vtt-wall-grid, 64px) * 0.52) calc(var(--vtt-wall-grid, 64px) * 0.52),
+    100% 100%;
+  border: 1px solid var(--vtt-wall-border);
+  box-shadow:
+    inset 0 2px 5px rgba(255, 255, 255, 0.2),
+    inset 0 -8px 16px var(--vtt-wall-shadow-inset),
+    0 8px 16px var(--vtt-wall-shadow-outer);
   z-index: 2;
 }
 
@@ -1974,49 +2051,32 @@
 .vtt-wall__tile::after {
   content: '';
   position: absolute;
-  top: 50%;
-  left: 50%;
-  width: calc(var(--vtt-wall-grid, 64px) * 1.42);
-  height: calc(var(--vtt-wall-grid, 64px) * 0.34);
-  border-radius: 999px;
-  transform-origin: 50% 50%;
+  inset: 0;
+  pointer-events: none;
 }
 
 .vtt-wall__tile::before {
-  background: var(--vtt-wall-surface);
-  border: 1px solid var(--vtt-wall-border);
-  box-shadow:
-    inset 0 3px 6px rgba(255, 255, 255, 0.2),
-    inset 0 -5px 10px var(--vtt-wall-shadow-inset),
-    0 8px 18px var(--vtt-wall-shadow-outer);
+  background:
+    linear-gradient(135deg, rgba(255, 255, 255, 0.22), transparent 42%),
+    linear-gradient(315deg, rgba(0, 0, 0, 0.22), transparent 48%);
+  mix-blend-mode: soft-light;
 }
 
 .vtt-wall__tile::after {
-  width: calc(var(--vtt-wall-grid, 64px) * 1.1);
-  height: calc(var(--vtt-wall-grid, 64px) * 0.12);
-  background: var(--vtt-wall-highlight);
-  opacity: 0.85;
-}
-
-.vtt-wall__tile--se::before,
-.vtt-wall__tile--se::after {
-  transform: translate(-50%, -50%) rotate(45deg);
-}
-
-.vtt-wall__tile--ne::before,
-.vtt-wall__tile--ne::after {
-  transform: translate(-50%, -50%) rotate(-45deg);
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.16);
 }
 
 .vtt-template--preview .vtt-wall__tile {
-  opacity: 0.9;
+  opacity: 0.88;
 }
 
-.vtt-template--wall.is-selected .vtt-wall__tile::before {
-  border-color: rgba(226, 232, 240, 0.9);
+.vtt-template--wall.is-selected .vtt-wall__tile {
+  border-color: rgba(226, 232, 240, 0.92);
   box-shadow:
-    inset 0 3px 6px rgba(255, 255, 255, 0.35),
-    inset 0 -5px 10px var(--vtt-wall-shadow-selected-inset),
+    inset 0 2px 6px rgba(255, 255, 255, 0.34),
+    inset 0 -8px 16px var(--vtt-wall-shadow-selected-inset),
+    0 0 0 2px rgba(226, 232, 240, 0.36),
     0 10px 22px var(--vtt-wall-shadow-selected-outer);
 }
 
@@ -2025,9 +2085,7 @@
   pointer-events: none;
   background: transparent;
   border: none;
-  border-radius: 0;
   opacity: 1;
-  transform-origin: 50% 50%;
   z-index: 1;
 }
 
@@ -2035,43 +2093,57 @@
 .vtt-wall__connector::after {
   content: '';
   position: absolute;
-  top: 50%;
-  left: 50%;
-  border-radius: 999px;
-  transform: translate(-50%, -50%);
-}
-
-.vtt-wall__connector::before {
-  width: 100%;
-  height: calc(var(--vtt-wall-grid, 64px) * 0.34);
-  background: var(--vtt-wall-surface);
+  width: 50%;
+  height: 50%;
+  background:
+    var(--vtt-wall-detail),
+    var(--vtt-wall-texture);
+  background-size:
+    100% 100%,
+    calc(var(--vtt-wall-grid, 64px) * 0.52) calc(var(--vtt-wall-grid, 64px) * 0.52),
+    100% 100%;
   border: 1px solid var(--vtt-wall-border);
   box-shadow:
-    inset 0 3px 6px rgba(255, 255, 255, 0.2),
-    inset 0 -5px 10px var(--vtt-wall-shadow-inset),
+    inset 0 2px 5px rgba(255, 255, 255, 0.18),
+    inset 0 -7px 14px var(--vtt-wall-shadow-inset),
     0 6px 14px var(--vtt-wall-shadow-outer);
 }
 
-.vtt-wall__connector::after {
-  width: calc(100% - var(--vtt-wall-grid, 64px) * 0.3);
-  height: calc(var(--vtt-wall-grid, 64px) * 0.12);
-  background: var(--vtt-wall-highlight);
-  opacity: 0.85;
+.vtt-wall__connector--se::before {
+  top: 0;
+  right: 0;
+  clip-path: polygon(0 100%, 0 0, 100% 100%);
 }
 
-.vtt-wall__connector--se {
-  transform: rotate(45deg);
+.vtt-wall__connector--se::after {
+  bottom: 0;
+  left: 0;
+  clip-path: polygon(0 0, 100% 0, 100% 100%);
 }
 
-.vtt-wall__connector--ne {
-  transform: rotate(-45deg);
+.vtt-wall__connector--ne::before {
+  top: 0;
+  left: 0;
+  clip-path: polygon(0 100%, 100% 0, 100% 100%);
 }
 
-.vtt-template--wall.is-selected .vtt-wall__connector::before {
-  border-color: rgba(226, 232, 240, 0.9);
+.vtt-wall__connector--ne::after {
+  right: 0;
+  bottom: 0;
+  clip-path: polygon(0 0, 100% 0, 0 100%);
+}
+
+.vtt-template--preview .vtt-wall__connector {
+  opacity: 0.88;
+}
+
+.vtt-template--wall.is-selected .vtt-wall__connector::before,
+.vtt-template--wall.is-selected .vtt-wall__connector::after {
+  border-color: rgba(226, 232, 240, 0.92);
   box-shadow:
-    inset 0 3px 6px rgba(255, 255, 255, 0.35),
-    inset 0 -5px 10px var(--vtt-wall-shadow-selected-inset),
+    inset 0 2px 6px rgba(255, 255, 255, 0.32),
+    inset 0 -7px 14px var(--vtt-wall-shadow-selected-inset),
+    0 0 0 2px rgba(226, 232, 240, 0.28),
     0 8px 18px var(--vtt-wall-shadow-selected-outer);
 }
 

--- a/dnd/vtt/assets/js/ui/board-interactions.js
+++ b/dnd/vtt/assets/js/ui/board-interactions.js
@@ -17250,7 +17250,7 @@ function createTemplateTool() {
 
     // Set wall color attribute for CSS variants
     const wallColor = data.wallColor;
-    if (type === 'wall' && typeof wallColor === 'string' && wallColor.trim() && !isPreview) {
+    if (type === 'wall' && typeof wallColor === 'string' && wallColor.trim()) {
       root.dataset.wallColor = wallColor.trim();
     }
 
@@ -18204,6 +18204,7 @@ function createTemplateTool() {
     wallField.input.min = '1';
     wallField.input.inputMode = 'numeric';
     wallField.input.pattern = '\\d*';
+    wallField.input.value = '3';
 
     // Template color picker (6 colors)
     const templateColors = [
@@ -18247,14 +18248,13 @@ function createTemplateTool() {
       templateColorRow.appendChild(swatch);
     });
 
-    // Wall color picker (6 colors that match the CSS data-wall-color variants)
+    // Wall material picker (matches the CSS data-wall-color texture variants)
     const wallColors = [
-      { name: 'brown', label: 'Brown', color: 'rgba(184, 115, 51, 0.95)' },
-      { name: 'gray', label: 'Gray', color: 'rgba(148, 163, 184, 0.95)' },
-      { name: 'red', label: 'Red', color: 'rgba(185, 28, 28, 0.95)' },
-      { name: 'green', label: 'Green', color: 'rgba(34, 197, 94, 0.95)' },
-      { name: 'blue', label: 'Blue', color: 'rgba(59, 130, 246, 0.95)' },
-      { name: 'purple', label: 'Purple', color: 'rgba(168, 85, 247, 0.95)' },
+      { name: 'stone', label: 'Stone', color: 'linear-gradient(135deg, #9ca3af 0%, #4b5563 100%)' },
+      { name: 'dirt', label: 'Dirt', color: 'linear-gradient(135deg, #9a6a3a 0%, #4a2c16 100%)' },
+      { name: 'metal', label: 'Metal', color: 'linear-gradient(135deg, #cbd5e1 0%, #475569 48%, #94a3b8 100%)' },
+      { name: 'ice', label: 'Ice', color: 'linear-gradient(135deg, #dff7ff 0%, #67b9d6 100%)' },
+      { name: 'fire', label: 'Fire', color: 'linear-gradient(135deg, #ffd166 0%, #ef4444 55%, #7f1d1d 100%)' },
     ];
 
     let selectedWallColor = null;
@@ -18262,7 +18262,7 @@ function createTemplateTool() {
     const wallColorPicker = document.createElement('div');
     wallColorPicker.className = 'vtt-template-menu__field';
     const wallColorLabel = document.createElement('label');
-    wallColorLabel.textContent = 'Color (optional)';
+    wallColorLabel.textContent = 'Material (optional)';
     wallColorPicker.appendChild(wallColorLabel);
     const wallColorRow = document.createElement('div');
     wallColorRow.className = 'vtt-template-menu__colors';
@@ -18437,7 +18437,7 @@ function createTemplateTool() {
         squares: [],
       };
 
-      previewShape = createShape('wall', { squares: [] }, { preview: true });
+      previewShape = createShape('wall', { squares: [], wallColor: values?.wallColor }, { preview: true });
       layer.appendChild(previewShape.elements.root);
       updateStatus('Select the first square for your wall.');
       updateLayerVisibility();
@@ -18765,7 +18765,7 @@ function createTemplateTool() {
     const sanitized = sanitizeWallSquares(squares);
     if (!previewShape || previewShape.type !== 'wall') {
       clearPreview();
-      previewShape = createShape('wall', { squares: sanitized }, { preview: true });
+      previewShape = createShape('wall', { squares: sanitized, wallColor: placementState?.values?.wallColor }, { preview: true });
       layer.appendChild(previewShape.elements.root);
     } else {
       previewShape.squares = sanitized;
@@ -19002,17 +19002,13 @@ function createTemplateTool() {
       connectorsMap.set(key, connector);
     }
 
-    const midColumn = ((startSquare.column + endSquare.column) / 2) + 0.5;
-    const midRow = ((startSquare.row + endSquare.row) / 2) + 0.5;
-    const localLeft = (midColumn - minColumn) * bounds.gridSize;
-    const localTop = (midRow - minRow) * bounds.gridSize;
+    const localLeft = (baseColumn - minColumn) * bounds.gridSize;
+    const localTop = (baseRow - minRow) * bounds.gridSize;
 
-    const connectorWidth = bounds.gridSize * Math.SQRT2;
-    const connectorThickness = bounds.gridSize;
-    connector.style.width = `${connectorWidth}px`;
-    connector.style.height = `${connectorThickness}px`;
-    connector.style.left = `${localLeft - connectorWidth / 2}px`;
-    connector.style.top = `${localTop - connectorThickness / 2}px`;
+    connector.style.width = `${bounds.gridSize * 2}px`;
+    connector.style.height = `${bounds.gridSize * 2}px`;
+    connector.style.left = `${localLeft}px`;
+    connector.style.top = `${localTop}px`;
 
     return key;
   }


### PR DESCRIPTION
### Motivation
- Fix the wall template visuals so a selected wall square fills its whole grid cell instead of rendering as thin per-square lines and make diagonal connections render as filled corner pieces. 
- Provide a sensible default for new wall placements (3 squares) and replace the garish neon color palette with material-like wall textures (stone, dirt, metal, ice, fire) so walls look like their material.

### Description
- Replace the wall styling in `dnd/vtt/assets/css/board.css` with textured/material variants and tile/connector rules so each wall tile fills its grid cell and diagonal connectors render as triangular corner pieces, and add backward-compatible mappings for legacy color names. 
- Update the template UI in `dnd/vtt/assets/js/ui/board-interactions.js` to default the wall squares input to `3`, swap the old color swatches for a material picker (`stone`, `dirt`, `metal`, `ice`, `fire`), and label it `Material (optional)`. 
- Ensure `wallColor`/material is propagated into previews and serialized shapes by writing the chosen `wallColor` into the template DOM dataset and passing it into `createShape` for preview and final shapes. 
- Adjust connector placement/size logic so connectors occupy the correct local tile area between diagonally adjacent squares and tuned CSS to blend highlights/shadows for each material. 
- Bump the project version metadata (`dnd/data/version.json`) to `1.8.11` (build `48`).

### Testing
- Ran `git diff --check` to validate there were no whitespace/merge errors, which succeeded. 
- Ran `node --check dnd/vtt/assets/js/ui/board-interactions.js` for a syntax check, which succeeded. 
- Validated JSON with `python3 -m json.tool dnd/data/version.json`, which succeeded. 
- Ran `npm test` but the configured glob matched no JS test files in this checkout (no tests executed). 
- Attempted `vendor/bin/phpunit --configuration phpunit.xml.dist` but `phpunit` was not present in the environment. 
- Attempted to install Playwright browsers (`npx playwright install chromium`) to generate a visual screenshot, but browser download was blocked by a `403 Domain forbidden` in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc3593732c8327b8deb260d7953c61)