### PR TITLE
Show movement overlay for any token during active combat

### DIFF
--- a/dnd/vtt/assets/js/token-system/token-movement-controller.js
+++ b/dnd/vtt/assets/js/token-system/token-movement-controller.js
@@ -212,7 +212,7 @@ export function createTokenMovementController({
 
   function canTrackPlacement(tokenId) {
     const context = getTurnContext();
-    return Boolean(context.active && tokenId && isActiveCombatantPlacement(tokenId));
+    return Boolean(context.active && tokenId);
   }
 
   function getTurnContext() {


### PR DESCRIPTION
Previously the movement range overlay only appeared when dragging the
active combatant. On the first round before any turn was explicitly
activated, picking up a token showed nothing because activeCombatantId
was still null. Drop the active-combatant gate from canTrackPlacement so
the overlay shows for any token while combat is active. Spent movement
is still tracked per token and reset on turn change via the existing
turn-key sync.