### PR TITLE
Add ability automation authoring builder

### DIFF
--- a/dnd/character_sheet/ability-automation/builder.css
+++ b/dnd/character_sheet/ability-automation/builder.css
@@ -1,0 +1,157 @@
+.automation-builder__modal {
+  width: min(900px, 96vw);
+}
+
+.automation-builder__header {
+  align-items: flex-start;
+}
+
+.automation-builder__eyebrow,
+.automation-builder__intro,
+.automation-builder__card-type {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.automation-builder__body {
+  gap: 12px;
+}
+
+.automation-builder__toolbar,
+.automation-builder__footer {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  justify-content: flex-end;
+}
+
+.automation-builder__stack {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.automation-builder__card {
+  background: var(--panel-alt);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 12px;
+}
+
+.automation-builder__card-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 10px;
+}
+
+.automation-builder__card-title {
+  margin: 0 0 4px;
+  font-size: 1rem;
+}
+
+.automation-builder__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 10px;
+}
+
+.automation-builder__field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  color: var(--muted);
+  font-size: 0.85rem;
+  font-weight: 700;
+}
+
+.automation-builder__field--wide {
+  grid-column: 1 / -1;
+}
+
+.automation-builder__field input,
+.automation-builder__field select,
+.automation-builder__field textarea {
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: #fff8ee;
+  color: var(--text);
+  padding: 7px 8px;
+  font: inherit;
+}
+
+.automation-builder__tiers {
+  display: grid;
+  gap: 8px;
+  margin-top: 12px;
+}
+
+.automation-builder__tier {
+  display: grid;
+  grid-template-columns: 70px minmax(80px, 1fr) minmax(110px, 1fr) minmax(180px, 2fr);
+  gap: 8px;
+  align-items: end;
+}
+
+.automation-builder__tier-label {
+  align-self: center;
+  background: var(--chip);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  color: var(--text);
+  font-weight: 700;
+  padding: 6px 8px;
+  text-align: center;
+}
+
+.automation-builder__warnings {
+  background: rgba(213, 91, 91, 0.12);
+  border: 1px solid var(--danger);
+  border-radius: 6px;
+  color: var(--text);
+  padding: 10px 12px;
+}
+
+.automation-builder__warnings ul,
+.automation-builder__warnings p {
+  margin: 0;
+}
+
+.automation-builder__warnings--ok {
+  background: rgba(95, 179, 106, 0.12);
+  border-color: var(--success);
+}
+
+.automation-builder__save,
+.automation-action-btn--configured {
+  border-color: var(--success);
+}
+
+.automation-action-btn {
+  align-items: center;
+  display: inline-flex;
+  gap: 6px;
+}
+
+.automation-action-btn__status {
+  background: var(--border);
+  border-radius: 999px;
+  display: inline-block;
+  height: 8px;
+  width: 8px;
+}
+
+.automation-action-btn--configured .automation-action-btn__status {
+  background: var(--success);
+}
+
+@media (max-width: 720px) {
+  .automation-builder__tier {
+    grid-template-columns: 1fr;
+  }
+}
+
+.automation-builder__tier .automation-builder__field--wide {
+  grid-column: auto;
+}

--- a/dnd/character_sheet/ability-automation/builder.js
+++ b/dnd/character_sheet/ability-automation/builder.js
@@ -1,0 +1,248 @@
+(function () {
+  "use strict";
+
+  const MODAL_ID = "ability-automation-modal";
+  const schema = window.AbilityAutomationSchema;
+  const registry = window.AbilityAutomationPrimitives;
+
+  function escapeHtml(value) {
+    return String(value ?? "")
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;")
+      .replace(/'/g, "&#39;");
+  }
+
+  function closeModal() {
+    document.getElementById(MODAL_ID)?.remove();
+  }
+
+  function cardShell(card, title, body) {
+    return `
+      <section class="automation-builder__card" data-automation-card="${escapeHtml(card.id)}" data-card-type="${escapeHtml(card.type)}">
+        <header class="automation-builder__card-header">
+          <div>
+            <h3 class="automation-builder__card-title">${escapeHtml(title)}</h3>
+            <p class="automation-builder__card-type">${escapeHtml(registry.getPrimitive(card.type).description)}</p>
+          </div>
+          <button class="icon-btn automation-builder__remove" type="button" data-remove-automation-card="${escapeHtml(card.id)}" aria-label="Remove ${escapeHtml(title)} card">✕</button>
+        </header>
+        <div class="automation-builder__card-body">${body}</div>
+      </section>
+    `;
+  }
+
+  function renderTargetCard(card) {
+    const data = card.data;
+    const body = `
+      <div class="automation-builder__grid">
+        <label class="automation-builder__field">
+          <span>Count</span>
+          <select data-card-field="count">
+            ${["one", "each", "all"].map((option) => `<option value="${option}" ${data.count === option ? "selected" : ""}>${option}</option>`).join("")}
+          </select>
+        </label>
+        <label class="automation-builder__field">
+          <span>Target type</span>
+          <select data-card-field="creature">
+            ${["enemy", "ally", "creature", "object", "creature or object"].map((option) => `<option value="${option}" ${data.creature === option ? "selected" : ""}>${option}</option>`).join("")}
+          </select>
+        </label>
+        <label class="automation-builder__field automation-builder__field--wide">
+          <span>Range / area note</span>
+          <input type="text" data-card-field="within" value="${escapeHtml(data.within)}" placeholder="e.g. within 1, melee 1, each enemy in the area" />
+        </label>
+      </div>
+    `;
+    return cardShell(card, "Target", body);
+  }
+
+  function renderPowerRollCard(card) {
+    const data = card.data;
+    const tiers = data.tiers;
+    const tierMarkup = schema.TIER_KEYS.map((key) => {
+      const tier = tiers[key];
+      const label = key === "low" ? "≤ 11" : key === "mid" ? "12-16" : "17+";
+      return `
+        <div class="automation-builder__tier" data-tier="${key}">
+          <div class="automation-builder__tier-label">${label}</div>
+          <label class="automation-builder__field">
+            <span>Damage</span>
+            <input type="text" data-tier-field="damage" value="${escapeHtml(tier.damage)}" placeholder="e.g. 3" />
+          </label>
+          <label class="automation-builder__field">
+            <span>Damage type</span>
+            <input type="text" data-tier-field="damageType" value="${escapeHtml(tier.damageType)}" placeholder="optional" />
+          </label>
+          <label class="automation-builder__field automation-builder__field--wide">
+            <span>Tier effect</span>
+            <input type="text" data-tier-field="effect" value="${escapeHtml(tier.effect)}" placeholder="optional push, condition, save note" />
+          </label>
+        </div>
+      `;
+    }).join("");
+
+    const body = `
+      <div class="automation-builder__grid">
+        <label class="automation-builder__field">
+          <span>Roll</span>
+          <input type="text" data-card-field="rollFormula" value="${escapeHtml(data.rollFormula)}" />
+        </label>
+        <label class="automation-builder__field">
+          <span>Attribute</span>
+          <select data-card-field="attribute">
+            ${registry.ATTRIBUTES.map((attr) => `<option value="${attr}" ${data.attribute === attr ? "selected" : ""}>${attr}</option>`).join("")}
+          </select>
+        </label>
+        <label class="automation-builder__field">
+          <span>Bonus</span>
+          <input type="text" data-card-field="bonus" value="${escapeHtml(data.bonus)}" placeholder="optional" />
+        </label>
+      </div>
+      <div class="automation-builder__tiers">${tierMarkup}</div>
+    `;
+    return cardShell(card, "Power Roll Damage", body);
+  }
+
+  function renderNoteCard(card) {
+    const body = `
+      <label class="automation-builder__field automation-builder__field--wide">
+        <span>Note</span>
+        <textarea rows="3" data-card-field="text" placeholder="Describe a future automation detail.">${escapeHtml(card.data.text)}</textarea>
+      </label>
+    `;
+    return cardShell(card, "Automation Note", body);
+  }
+
+  function renderCard(card) {
+    if (card.type === "powerRollDamage") return renderPowerRollCard(card);
+    if (card.type === "note") return renderNoteCard(card);
+    return renderTargetCard(card);
+  }
+
+  function readAutomation(modal) {
+    const cards = Array.from(modal.querySelectorAll("[data-automation-card]")).map((cardEl) => {
+      const type = cardEl.getAttribute("data-card-type") || "target";
+      const id = cardEl.getAttribute("data-automation-card") || schema.createId("card");
+      const getField = (field) => cardEl.querySelector(`[data-card-field="${field}"]`);
+
+      if (type === "powerRollDamage") {
+        const tiers = {};
+        schema.TIER_KEYS.forEach((key) => {
+          const tierEl = cardEl.querySelector(`[data-tier="${key}"]`);
+          const getTierField = (field) => tierEl?.querySelector(`[data-tier-field="${field}"]`);
+          tiers[key] = {
+            range: key === "low" ? "≤ 11" : key === "mid" ? "12-16" : "17+",
+            damage: getTierField("damage")?.value || "",
+            damageType: getTierField("damageType")?.value || "",
+            effect: getTierField("effect")?.value || "",
+          };
+        });
+        return {
+          id,
+          type,
+          data: {
+            rollFormula: getField("rollFormula")?.value || "2d10",
+            attribute: getField("attribute")?.value || "Might",
+            bonus: getField("bonus")?.value || "",
+            tiers,
+          },
+        };
+      }
+
+      if (type === "note") {
+        return { id, type, data: { text: getField("text")?.value || "" } };
+      }
+
+      return {
+        id,
+        type: "target",
+        data: {
+          count: getField("count")?.value || "one",
+          creature: getField("creature")?.value || "enemy",
+          within: getField("within")?.value || "",
+        },
+      };
+    });
+
+    return schema.normalizeAutomation({ cards });
+  }
+
+  function renderWarnings(modal) {
+    const warningsEl = modal.querySelector("[data-automation-warnings]");
+    if (!warningsEl) return;
+    const warnings = schema.validateAutomation(readAutomation(modal));
+    warningsEl.innerHTML = warnings.length
+      ? `<ul>${warnings.map((warning) => `<li>${escapeHtml(warning)}</li>`).join("")}</ul>`
+      : "<p>Ready to save. Runtime execution will be added later.</p>";
+    warningsEl.classList.toggle("automation-builder__warnings--ok", warnings.length === 0);
+  }
+
+  function addCard(modal, type) {
+    const automation = readAutomation(modal);
+    automation.cards.push(schema.normalizeAutomation({ cards: [{ type }] }).cards[0]);
+    modal.querySelector("[data-automation-cards]").innerHTML = automation.cards.map(renderCard).join("");
+    renderWarnings(modal);
+  }
+
+  function open(actionId, actionType, currentAutomation, onSave) {
+    closeModal();
+
+    const automation = schema.normalizeAutomation(currentAutomation);
+    const modal = document.createElement("div");
+    modal.id = MODAL_ID;
+    modal.className = "modal-overlay automation-builder";
+    modal.innerHTML = `
+      <div class="modal automation-builder__modal" role="dialog" aria-modal="true" aria-labelledby="ability-automation-title">
+        <header class="modal__header automation-builder__header">
+          <div>
+            <p class="automation-builder__eyebrow">${escapeHtml(actionType)} • ${escapeHtml(actionId)}</p>
+            <h2 class="modal__title" id="ability-automation-title">Ability Automation</h2>
+          </div>
+          <button class="icon-btn" type="button" data-close-automation-builder aria-label="Close automation builder">✕</button>
+        </header>
+        <div class="modal__body automation-builder__body">
+          <p class="automation-builder__intro">Describe this ability as cards. These values are saved as data only; play-mode execution is intentionally not part of this version.</p>
+          <div class="automation-builder__toolbar">
+            ${registry.primitives.map((primitive) => `<button class="text-btn" type="button" data-add-automation-card="${escapeHtml(primitive.type)}">+ ${escapeHtml(primitive.label)}</button>`).join("")}
+          </div>
+          <div class="automation-builder__stack" data-automation-cards>${automation.cards.map(renderCard).join("")}</div>
+          <aside class="automation-builder__warnings" data-automation-warnings aria-live="polite"></aside>
+        </div>
+        <footer class="automation-builder__footer">
+          <button class="text-btn" type="button" data-close-automation-builder>Cancel</button>
+          <button class="text-btn automation-builder__save" type="button" data-save-automation-builder>Save Automation</button>
+        </footer>
+      </div>
+    `;
+
+    document.body.appendChild(modal);
+    renderWarnings(modal);
+
+    modal.addEventListener("click", (event) => {
+      if (event.target === modal) closeModal();
+      const target = event.target instanceof Element ? event.target : null;
+      if (!target) return;
+      if (target.closest("[data-close-automation-builder]")) closeModal();
+      const addButton = target.closest("[data-add-automation-card]");
+      if (addButton) addCard(modal, addButton.getAttribute("data-add-automation-card") || "target");
+      const removeButton = target.closest("[data-remove-automation-card]");
+      if (removeButton) {
+        removeButton.closest("[data-automation-card]")?.remove();
+        renderWarnings(modal);
+      }
+      if (target.closest("[data-save-automation-builder]")) {
+        if (typeof onSave === "function") {
+          onSave(readAutomation(modal));
+        }
+        closeModal();
+      }
+    });
+
+    modal.addEventListener("input", () => renderWarnings(modal));
+    modal.addEventListener("change", () => renderWarnings(modal));
+  }
+
+  window.AbilityAutomation = { open };
+})();

--- a/dnd/character_sheet/ability-automation/primitives.js
+++ b/dnd/character_sheet/ability-automation/primitives.js
@@ -1,0 +1,33 @@
+(function () {
+  "use strict";
+
+  const ATTRIBUTES = ["Might", "Agility", "Reason", "Intuition", "Presence"];
+
+  const primitives = [
+    {
+      type: "target",
+      label: "Target",
+      description: "Choose the creatures or objects affected by the ability.",
+    },
+    {
+      type: "powerRollDamage",
+      label: "Power Roll Damage",
+      description: "Roll 2d10 plus an attribute and define damage for each tier.",
+    },
+    {
+      type: "note",
+      label: "Automation Note",
+      description: "Capture future automation details without making them executable yet.",
+    },
+  ];
+
+  function getPrimitive(type) {
+    return primitives.find((primitive) => primitive.type === type) || primitives[0];
+  }
+
+  window.AbilityAutomationPrimitives = {
+    ATTRIBUTES,
+    primitives,
+    getPrimitive,
+  };
+})();

--- a/dnd/character_sheet/ability-automation/schema.js
+++ b/dnd/character_sheet/ability-automation/schema.js
@@ -1,0 +1,158 @@
+(function () {
+  "use strict";
+
+  const AUTOMATION_SCHEMA_VERSION = 1;
+  const AUTOMATION_SCHEMA_ID = "ability-automation/v1";
+  const TIER_KEYS = ["low", "mid", "high"];
+
+  function createId(prefix) {
+    return `${prefix}_${Date.now()}_${Math.random().toString(16).slice(2)}`;
+  }
+
+  function emptyTier() {
+    return {
+      range: "",
+      damage: "",
+      damageType: "",
+      effect: "",
+    };
+  }
+
+  function defaultAutomation() {
+    return {
+      schema: AUTOMATION_SCHEMA_ID,
+      version: AUTOMATION_SCHEMA_VERSION,
+      cards: [
+        {
+          id: createId("card"),
+          type: "target",
+          data: {
+            count: "one",
+            creature: "enemy",
+            within: "",
+          },
+        },
+        {
+          id: createId("card"),
+          type: "powerRollDamage",
+          data: {
+            rollFormula: "2d10",
+            attribute: "Might",
+            bonus: "",
+            tiers: {
+              low: { ...emptyTier(), range: "≤ 11" },
+              mid: { ...emptyTier(), range: "12-16" },
+              high: { ...emptyTier(), range: "17+" },
+            },
+          },
+        },
+      ],
+    };
+  }
+
+  function normalizeCard(card) {
+    const id = card?.id || createId("card");
+    const type = card?.type || "target";
+    const data = card?.data && typeof card.data === "object" ? card.data : {};
+
+    if (type === "powerRollDamage") {
+      const tiers = data.tiers && typeof data.tiers === "object" ? data.tiers : {};
+      return {
+        id,
+        type,
+        data: {
+          rollFormula: data.rollFormula || "2d10",
+          attribute: data.attribute || "Might",
+          bonus: data.bonus || "",
+          tiers: Object.fromEntries(
+            TIER_KEYS.map((key) => [
+              key,
+              {
+                ...emptyTier(),
+                range: key === "low" ? "≤ 11" : key === "mid" ? "12-16" : "17+",
+                ...(tiers[key] || {}),
+              },
+            ])
+          ),
+        },
+      };
+    }
+
+    if (type === "note") {
+      return {
+        id,
+        type,
+        data: {
+          text: data.text || "",
+        },
+      };
+    }
+
+    return {
+      id,
+      type: "target",
+      data: {
+        count: data.count || "one",
+        creature: data.creature || "enemy",
+        within: data.within || "",
+      },
+    };
+  }
+
+  function normalizeAutomation(input) {
+    if (!input || typeof input !== "object") {
+      return defaultAutomation();
+    }
+
+    const cards = Array.isArray(input.cards) ? input.cards.map(normalizeCard) : [];
+    return {
+      schema: input.schema || AUTOMATION_SCHEMA_ID,
+      version: Number(input.version) || AUTOMATION_SCHEMA_VERSION,
+      cards: cards.length ? cards : defaultAutomation().cards,
+    };
+  }
+
+  function hasAutomation(input) {
+    return Boolean(input && typeof input === "object" && Array.isArray(input.cards) && input.cards.length);
+  }
+
+  function validateAutomation(input) {
+    const automation = normalizeAutomation(input);
+    const warnings = [];
+    const hasTarget = automation.cards.some((card) => card.type === "target");
+    const powerRollCards = automation.cards.filter((card) => card.type === "powerRollDamage");
+
+    if (!hasTarget) {
+      warnings.push("Add a target card so play mode will know who the ability affects later.");
+    }
+
+    if (!powerRollCards.length) {
+      warnings.push("Add a power roll damage card to describe tiered damage.");
+    }
+
+    powerRollCards.forEach((card, index) => {
+      if (!card.data.attribute) {
+        warnings.push(`Power roll card ${index + 1} is missing an attribute.`);
+      }
+      TIER_KEYS.forEach((key) => {
+        const tier = card.data.tiers[key];
+        if (!tier.damage) {
+          warnings.push(`Power roll card ${index + 1} ${key} tier has no damage value.`);
+        }
+      });
+    });
+
+    return warnings;
+  }
+
+  window.AbilityAutomationSchema = {
+    AUTOMATION_SCHEMA_ID,
+    AUTOMATION_SCHEMA_VERSION,
+    TIER_KEYS,
+    createId,
+    defaultAutomation,
+    normalizeAutomation,
+    validateAutomation,
+    hasAutomation,
+  };
+})();

--- a/dnd/character_sheet/index.php
+++ b/dnd/character_sheet/index.php
@@ -38,6 +38,10 @@ require_once '../includes/strix-nav.php';
   <title>Hero Sheet</title>
   <link rel="stylesheet" href="../css/chat-panel.css?v=<?php echo (int) $assetVersion; ?>" />
   <link rel="stylesheet" href="styles.css?v=<?php echo (int) $assetVersion; ?>" />
+  <link rel="stylesheet" href="ability-automation/builder.css?v=<?php echo (int) $assetVersion; ?>" />
+  <script src="ability-automation/schema.js?v=<?php echo (int) $assetVersion; ?>"></script>
+  <script src="ability-automation/primitives.js?v=<?php echo (int) $assetVersion; ?>"></script>
+  <script src="ability-automation/builder.js?v=<?php echo (int) $assetVersion; ?>"></script>
   <script type="module" src="sheet.js?v=<?php echo (int) $assetVersion; ?>"></script>
 <?php if ($chatPusherConfig !== null): ?>
   <script src="https://js.pusher.com/8.4.0/pusher.min.js"></script>

--- a/dnd/character_sheet/sheet.js
+++ b/dnd/character_sheet/sheet.js
@@ -224,6 +224,23 @@ const ATTRIBUTES = ["Might", "Agility", "Reason", "Intuition", "Presence"];
 
 const SKILL_MODAL_ID = "skill-picker-modal";
 
+function hasAbilityAutomation(automation) {
+  return Boolean(
+    automation &&
+      typeof automation === "object" &&
+      Array.isArray(automation.cards) &&
+      automation.cards.length > 0
+  );
+}
+
+function normalizeAutomationBlock(automation) {
+  if (!hasAbilityAutomation(automation)) return null;
+  if (window.AbilityAutomationSchema?.normalizeAutomation) {
+    return window.AbilityAutomationSchema.normalizeAutomation(automation);
+  }
+  return deepClone(automation);
+}
+
 function deepClone(obj) {
   return JSON.parse(JSON.stringify(obj));
 }
@@ -476,6 +493,7 @@ function mergeWithDefaults(data) {
         tests: Array.isArray(action.tests)
           ? action.tests.map(normalizeTest)
           : convertLegacyEffectsToTests(action.effects).map(normalizeTest),
+        automation: normalizeAutomationBlock(action.automation),
       };
       if (key === "triggers") {
         normalizedAction.trigger = action.trigger || "";
@@ -2439,6 +2457,8 @@ function renderActionSection(type, containerId) {
               .join("");
 
             const useWhenValue = (action.useWhen || "").trim();
+            const automationConfigured = hasAbilityAutomation(action.automation);
+            const automationLabel = automationConfigured ? "Edit Automation" : "Automate";
             return `
             <article class="action-card action-card--collapsed" data-action-id="${action.id}" data-action-type="${type}">
               <header class="card-head">
@@ -2458,6 +2478,16 @@ function renderActionSection(type, containerId) {
                   <input class="edit-field" type="text" data-field="tags" value="${(action.tags || []).join(", ")}" placeholder="Tags" />
                 </div>
                 <span class="chat-dot-wrap"><button class="chat-dot" type="button" aria-label="Post to chat" data-chat-type="action" data-chat-id="${action.id}" data-chat-action-type="${type}"></button></span>
+                ${
+                  isEditMode
+                    ? `<button
+                        class="text-btn edit-only automation-action-btn ${automationConfigured ? "automation-action-btn--configured" : ""}"
+                        type="button"
+                        data-automate-action="${action.id}"
+                        data-action-type="${type}"
+                      ><span class="automation-action-btn__status" aria-hidden="true"></span>${automationLabel}</button>`
+                    : ""
+                }
                 <button
                   class="icon-btn edit-only"
                   data-move-action="up"
@@ -2526,6 +2556,7 @@ function renderActionSection(type, containerId) {
   bindActionRemovals();
   bindActionMoves();
   bindActionToggles();
+  bindAutomationButtons();
   bindTestAdds();
   bindTestRemovals();
   bindAttributeToggles();
@@ -2867,6 +2898,30 @@ function bindActionToggles() {
   });
 }
 
+function bindAutomationButtons() {
+  document.querySelectorAll("[data-automate-action]").forEach((btn) => {
+    btn.onclick = () => {
+      const actionId = btn.getAttribute("data-automate-action");
+      const type = btn.getAttribute("data-action-type");
+      if (!actionId || !type) return;
+      if (!window.AbilityAutomation || typeof window.AbilityAutomation.open !== "function") {
+        console.warn("Ability automation builder is not available.");
+        return;
+      }
+
+      captureActions();
+      const action = (sheetState.actions[type] || []).find((item) => item.id === actionId);
+      if (!action) return;
+
+      window.AbilityAutomation.open(actionId, type, action.automation, (automation) => {
+        action.automation = normalizeAutomationBlock(automation);
+        renderActionSection(type, ACTION_CONTAINER_IDS[type] || `${type}-pane`);
+        saveSheet();
+      });
+    };
+  });
+}
+
 function bindTestAdds() {
   document.querySelectorAll("[data-add-test]").forEach((btn) => {
     btn.onclick = () => {
@@ -3019,6 +3074,7 @@ function captureActions() {
     cards.forEach((card) => {
       const id = card.getAttribute("data-action-id") || createId("action");
       const getField = (field) => card.querySelector(`[data-field="${field}"]`);
+      const existingAction = (sheetState.actions[type] || []).find((action) => action.id === id);
       const tests = Array.from(card.querySelectorAll(".test")).map((testEl) => {
         const tiers = {};
         TEST_TIERS.forEach(({ key }) => {
@@ -3060,6 +3116,7 @@ function captureActions() {
         cost: getField("cost")?.value || "",
         description: sanitizeRichText(normalizeRichText(getField("description")?.innerHTML || "")),
         tests,
+        automation: normalizeAutomationBlock(existingAction?.automation),
         ...(type === "triggers"
           ? {
               trigger: getField("trigger")?.value || "",

--- a/dnd/data/version.json
+++ b/dnd/data/version.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.8.18",
-    "last_updated": "2026-05-07 22:19:15",
-    "build_number": 55
+    "version": "1.8.19",
+    "last_updated": "2026-05-08 17:44:53",
+    "build_number": 56
 }


### PR DESCRIPTION
### Motivation
- Provide an authoring UI so designers can describe an ability's automation as data (card-stack of primitives) and persist it on each ability's JSON record without adding any runtime execution in v1.
- Implement the minimal v1 surface required for a power-roll damage example: a target card + power-roll-damage card with tiered damage fields and validate-but-allow warnings.
- Wire the authoring flow into the existing sheet save pipeline so automation lives alongside existing `tests` and is saved with the sheet state.

### Description
- Added a normalization/validation schema at `dnd/character_sheet/ability-automation/schema.js` that defines the v1 automation shape, provides defaults, and returns warn-but-allow validation messages.
- Added a primitive registry at `dnd/character_sheet/ability-automation/primitives.js` for card types (Target, Power Roll Damage, Note) to drive the authoring UI.
- Implemented the card-stack builder UI at `dnd/character_sheet/ability-automation/builder.js` plus styles in `dnd/character_sheet/ability-automation/builder.css`; the builder exposes `window.AbilityAutomation.open(actionId, actionType, currentAutomation, onSave)` and returns the chosen automation via the `onSave` callback only.
- Integrated assets into the sheet by including the new CSS/JS in `dnd/character_sheet/index.php` so the builder is available before `sheet.js` runs.
- Wired the Automate/Edit Automation button into the action card rendering in `dnd/character_sheet/sheet.js` (edit-mode only), added a green status dot when an `automation` block exists, preserved automation through `captureActions()`, normalized automation on load/save, and persisted it through the existing `saveSheet()` flow.

### Testing
- Performed static/syntax checks: `php -l dnd/character_sheet/index.php` and `node --check` on `sheet.js`, `schema.js`, `primitives.js`, and `builder.js`; all returned clean results.
- JSDOM smoke test exercised the builder (opened the modal, populated tier damage fields, clicked Save) and verified the saved automation payload contains the tiered damage values, which succeeded.
- Attempted end-to-end UI screenshot via Playwright, but Playwright browser installation failed due to CDN download being blocked (403), so Playwright-driven screenshot verification could not run.
- `npm test` did not run any repository tests relevant to these files because the configured test glob has no matching files in this checkout; no repo-wide test failures were introduced by the added files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe2014adc88327912d1a1f712e00bb)