### PR TITLE
Replace Skills Overview with Standards-based Learning Targets

### DIFF
--- a/asl1/add_learning_target.php
+++ b/asl1/add_learning_target.php
@@ -18,12 +18,15 @@ if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
     exit;
 }
 
-$student_id = intval($_POST['student_id'] ?? 0);
 $standard_id = trim($_POST['standard_id'] ?? '');
 $title = trim($_POST['title'] ?? '');
 $description = trim($_POST['description'] ?? '');
+$asl_level = (int) ($_POST['asl_level'] ?? (defined('ASLHUB_SITE_LEVEL') ? ASLHUB_SITE_LEVEL : 1));
+if (!in_array($asl_level, [1, 2], true)) {
+    $asl_level = defined('ASLHUB_SITE_LEVEL') ? (int) ASLHUB_SITE_LEVEL : 1;
+}
 
-if ($student_id <= 0 || $standard_id === '' || $title === '') {
+if ($standard_id === '' || $title === '') {
     http_response_code(400);
     echo json_encode(['success' => false, 'message' => 'Standard and title are required.']);
     exit;
@@ -32,14 +35,6 @@ if ($student_id <= 0 || $standard_id === '' || $title === '') {
 aslhubEnsureStudentDashboardSchema($pdo);
 
 try {
-    $stmt = $pdo->prepare("SELECT id FROM users WHERE id = ? AND is_teacher = FALSE");
-    $stmt->execute([$student_id]);
-    if (!$stmt->fetch()) {
-        http_response_code(404);
-        echo json_encode(['success' => false, 'message' => 'Student not found.']);
-        exit;
-    }
-
     $stmt = $pdo->prepare("SELECT standard_id FROM asl_standards WHERE standard_id = ?");
     $stmt->execute([$standard_id]);
     if (!$stmt->fetch()) {
@@ -52,15 +47,15 @@ try {
     $stmt->execute([$standard_id]);
     $next_order = (int) $stmt->fetchColumn();
 
-    $stmt = $pdo->prepare("INSERT INTO asl_learning_targets (standard_id, title, description, order_index)
-        VALUES (?, ?, ?, ?)");
-    $stmt->execute([$standard_id, $title, $description === '' ? null : $description, $next_order]);
+    $stmt = $pdo->prepare("INSERT INTO asl_learning_targets (standard_id, title, description, order_index, asl_level)
+        VALUES (?, ?, ?, ?, ?)");
+    $stmt->execute([$standard_id, $title, $description === '' ? null : $description, $next_order, $asl_level]);
 
     echo json_encode([
         'success' => true,
         'message' => 'Learning target added.',
         'learning_target_id' => $pdo->lastInsertId(),
-        'dashboard' => aslhubFetchStudentDashboardData($pdo, $student_id),
+        'standards' => aslhubFetchTeacherStandardsData($pdo, $asl_level),
     ]);
 } catch (PDOException $e) {
     error_log('ASL learning target add failed: ' . $e->getMessage());

--- a/asl1/config.php
+++ b/asl1/config.php
@@ -84,6 +84,9 @@ if (!function_exists('aslhubEnsureGoalsTable')) {
     }
 }
 
+if (!defined('ASLHUB_SITE_LEVEL')) {
+    define('ASLHUB_SITE_LEVEL', 1);
+}
 aslhubEnsureSkillLevels($pdo, 1);
 aslhubEnsureGoalsTable($pdo);
 ?>

--- a/asl1/student_details.php
+++ b/asl1/student_details.php
@@ -142,12 +142,6 @@ $student_name = trim(($student['first_name'] ?? '') . ' ' . ($student['last_name
                     <div>
                         <h3 class="column-title">Standards</h3>
                         <div id="standard-list" class="standard-list"></div>
-                        <form id="add-lt-form" class="add-lt-form">
-                            <h4>Add Learning Target</h4>
-                            <input type="text" name="title" placeholder="Learning target title" required>
-                            <textarea name="description" placeholder="Optional description"></textarea>
-                            <button type="submit">Add to Selected Standard</button>
-                        </form>
                     </div>
                     <div>
                         <h3 class="column-title">Learning Targets</h3>
@@ -459,30 +453,6 @@ $student_name = trim(($student['first_name'] ?? '') . ' ' . ($student['last_name
             document.body.appendChild(toast);
             setTimeout(() => toast.remove(), 2400);
         }
-
-        document.getElementById('add-lt-form').addEventListener('submit', event => {
-            event.preventDefault();
-            const form = event.currentTarget;
-            const formData = new FormData(form);
-            formData.append('student_id', studentId);
-            formData.append('standard_id', state.standardId || '');
-
-            fetch('add_learning_target.php', {
-                method: 'POST',
-                body: formData
-            })
-            .then(response => response.json())
-            .then(data => {
-                if (!data.success) {
-                    throw new Error(data.message || 'Unable to add learning target.');
-                }
-                dashboardData = data.dashboard;
-                form.reset();
-                renderDashboard();
-                showTeacherToast('Learning target added.', 'success');
-            })
-            .catch(error => showTeacherToast(error.message || 'Unable to add learning target.', 'error'));
-        });
 
         document.getElementById('delete-student-btn').addEventListener('click', function() {
             if (!confirm('Are you sure you want to delete this student? This action cannot be undone.')) {

--- a/asl1/teacher_dashboard.php
+++ b/asl1/teacher_dashboard.php
@@ -87,6 +87,13 @@ try {
     $total_skills = 0;
     $skills_summary = [];
 }
+
+$aslhub_site_level = defined('ASLHUB_SITE_LEVEL') ? (int) ASLHUB_SITE_LEVEL : 1;
+$standards_data = aslhubFetchTeacherStandardsData($pdo, $aslhub_site_level);
+$standards_json = json_encode($standards_data, JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP);
+if ($standards_json === false) {
+    $standards_json = '{}';
+}
 ?>
 <!DOCTYPE html>
 <html lang="en">
@@ -111,8 +118,7 @@ try {
 
         <nav class="teacher-tabs" aria-label="Dashboard sections">
             <button type="button" class="teacher-tab" onclick="showSection('students')" id="students-btn">Student Progress</button>
-            <button type="button" class="teacher-tab" onclick="showSection('skills')" id="skills-btn">Skills Overview</button>
-            <button type="button" class="teacher-tab" onclick="showSection('manage')" id="manage-btn">Manage Skills</button>
+            <button type="button" class="teacher-tab" onclick="showSection('standards')" id="standards-btn">Standards</button>
             <button type="button" class="teacher-tab" onclick="showSection('scroller')" id="scroller-btn">Scroller Game</button>
             <button type="button" class="teacher-tab" onclick="window.location.href='bingo_dashboard.php'" id="bingo-btn">Bingo</button>
         </nav>
@@ -193,7 +199,6 @@ try {
                                 <div class="student-card-avatar" aria-hidden="true"><?php echo $initials; ?></div>
                                 <div class="student-card-identity">
                                     <h3 class="student-name"><?php echo htmlspecialchars($student['first_name'] . ' ' . $student['last_name']); ?></h3>
-                                    <p class="student-email"><?php echo htmlspecialchars($student['email']); ?></p>
                                 </div>
                             </header>
                             <div class="student-card-meta">
@@ -218,143 +223,39 @@ try {
                 </div>
             </section>
                 
-            <!-- Skills Overview Section -->
-            <section class="student-section" id="skills-section" style="display: none;">
+            <!-- Standards Section -->
+            <section class="student-section" id="standards-section" style="display: none;">
                 <div class="student-section-header">
                     <div>
-                        <p class="student-kicker">Skills Overview</p>
-                        <h2>Progress Across All Skills</h2>
+                        <p class="student-kicker">Standards &amp; Learning Targets</p>
+                        <h2>Standards for ASL <?php echo (int) $aslhub_site_level; ?></h2>
                     </div>
-                    <p>Aggregated student status per skill.</p>
+                    <p>Click a bucket, then a standard, then add learning targets that will appear for every ASL <?php echo (int) $aslhub_site_level; ?> student.</p>
                 </div>
 
-                <div class="skills-summary">
-                        <?php 
-                        // Get all skills with their IDs for the action buttons
-                        $stmt = $pdo->prepare("SELECT id, skill_name, skill_description, unit, order_index, asl_level FROM skills ORDER BY order_index");
-                        $stmt->execute();
-                        $all_skills = $stmt->fetchAll();
-                        
-                        $position_number = 1;
-                        foreach ($all_skills as $skill): 
-                            // Find the corresponding skill summary
-                            $skill_summary = null;
-        foreach ($skills_summary as $summary) {
-            if ((int)$summary['id'] === (int)$skill['id']) {
-                $skill_summary = $summary;
-                break;
-            }
-        }
-                            
-                            if (!$skill_summary) {
-                                $skill_summary = [
-                                    'skill_name' => $skill['skill_name'],
-                                    'not_started' => 0,
-                                    'progressing' => 0,
-                                    'proficient' => 0
-                                ];
-                            }
-                        ?>
-                            <div class="skill-summary-card" data-skill-id="<?php echo $skill['id']; ?>">
-                                <div class="skill-position-controls">
-                                    <span class="skill-position-number">#<?php echo $position_number; ?></span>
-                                    <div class="position-buttons">
-                                        <button class="position-btn" onclick="moveSkill(<?php echo $skill['id']; ?>, 'move_up')" <?php echo $position_number == 1 ? 'disabled' : ''; ?> title="Move Up">▲</button>
-                                        <button class="position-btn" onclick="moveSkill(<?php echo $skill['id']; ?>, 'move_down')" <?php echo $position_number == count($all_skills) ? 'disabled' : ''; ?> title="Move Down">▼</button>
-                                        <input type="number" class="position-input" id="position-<?php echo $skill['id']; ?>" min="1" max="<?php echo count($all_skills); ?>" value="<?php echo $position_number; ?>" onchange="moveToPosition(<?php echo $skill['id']; ?>, this.value)" title="Move to position">
-                                    </div>
-                                </div>
-                                <div class="skill-summary-header">
-                                    <div>
-                                        <h3><?php echo htmlspecialchars($skill_summary['skill_name']); ?></h3>
-                                        <div class="skill-meta-line">
-                                            <?php if (!empty($skill['unit'])): ?>
-                                                <span class="skill-unit">Unit: <?php echo htmlspecialchars($skill['unit']); ?></span>
-                                            <?php else: ?>
-                                                <span class="skill-unit no-unit">No Unit</span>
-                                            <?php endif; ?>
-                                            <span class="skill-level-badge">
-                                                <?php echo (($skill['asl_level'] ?? 3) == 3) ? 'ASL 1 & 2' : 'ASL ' . (int)$skill['asl_level']; ?>
-                                            </span>
-                                        </div>
-                                    </div>
-                                    <div class="skill-actions">
-                                        <button class="action-btn edit-btn" onclick="editSkill(<?php echo $skill['id']; ?>, '<?php echo htmlspecialchars($skill['skill_name'], ENT_QUOTES); ?>', '<?php echo htmlspecialchars($skill['skill_description'], ENT_QUOTES); ?>', '<?php echo htmlspecialchars($skill['unit'] ?? '', ENT_QUOTES); ?>', <?php echo (int)($skill['asl_level'] ?? 3); ?>)">Edit</button>
-                                        <button class="action-btn resources-btn" onclick="manageResources(<?php echo $skill['id']; ?>, '<?php echo htmlspecialchars($skill['skill_name'], ENT_QUOTES); ?>')">Resources</button>
-                                        <button class="action-btn delete-btn" onclick="deleteSkill(<?php echo $skill['id']; ?>, '<?php echo htmlspecialchars($skill['skill_name'], ENT_QUOTES); ?>')">Delete</button>
-                                    </div>
-                                </div>
-                                <div class="skill-stats">
-                                    <div class="stat-item">
-                                        <span class="stat-label">Not Started:</span>
-                                        <span class="stat-value not-started"><?php echo $skill_summary['not_started']; ?></span>
-                                    </div>
-                                    <div class="stat-item">
-                                        <span class="stat-label">Progressing:</span>
-                                        <span class="stat-value progressing"><?php echo $skill_summary['progressing']; ?></span>
-                                    </div>
-                                    <div class="stat-item">
-                                        <span class="stat-label">Proficient:</span>
-                                        <span class="stat-value proficient"><?php echo $skill_summary['proficient']; ?></span>
-                                    </div>
-                                </div>
-                            </div>
-                        <?php
-                            $position_number++;
-                        endforeach; ?>
+                <div class="curriculum-grid teacher-standards-grid">
+                    <div>
+                        <h3 class="column-title">Buckets</h3>
+                        <div id="standards-bucket-list" class="bucket-list"></div>
+                    </div>
+                    <div>
+                        <h3 class="column-title">Standards</h3>
+                        <div id="standards-standard-list" class="standard-list"></div>
+                    </div>
+                    <div>
+                        <h3 class="column-title">Learning Targets</h3>
+                        <div id="standards-target-panel" class="target-panel"></div>
+                        <form id="standards-add-lt-form" class="add-lt-form">
+                            <h4>Add Learning Target</h4>
+                            <input type="text" name="title" placeholder="Learning target title" required>
+                            <textarea name="description" placeholder="Optional description"></textarea>
+                            <button type="submit">Add to Selected Standard</button>
+                        </form>
+                    </div>
                 </div>
             </section>
 
-            <!-- Manage Skills Section -->
-            <section class="student-section" id="manage-section" style="display: none;">
-                <div class="student-section-header">
-                    <div>
-                        <p class="student-kicker">Manage Skills</p>
-                        <h2>Add, Edit, or Remove Skills</h2>
-                    </div>
-                    <p>Skills appear under each standard for grading.</p>
-                </div>
-
-                <div class="manage-actions">
-                    <button class="teacher-btn teacher-btn-success" onclick="showAddSkillForm()">Add New Skill</button>
-                    <button class="teacher-btn teacher-btn-neutral" onclick="exportProgress()">Export Progress Report</button>
-                </div>
-
-                <div id="add-skill-form" class="teacher-inline-form" style="display: none;">
-                        <h3>Add New Skill</h3>
-                        <form id="new-skill-form">
-                            <div class="form-group">
-                                <label>Skill Name</label>
-                                <input type="text" name="skill_name" class="form-input" required>
-                            </div>
-                            <div class="form-group">
-                                <label>Skill Description</label>
-                                <textarea name="skill_description" class="form-input" rows="3"></textarea>
-                            </div>
-                            <div class="form-group">
-                                <label>Unit (optional - leave blank for year-round skills)</label>
-                                <input type="text" name="unit" class="form-input" placeholder="e.g., Unit 1, Semester 1, etc.">
-                            </div>
-                            <div class="form-group">
-                                <label>ASL Level</label>
-                                <select name="asl_level" class="form-input">
-                                    <option value="1" selected>ASL 1 Only</option>
-                                    <option value="2">ASL 2 Only</option>
-                                    <option value="3">Both ASL 1 &amp; 2</option>
-                                </select>
-                            </div>
-                            <div class="form-group">
-                                <label>Resources (one per line)</label>
-                                <textarea name="resources" class="form-input" rows="5" placeholder="Resource Name 1|https://example.com&#10;https://docs.google.com/document/d/123&#10;Just a resource name&#10;Another Resource|https://link.com"></textarea>
-                                <small style="color: #6c757d; font-size: 0.85rem; margin-top: 5px; display: block;">
-                                    Format: "Name|URL" or just "URL" or just "Name". Use the Resources button after creation for advanced editing.
-                                </small>
-                            </div>
-                        <button type="submit" class="form-button">Add Skill</button>
-                        <button type="button" class="form-button" onclick="hideAddSkillForm()" style="background: #6c757d;">Cancel</button>
-                    </form>
-                </div>
-            </section>
+            <!-- Hidden legacy skills overview (disabled) -->
 
             <!-- Scroller Game Section -->
             <section class="student-section" id="scroller-section" style="display: none;">
@@ -556,25 +457,22 @@ try {
     
     <script>
         function showSection(sectionName) {
-            // Hide all sections
-            document.getElementById('students-section').style.display = 'none';
-            document.getElementById('skills-section').style.display = 'none';
-            document.getElementById('manage-section').style.display = 'none';
-            document.getElementById('scroller-section').style.display = 'none';
-            
-            // Remove active class from all buttons
-            document.getElementById('students-btn').classList.remove('active');
-            document.getElementById('skills-btn').classList.remove('active');
-            document.getElementById('manage-btn').classList.remove('active');
-            document.getElementById('scroller-btn').classList.remove('active');
-            
-            // Show selected section and activate button
-            document.getElementById(sectionName + '-section').style.display = 'block';
-            document.getElementById(sectionName + '-btn').classList.add('active');
-            
-            // Load section-specific content
+            ['students', 'standards', 'scroller'].forEach(name => {
+                const section = document.getElementById(name + '-section');
+                const btn = document.getElementById(name + '-btn');
+                if (section) section.style.display = 'none';
+                if (btn) btn.classList.remove('active');
+            });
+
+            const showSec = document.getElementById(sectionName + '-section');
+            const showBtn = document.getElementById(sectionName + '-btn');
+            if (showSec) showSec.style.display = 'block';
+            if (showBtn) showBtn.classList.add('active');
+
             if (sectionName === 'scroller') {
                 loadWordlists();
+            } else if (sectionName === 'standards') {
+                renderStandardsSection();
             }
         }
         
@@ -642,21 +540,144 @@ try {
             });
         }
 
-        function showAddSkillForm() {
-            document.getElementById('add-skill-form').style.display = 'block';
+        // ===== Standards section =====
+        const SITE_ASL_LEVEL = <?php echo (int) $aslhub_site_level; ?>;
+        let standardsData = <?php echo $standards_json; ?>;
+        const standardsState = {
+            bucketId: (standardsData.buckets && standardsData.buckets[0]) ? standardsData.buckets[0].id : null,
+            standardId: (standardsData.buckets && standardsData.buckets[0] && standardsData.buckets[0].standards[0]) ? standardsData.buckets[0].standards[0].id : null
+        };
+
+        function standardsEscapeHtml(value) {
+            const div = document.createElement('div');
+            div.textContent = value == null ? '' : String(value);
+            return div.innerHTML;
         }
-        
-        function hideAddSkillForm() {
-            document.getElementById('add-skill-form').style.display = 'none';
-            document.getElementById('new-skill-form').reset();
+
+        function getStandardsBucket(bucketId) {
+            return (standardsData.buckets || []).find(b => b.id === bucketId) || null;
         }
-        
-        function exportProgress() {
-            // This would generate and download a progress report
-            alert('Export functionality coming soon!');
+
+        function getStandardsStandard(standardId) {
+            for (const b of standardsData.buckets || []) {
+                const found = (b.standards || []).find(s => s.id === standardId);
+                if (found) return found;
+            }
+            return null;
         }
-        
-        
+
+        function getStandardsTargets(standardId) {
+            return (standardsData.targetsByStandard || {})[standardId] || [];
+        }
+
+        function renderStandardsBuckets() {
+            const list = document.getElementById('standards-bucket-list');
+            if (!list) return;
+            list.innerHTML = (standardsData.buckets || []).map(b => {
+                const count = (b.standards || []).reduce((sum, s) => sum + getStandardsTargets(s.id).length, 0);
+                return `
+                    <button type="button" class="bucket-card ${b.id === standardsState.bucketId ? 'active' : ''}" data-bucket-id="${standardsEscapeHtml(b.id)}">
+                        <span class="bucket-code">${standardsEscapeHtml(b.code)}</span>
+                        <span class="bucket-name">${standardsEscapeHtml(b.name)}</span>
+                        <span class="bucket-progress">${count} learning target${count === 1 ? '' : 's'}</span>
+                    </button>
+                `;
+            }).join('');
+            list.querySelectorAll('[data-bucket-id]').forEach(btn => {
+                btn.addEventListener('click', () => {
+                    const b = getStandardsBucket(btn.dataset.bucketId);
+                    standardsState.bucketId = btn.dataset.bucketId;
+                    standardsState.standardId = (b && b.standards[0]) ? b.standards[0].id : null;
+                    renderStandardsSection();
+                });
+            });
+        }
+
+        function renderStandardsStandards() {
+            const list = document.getElementById('standards-standard-list');
+            if (!list) return;
+            const bucket = getStandardsBucket(standardsState.bucketId);
+            const standards = bucket ? (bucket.standards || []) : [];
+            list.innerHTML = standards.map(s => {
+                const count = getStandardsTargets(s.id).length;
+                return `
+                    <button type="button" class="standard-row ${s.id === standardsState.standardId ? 'active' : ''}" data-standard-id="${standardsEscapeHtml(s.id)}">
+                        <span class="standard-id">${standardsEscapeHtml(s.id)}</span>
+                        <span class="standard-name">${standardsEscapeHtml(s.name)}</span>
+                        <span class="standard-desc">${standardsEscapeHtml(s.description || '')}</span>
+                        <span class="standard-progress">${count} LT${count === 1 ? '' : 's'}</span>
+                    </button>
+                `;
+            }).join('');
+            list.querySelectorAll('[data-standard-id]').forEach(btn => {
+                btn.addEventListener('click', () => {
+                    standardsState.standardId = btn.dataset.standardId;
+                    renderStandardsSection();
+                });
+            });
+        }
+
+        function renderStandardsTargets() {
+            const panel = document.getElementById('standards-target-panel');
+            if (!panel) return;
+            const standard = getStandardsStandard(standardsState.standardId);
+            if (!standard) {
+                panel.innerHTML = '<div class="empty-panel">Select a standard to view its learning targets.</div>';
+                return;
+            }
+            const targets = getStandardsTargets(standard.id);
+            const targetItems = targets.length
+                ? targets.map(t => `
+                    <div class="target-row">
+                        <span>${standardsEscapeHtml(t.title)}</span>
+                        ${t.description ? `<small>${standardsEscapeHtml(t.description)}</small>` : ''}
+                    </div>
+                `).join('')
+                : '<div class="empty-panel">No learning targets yet. Add one below.</div>';
+            panel.innerHTML = `
+                <div class="target-standard-summary">
+                    <span>${standardsEscapeHtml(standard.id)}</span>
+                    <h4>${standardsEscapeHtml(standard.name)}</h4>
+                    <p>${standardsEscapeHtml(standard.description || '')}</p>
+                </div>
+                <div class="target-list">${targetItems}</div>
+            `;
+        }
+
+        function renderStandardsSection() {
+            renderStandardsBuckets();
+            renderStandardsStandards();
+            renderStandardsTargets();
+        }
+
+        function submitStandardsAddLearningTarget() {
+            const form = document.getElementById('standards-add-lt-form');
+            if (!form) return;
+            if (!standardsState.standardId) {
+                showMessage('Select a standard first.', 'error');
+                return;
+            }
+            const formData = new FormData(form);
+            formData.append('standard_id', standardsState.standardId);
+            formData.append('asl_level', SITE_ASL_LEVEL);
+
+            fetch('add_learning_target.php', { method: 'POST', body: formData })
+                .then(r => r.json())
+                .then(data => {
+                    if (!data.success) {
+                        throw new Error(data.message || 'Unable to add learning target.');
+                    }
+                    if (data.standards) {
+                        standardsData = data.standards;
+                    }
+                    form.reset();
+                    renderStandardsSection();
+                    showMessage('Learning target added.', 'success');
+                })
+                .catch(err => showMessage(err.message || 'Unable to add learning target.', 'error'));
+        }
+
+
         // Set initial active state
         document.addEventListener('DOMContentLoaded', function() {
             document.getElementById('students-btn').classList.add('active');
@@ -667,12 +688,15 @@ try {
             document.getElementById('level-filter').addEventListener('change', filterAndSortStudents);
             document.getElementById('sort-filter').addEventListener('change', filterAndSortStudents);
             
-            // Add form submission handler
-            document.getElementById('new-skill-form').addEventListener('submit', function(e) {
-                e.preventDefault();
-                submitNewSkill();
-            });
-            
+            // Standards add-LT form handler
+            const addLtForm = document.getElementById('standards-add-lt-form');
+            if (addLtForm) {
+                addLtForm.addEventListener('submit', function(e) {
+                    e.preventDefault();
+                    submitStandardsAddLearningTarget();
+                });
+            }
+
             // Add scroller wordlist form submission handler
             document.getElementById('new-wordlist-form').addEventListener('submit', function(e) {
                 e.preventDefault();

--- a/asl2/config.php
+++ b/asl2/config.php
@@ -79,6 +79,9 @@ if (!function_exists('aslhubEnsureGoalsTable')) {
     }
 }
 
+if (!defined('ASLHUB_SITE_LEVEL')) {
+    define('ASLHUB_SITE_LEVEL', 2);
+}
 aslhubEnsureSkillLevels($pdo, 2);
 aslhubEnsureGoalsTable($pdo);
 ?>

--- a/asl2/teacher_dashboard.php
+++ b/asl2/teacher_dashboard.php
@@ -87,6 +87,13 @@ try {
     $total_skills = 0;
     $skills_summary = [];
 }
+
+$aslhub_site_level = defined('ASLHUB_SITE_LEVEL') ? (int) ASLHUB_SITE_LEVEL : 2;
+$standards_data = aslhubFetchTeacherStandardsData($pdo, $aslhub_site_level);
+$standards_json = json_encode($standards_data, JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP);
+if ($standards_json === false) {
+    $standards_json = '{}';
+}
 ?>
 <!DOCTYPE html>
 <html lang="en">
@@ -111,8 +118,7 @@ try {
 
         <nav class="teacher-tabs" aria-label="Dashboard sections">
             <button type="button" class="teacher-tab" onclick="showSection('students')" id="students-btn">Student Progress</button>
-            <button type="button" class="teacher-tab" onclick="showSection('skills')" id="skills-btn">Skills Overview</button>
-            <button type="button" class="teacher-tab" onclick="showSection('manage')" id="manage-btn">Manage Skills</button>
+            <button type="button" class="teacher-tab" onclick="showSection('standards')" id="standards-btn">Standards</button>
             <button type="button" class="teacher-tab" onclick="showSection('scroller')" id="scroller-btn">Scroller Game</button>
             <button type="button" class="teacher-tab" onclick="window.location.href='bingo_dashboard.php'" id="bingo-btn">Bingo</button>
         </nav>
@@ -193,7 +199,6 @@ try {
                                 <div class="student-card-avatar" aria-hidden="true"><?php echo $initials; ?></div>
                                 <div class="student-card-identity">
                                     <h3 class="student-name"><?php echo htmlspecialchars($student['first_name'] . ' ' . $student['last_name']); ?></h3>
-                                    <p class="student-email"><?php echo htmlspecialchars($student['email']); ?></p>
                                 </div>
                             </header>
                             <div class="student-card-meta">
@@ -218,143 +223,38 @@ try {
                 </div>
             </section>
                 
-            <!-- Skills Overview Section -->
-            <section class="student-section" id="skills-section" style="display: none;">
+            <!-- Standards Section -->
+            <section class="student-section" id="standards-section" style="display: none;">
                 <div class="student-section-header">
                     <div>
-                        <p class="student-kicker">Skills Overview</p>
-                        <h2>Progress Across All Skills</h2>
+                        <p class="student-kicker">Standards &amp; Learning Targets</p>
+                        <h2>Standards for ASL <?php echo (int) $aslhub_site_level; ?></h2>
                     </div>
-                    <p>Aggregated student status per skill.</p>
+                    <p>Click a bucket, then a standard, then add learning targets that will appear for every ASL <?php echo (int) $aslhub_site_level; ?> student.</p>
                 </div>
 
-                <div class="skills-summary">
-                        <?php 
-                        // Get all skills with their IDs for the action buttons
-                        $stmt = $pdo->prepare("SELECT id, skill_name, skill_description, unit, order_index, asl_level FROM skills ORDER BY order_index");
-                        $stmt->execute();
-                        $all_skills = $stmt->fetchAll();
-                        
-                        $position_number = 1;
-                        foreach ($all_skills as $skill): 
-                            // Find the corresponding skill summary
-                            $skill_summary = null;
-        foreach ($skills_summary as $summary) {
-            if ((int)$summary['id'] === (int)$skill['id']) {
-                $skill_summary = $summary;
-                break;
-            }
-        }
-                            
-                            if (!$skill_summary) {
-                                $skill_summary = [
-                                    'skill_name' => $skill['skill_name'],
-                                    'not_started' => 0,
-                                    'progressing' => 0,
-                                    'proficient' => 0
-                                ];
-                            }
-                        ?>
-                            <div class="skill-summary-card" data-skill-id="<?php echo $skill['id']; ?>">
-                                <div class="skill-position-controls">
-                                    <span class="skill-position-number">#<?php echo $position_number; ?></span>
-                                    <div class="position-buttons">
-                                        <button class="position-btn" onclick="moveSkill(<?php echo $skill['id']; ?>, 'move_up')" <?php echo $position_number == 1 ? 'disabled' : ''; ?> title="Move Up">▲</button>
-                                        <button class="position-btn" onclick="moveSkill(<?php echo $skill['id']; ?>, 'move_down')" <?php echo $position_number == count($all_skills) ? 'disabled' : ''; ?> title="Move Down">▼</button>
-                                        <input type="number" class="position-input" id="position-<?php echo $skill['id']; ?>" min="1" max="<?php echo count($all_skills); ?>" value="<?php echo $position_number; ?>" onchange="moveToPosition(<?php echo $skill['id']; ?>, this.value)" title="Move to position">
-                                    </div>
-                                </div>
-                                <div class="skill-summary-header">
-                                    <div>
-                                        <h3><?php echo htmlspecialchars($skill_summary['skill_name']); ?></h3>
-                                        <div class="skill-meta-line">
-                                            <?php if (!empty($skill['unit'])): ?>
-                                                <span class="skill-unit">Unit: <?php echo htmlspecialchars($skill['unit']); ?></span>
-                                            <?php else: ?>
-                                                <span class="skill-unit no-unit">No Unit</span>
-                                            <?php endif; ?>
-                                            <span class="skill-level-badge">
-                                                <?php echo (($skill['asl_level'] ?? 3) == 3) ? 'ASL 1 & 2' : 'ASL ' . (int)$skill['asl_level']; ?>
-                                            </span>
-                                        </div>
-                                    </div>
-                                    <div class="skill-actions">
-                                        <button class="action-btn edit-btn" onclick="editSkill(<?php echo $skill['id']; ?>, '<?php echo htmlspecialchars($skill['skill_name'], ENT_QUOTES); ?>', '<?php echo htmlspecialchars($skill['skill_description'], ENT_QUOTES); ?>', '<?php echo htmlspecialchars($skill['unit'] ?? '', ENT_QUOTES); ?>', <?php echo (int)($skill['asl_level'] ?? 3); ?>)">Edit</button>
-                                        <button class="action-btn resources-btn" onclick="manageResources(<?php echo $skill['id']; ?>, '<?php echo htmlspecialchars($skill['skill_name'], ENT_QUOTES); ?>')">Resources</button>
-                                        <button class="action-btn delete-btn" onclick="deleteSkill(<?php echo $skill['id']; ?>, '<?php echo htmlspecialchars($skill['skill_name'], ENT_QUOTES); ?>')">Delete</button>
-                                    </div>
-                                </div>
-                                <div class="skill-stats">
-                                    <div class="stat-item">
-                                        <span class="stat-label">Not Started:</span>
-                                        <span class="stat-value not-started"><?php echo $skill_summary['not_started']; ?></span>
-                                    </div>
-                                    <div class="stat-item">
-                                        <span class="stat-label">Progressing:</span>
-                                        <span class="stat-value progressing"><?php echo $skill_summary['progressing']; ?></span>
-                                    </div>
-                                    <div class="stat-item">
-                                        <span class="stat-label">Proficient:</span>
-                                        <span class="stat-value proficient"><?php echo $skill_summary['proficient']; ?></span>
-                                    </div>
-                                </div>
-                            </div>
-                        <?php
-                            $position_number++;
-                        endforeach; ?>
+                <div class="curriculum-grid teacher-standards-grid">
+                    <div>
+                        <h3 class="column-title">Buckets</h3>
+                        <div id="standards-bucket-list" class="bucket-list"></div>
+                    </div>
+                    <div>
+                        <h3 class="column-title">Standards</h3>
+                        <div id="standards-standard-list" class="standard-list"></div>
+                    </div>
+                    <div>
+                        <h3 class="column-title">Learning Targets</h3>
+                        <div id="standards-target-panel" class="target-panel"></div>
+                        <form id="standards-add-lt-form" class="add-lt-form">
+                            <h4>Add Learning Target</h4>
+                            <input type="text" name="title" placeholder="Learning target title" required>
+                            <textarea name="description" placeholder="Optional description"></textarea>
+                            <button type="submit">Add to Selected Standard</button>
+                        </form>
+                    </div>
                 </div>
             </section>
 
-            <!-- Manage Skills Section -->
-            <section class="student-section" id="manage-section" style="display: none;">
-                <div class="student-section-header">
-                    <div>
-                        <p class="student-kicker">Manage Skills</p>
-                        <h2>Add, Edit, or Remove Skills</h2>
-                    </div>
-                    <p>Skills appear under each standard for grading.</p>
-                </div>
-
-                <div class="manage-actions">
-                    <button class="teacher-btn teacher-btn-success" onclick="showAddSkillForm()">Add New Skill</button>
-                    <button class="teacher-btn teacher-btn-neutral" onclick="exportProgress()">Export Progress Report</button>
-                </div>
-
-                <div id="add-skill-form" class="teacher-inline-form" style="display: none;">
-                        <h3>Add New Skill</h3>
-                        <form id="new-skill-form">
-                            <div class="form-group">
-                                <label>Skill Name</label>
-                                <input type="text" name="skill_name" class="form-input" required>
-                            </div>
-                            <div class="form-group">
-                                <label>Skill Description</label>
-                                <textarea name="skill_description" class="form-input" rows="3"></textarea>
-                            </div>
-                            <div class="form-group">
-                                <label>Unit (optional - leave blank for year-round skills)</label>
-                                <input type="text" name="unit" class="form-input" placeholder="e.g., Unit 1, Semester 1, etc.">
-                            </div>
-                            <div class="form-group">
-                                <label>ASL Level</label>
-                                <select name="asl_level" class="form-input">
-                                    <option value="1">ASL 1 Only</option>
-                                    <option value="2" selected>ASL 2 Only</option>
-                                    <option value="3">Both ASL 1 &amp; 2</option>
-                                </select>
-                            </div>
-                            <div class="form-group">
-                                <label>Resources (one per line)</label>
-                                <textarea name="resources" class="form-input" rows="5" placeholder="Resource Name 1|https://example.com&#10;https://docs.google.com/document/d/123&#10;Just a resource name&#10;Another Resource|https://link.com"></textarea>
-                                <small style="color: #6c757d; font-size: 0.85rem; margin-top: 5px; display: block;">
-                                    Format: "Name|URL" or just "URL" or just "Name". Use the Resources button after creation for advanced editing.
-                                </small>
-                            </div>
-                        <button type="submit" class="form-button">Add Skill</button>
-                        <button type="button" class="form-button" onclick="hideAddSkillForm()" style="background: #6c757d;">Cancel</button>
-                    </form>
-                </div>
-            </section>
 
             <!-- Scroller Game Section -->
             <section class="student-section" id="scroller-section" style="display: none;">
@@ -556,25 +456,22 @@ try {
     
     <script>
         function showSection(sectionName) {
-            // Hide all sections
-            document.getElementById('students-section').style.display = 'none';
-            document.getElementById('skills-section').style.display = 'none';
-            document.getElementById('manage-section').style.display = 'none';
-            document.getElementById('scroller-section').style.display = 'none';
-            
-            // Remove active class from all buttons
-            document.getElementById('students-btn').classList.remove('active');
-            document.getElementById('skills-btn').classList.remove('active');
-            document.getElementById('manage-btn').classList.remove('active');
-            document.getElementById('scroller-btn').classList.remove('active');
-            
-            // Show selected section and activate button
-            document.getElementById(sectionName + '-section').style.display = 'block';
-            document.getElementById(sectionName + '-btn').classList.add('active');
-            
-            // Load section-specific content
+            ['students', 'standards', 'scroller'].forEach(name => {
+                const section = document.getElementById(name + '-section');
+                const btn = document.getElementById(name + '-btn');
+                if (section) section.style.display = 'none';
+                if (btn) btn.classList.remove('active');
+            });
+
+            const showSec = document.getElementById(sectionName + '-section');
+            const showBtn = document.getElementById(sectionName + '-btn');
+            if (showSec) showSec.style.display = 'block';
+            if (showBtn) showBtn.classList.add('active');
+
             if (sectionName === 'scroller') {
                 loadWordlists();
+            } else if (sectionName === 'standards') {
+                renderStandardsSection();
             }
         }
         
@@ -642,21 +539,144 @@ try {
             });
         }
 
-        function showAddSkillForm() {
-            document.getElementById('add-skill-form').style.display = 'block';
+        // ===== Standards section =====
+        const SITE_ASL_LEVEL = <?php echo (int) $aslhub_site_level; ?>;
+        let standardsData = <?php echo $standards_json; ?>;
+        const standardsState = {
+            bucketId: (standardsData.buckets && standardsData.buckets[0]) ? standardsData.buckets[0].id : null,
+            standardId: (standardsData.buckets && standardsData.buckets[0] && standardsData.buckets[0].standards[0]) ? standardsData.buckets[0].standards[0].id : null
+        };
+
+        function standardsEscapeHtml(value) {
+            const div = document.createElement('div');
+            div.textContent = value == null ? '' : String(value);
+            return div.innerHTML;
         }
-        
-        function hideAddSkillForm() {
-            document.getElementById('add-skill-form').style.display = 'none';
-            document.getElementById('new-skill-form').reset();
+
+        function getStandardsBucket(bucketId) {
+            return (standardsData.buckets || []).find(b => b.id === bucketId) || null;
         }
-        
-        function exportProgress() {
-            // This would generate and download a progress report
-            alert('Export functionality coming soon!');
+
+        function getStandardsStandard(standardId) {
+            for (const b of standardsData.buckets || []) {
+                const found = (b.standards || []).find(s => s.id === standardId);
+                if (found) return found;
+            }
+            return null;
         }
-        
-        
+
+        function getStandardsTargets(standardId) {
+            return (standardsData.targetsByStandard || {})[standardId] || [];
+        }
+
+        function renderStandardsBuckets() {
+            const list = document.getElementById('standards-bucket-list');
+            if (!list) return;
+            list.innerHTML = (standardsData.buckets || []).map(b => {
+                const count = (b.standards || []).reduce((sum, s) => sum + getStandardsTargets(s.id).length, 0);
+                return `
+                    <button type="button" class="bucket-card ${b.id === standardsState.bucketId ? 'active' : ''}" data-bucket-id="${standardsEscapeHtml(b.id)}">
+                        <span class="bucket-code">${standardsEscapeHtml(b.code)}</span>
+                        <span class="bucket-name">${standardsEscapeHtml(b.name)}</span>
+                        <span class="bucket-progress">${count} learning target${count === 1 ? '' : 's'}</span>
+                    </button>
+                `;
+            }).join('');
+            list.querySelectorAll('[data-bucket-id]').forEach(btn => {
+                btn.addEventListener('click', () => {
+                    const b = getStandardsBucket(btn.dataset.bucketId);
+                    standardsState.bucketId = btn.dataset.bucketId;
+                    standardsState.standardId = (b && b.standards[0]) ? b.standards[0].id : null;
+                    renderStandardsSection();
+                });
+            });
+        }
+
+        function renderStandardsStandards() {
+            const list = document.getElementById('standards-standard-list');
+            if (!list) return;
+            const bucket = getStandardsBucket(standardsState.bucketId);
+            const standards = bucket ? (bucket.standards || []) : [];
+            list.innerHTML = standards.map(s => {
+                const count = getStandardsTargets(s.id).length;
+                return `
+                    <button type="button" class="standard-row ${s.id === standardsState.standardId ? 'active' : ''}" data-standard-id="${standardsEscapeHtml(s.id)}">
+                        <span class="standard-id">${standardsEscapeHtml(s.id)}</span>
+                        <span class="standard-name">${standardsEscapeHtml(s.name)}</span>
+                        <span class="standard-desc">${standardsEscapeHtml(s.description || '')}</span>
+                        <span class="standard-progress">${count} LT${count === 1 ? '' : 's'}</span>
+                    </button>
+                `;
+            }).join('');
+            list.querySelectorAll('[data-standard-id]').forEach(btn => {
+                btn.addEventListener('click', () => {
+                    standardsState.standardId = btn.dataset.standardId;
+                    renderStandardsSection();
+                });
+            });
+        }
+
+        function renderStandardsTargets() {
+            const panel = document.getElementById('standards-target-panel');
+            if (!panel) return;
+            const standard = getStandardsStandard(standardsState.standardId);
+            if (!standard) {
+                panel.innerHTML = '<div class="empty-panel">Select a standard to view its learning targets.</div>';
+                return;
+            }
+            const targets = getStandardsTargets(standard.id);
+            const targetItems = targets.length
+                ? targets.map(t => `
+                    <div class="target-row">
+                        <span>${standardsEscapeHtml(t.title)}</span>
+                        ${t.description ? `<small>${standardsEscapeHtml(t.description)}</small>` : ''}
+                    </div>
+                `).join('')
+                : '<div class="empty-panel">No learning targets yet. Add one below.</div>';
+            panel.innerHTML = `
+                <div class="target-standard-summary">
+                    <span>${standardsEscapeHtml(standard.id)}</span>
+                    <h4>${standardsEscapeHtml(standard.name)}</h4>
+                    <p>${standardsEscapeHtml(standard.description || '')}</p>
+                </div>
+                <div class="target-list">${targetItems}</div>
+            `;
+        }
+
+        function renderStandardsSection() {
+            renderStandardsBuckets();
+            renderStandardsStandards();
+            renderStandardsTargets();
+        }
+
+        function submitStandardsAddLearningTarget() {
+            const form = document.getElementById('standards-add-lt-form');
+            if (!form) return;
+            if (!standardsState.standardId) {
+                showMessage('Select a standard first.', 'error');
+                return;
+            }
+            const formData = new FormData(form);
+            formData.append('standard_id', standardsState.standardId);
+            formData.append('asl_level', SITE_ASL_LEVEL);
+
+            fetch('add_learning_target.php', { method: 'POST', body: formData })
+                .then(r => r.json())
+                .then(data => {
+                    if (!data.success) {
+                        throw new Error(data.message || 'Unable to add learning target.');
+                    }
+                    if (data.standards) {
+                        standardsData = data.standards;
+                    }
+                    form.reset();
+                    renderStandardsSection();
+                    showMessage('Learning target added.', 'success');
+                })
+                .catch(err => showMessage(err.message || 'Unable to add learning target.', 'error'));
+        }
+
+
         // Set initial active state
         document.addEventListener('DOMContentLoaded', function() {
             document.getElementById('students-btn').classList.add('active');
@@ -667,12 +687,15 @@ try {
             document.getElementById('level-filter').addEventListener('change', filterAndSortStudents);
             document.getElementById('sort-filter').addEventListener('change', filterAndSortStudents);
             
-            // Add form submission handler
-            document.getElementById('new-skill-form').addEventListener('submit', function(e) {
-                e.preventDefault();
-                submitNewSkill();
-            });
-            
+            // Standards add-LT form handler
+            const addLtForm = document.getElementById('standards-add-lt-form');
+            if (addLtForm) {
+                addLtForm.addEventListener('submit', function(e) {
+                    e.preventDefault();
+                    submitStandardsAddLearningTarget();
+                });
+            }
+
             // Add scroller wordlist form submission handler
             document.getElementById('new-wordlist-form').addEventListener('submit', function(e) {
                 e.preventDefault();

--- a/common/asl_student_dashboard_data.php
+++ b/common/asl_student_dashboard_data.php
@@ -167,10 +167,22 @@ if (!function_exists('aslhubEnsureStudentDashboardSchema')) {
                 description TEXT NULL,
                 order_index INT NOT NULL DEFAULT 0,
                 active TINYINT(1) NOT NULL DEFAULT 1,
+                asl_level TINYINT NULL,
                 created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
                 updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-                INDEX idx_asl_lts_standard (standard_id)
+                INDEX idx_asl_lts_standard (standard_id),
+                INDEX idx_asl_lts_level (asl_level)
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci");
+
+            try {
+                $columnCheck = $pdo->query("SHOW COLUMNS FROM asl_learning_targets LIKE 'asl_level'");
+                if ($columnCheck && $columnCheck->rowCount() === 0) {
+                    $pdo->exec("ALTER TABLE asl_learning_targets ADD COLUMN asl_level TINYINT NULL AFTER active");
+                    $pdo->exec("ALTER TABLE asl_learning_targets ADD INDEX idx_asl_lts_level (asl_level)");
+                }
+            } catch (PDOException $e) {
+                error_log('ASL learning_targets level migration failed: ' . $e->getMessage());
+            }
 
             $pdo->exec("CREATE TABLE IF NOT EXISTS asl_learning_target_resources (
                 id INT AUTO_INCREMENT PRIMARY KEY,
@@ -521,12 +533,24 @@ if (!function_exists('aslhubFetchStudentDashboardData')) {
         }
 
         try {
+            $userLevel = null;
+            try {
+                $levelStmt = $pdo->prepare("SELECT level FROM users WHERE id = ?");
+                $levelStmt->execute([$userId]);
+                $levelRow = $levelStmt->fetch(PDO::FETCH_ASSOC);
+                if ($levelRow && in_array((int) $levelRow['level'], [1, 2], true)) {
+                    $userLevel = (int) $levelRow['level'];
+                }
+            } catch (PDOException $e) {
+                $userLevel = null;
+            }
+
             $stmt = $pdo->prepare("SELECT lt.id, lt.standard_id, lt.title, lt.description, COALESCE(ult.score, 0) AS score, ult.completed_at
                 FROM asl_learning_targets lt
                 LEFT JOIN user_learning_targets ult ON ult.learning_target_id = lt.id AND ult.user_id = ?
-                WHERE lt.active = 1
+                WHERE lt.active = 1 AND (lt.asl_level IS NULL OR lt.asl_level = ?)
                 ORDER BY lt.standard_id, lt.order_index, lt.id");
-            $stmt->execute([$userId]);
+            $stmt->execute([$userId, $userLevel]);
             foreach ($stmt->fetchAll(PDO::FETCH_ASSOC) as $target) {
                 $standardId = $target['standard_id'];
                 if (!isset($targetsByStandard[$standardId])) {
@@ -643,6 +667,76 @@ if (!function_exists('aslhubFetchStudentDashboardData')) {
             'scale' => aslhubLearningTargetScale(),
             'graph' => aslhubStudentDashboardBuildGraph($pdo, $userId),
             'comparisons' => aslhubStudentDashboardComparisons($pdo, $userId),
+        ];
+    }
+}
+
+if (!function_exists('aslhubFetchTeacherStandardsData')) {
+    function aslhubFetchTeacherStandardsData(PDO $pdo, int $aslLevel): array
+    {
+        aslhubEnsureStudentDashboardSchema($pdo);
+
+        $buckets = [];
+        $standardsByBucket = [];
+        $targetsByStandard = [];
+
+        try {
+            $stmt = $pdo->query("SELECT bucket_id, code, name, blurb FROM asl_skill_buckets ORDER BY order_index, bucket_id");
+            foreach ($stmt->fetchAll(PDO::FETCH_ASSOC) as $bucket) {
+                $buckets[$bucket['bucket_id']] = [
+                    'id' => $bucket['bucket_id'],
+                    'code' => $bucket['code'],
+                    'name' => $bucket['name'],
+                    'blurb' => $bucket['blurb'],
+                    'standards' => [],
+                ];
+                $standardsByBucket[$bucket['bucket_id']] = [];
+            }
+
+            $stmt = $pdo->query("SELECT standard_id, bucket_id, name, description FROM asl_standards ORDER BY bucket_id, order_index, standard_id");
+            foreach ($stmt->fetchAll(PDO::FETCH_ASSOC) as $standard) {
+                if (!isset($standardsByBucket[$standard['bucket_id']])) {
+                    continue;
+                }
+                $standardsByBucket[$standard['bucket_id']][] = [
+                    'id' => $standard['standard_id'],
+                    'bucketId' => $standard['bucket_id'],
+                    'name' => $standard['name'],
+                    'description' => $standard['description'],
+                ];
+                $targetsByStandard[$standard['standard_id']] = [];
+            }
+
+            $stmt = $pdo->prepare("SELECT id, standard_id, title, description, asl_level
+                FROM asl_learning_targets
+                WHERE active = 1 AND (asl_level IS NULL OR asl_level = ?)
+                ORDER BY standard_id, order_index, id");
+            $stmt->execute([$aslLevel]);
+            foreach ($stmt->fetchAll(PDO::FETCH_ASSOC) as $target) {
+                $sid = $target['standard_id'];
+                if (!isset($targetsByStandard[$sid])) {
+                    $targetsByStandard[$sid] = [];
+                }
+                $targetsByStandard[$sid][] = [
+                    'id' => (int) $target['id'],
+                    'standardId' => $sid,
+                    'title' => $target['title'],
+                    'description' => $target['description'],
+                    'aslLevel' => $target['asl_level'] !== null ? (int) $target['asl_level'] : null,
+                ];
+            }
+        } catch (PDOException $e) {
+            error_log('ASL teacher standards fetch failed: ' . $e->getMessage());
+        }
+
+        foreach ($buckets as $bid => $bucket) {
+            $buckets[$bid]['standards'] = $standardsByBucket[$bid] ?? [];
+        }
+
+        return [
+            'aslLevel' => $aslLevel,
+            'buckets' => array_values($buckets),
+            'targetsByStandard' => $targetsByStandard,
         ];
     }
 }


### PR DESCRIPTION
## Summary
This PR replaces the Skills Overview and Manage Skills sections in the teacher dashboard with a new Standards-based interface for managing learning targets. The change introduces a three-column curriculum grid (Buckets → Standards → Learning Targets) that allows teachers to organize and assign learning targets by ASL level.

## Key Changes

### Teacher Dashboard Updates (asl1/teacher_dashboard.php, asl2/teacher_dashboard.php)
- Removed "Skills Overview" and "Manage Skills" tabs, replaced with single "Standards" tab
- Removed student email display from student cards
- Replaced 144+ lines of skill management UI with new standards interface featuring:
  - Three-column layout: Buckets, Standards, and Learning Targets
  - Form to add learning targets to selected standards
  - Dynamic rendering functions for bucket/standard/target selection
- Refactored `showSection()` function to use cleaner array-based iteration
- Added standards data fetching and JSON encoding with proper error handling
- Integrated `renderStandardsSection()` callback when standards tab is selected

### Data Layer (common/asl_student_dashboard_data.php)
- Added `asl_level` column to `asl_learning_targets` table with migration logic
- Added index on `asl_level` column for query performance
- Updated `aslhubFetchStudentDashboardData()` to filter learning targets by user's ASL level
- Implemented new `aslhubFetchTeacherStandardsData()` function that:
  - Fetches buckets, standards, and learning targets organized by ASL level
  - Returns structured data for teacher dashboard rendering
  - Filters targets by specified ASL level

### Learning Target Management (asl1/add_learning_target.php)
- Removed student_id requirement (targets are now global, not student-specific)
- Added `asl_level` parameter to associate targets with specific ASL levels
- Simplified validation to only require standard_id and title
- Updated database insert to include asl_level field

### Configuration (asl1/config.php, asl2/config.php)
- Added `ASLHUB_SITE_LEVEL` constant definition (1 for ASL1, 2 for ASL2)
- Ensures proper ASL level context throughout the application

### Student Details (asl1/student_details.php)
- Removed "Add Learning Target" form from student details page
- Learning targets are now managed globally via teacher dashboard, not per-student

## Implementation Details
- Standards data is JSON-encoded with HTML entity escaping (JSON_HEX_TAG, JSON_HEX_APOS, JSON_HEX_QUOT, JSON_HEX_AMP) for safe embedding in JavaScript
- Learning targets are now filtered by ASL level at both student dashboard and teacher dashboard levels
- The new standards interface uses state management to track selected bucket and standard
- Proper error handling for JSON encoding failures (defaults to empty object)
- Database migration includes try-catch for safe column addition to existing tables

https://claude.ai/code/session_01LXanmCa1S74HLaCfKJPF4g