### PR TITLE
Add real wall structure for automation walls (Motivate Earth)

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -77,7 +77,9 @@
       "Bash(node --check dnd/vtt/assets/js/ui/character-summary-panel.js)",
       "Bash(git check-ignore *)",
       "Bash(node --check dnd/character_sheet/sheet.js)",
-      "Bash(node --check dnd/character_sheet/ability-automation/paste.js)"
+      "Bash(node --check dnd/character_sheet/ability-automation/paste.js)",
+      "Bash(git checkout *)",
+      "Bash(git push *)"
     ],
     "deny": []
   }

--- a/dnd/character_sheet/ability-automation/AUTHORING.md
+++ b/dnd/character_sheet/ability-automation/AUTHORING.md
@@ -193,6 +193,10 @@ For `mode: "area"` add:
 | `size` | int — primary dimension in squares |
 | `width`, `height` | ints — for `rectangle` |
 | `length` | int — for `line`, `wall` |
+| `structure` | bool — **`shape: "wall"` only.** When `true`, the placed wall becomes a real, permanent wall template (textured, selectable, lives in scene state) instead of vanishing after placement. Use for terrain-creating abilities (e.g. Motivate Earth). Omit/`false` for walls that exist only as a damaging persistent zone (e.g. Wall of Fire), which use a `persistent` block for their visuals. |
+| `wallColor` | string — **`shape: "wall"` only.** Material/color variant of the wall texture: `"stone"`/`"gray"`, `"dirt"`/`"brown"`/`"green"`, `"metal"`/`"purple"`, `"ice"`/`"blue"`/`"cyan"`, `"fire"`/`"red"`. Omit to use the default. |
+
+A `structure: true` wall does **not** need a `persistent` block — the wall template itself persists on the board until manually deleted with the normal template tool. A wall that should apply ongoing effects to creatures (damage zone) still needs a `persistent` block and should leave `structure` unset.
 
 **Distance forms:**
 

--- a/dnd/vtt/assets/js/ui/board-interactions.js
+++ b/dnd/vtt/assets/js/ui/board-interactions.js
@@ -14492,13 +14492,18 @@ export function mountBoardInteractions(store, routes = {}) {
       );
       const request = pendingAutomationArea;
       const wallColor = request.targetConfig?.wallColor;
+      // `structure: true` opts this wall into creating a real, permanent wall
+      // template (textured, selectable, lives in scene state) instead of only a
+      // transient persistent-zone overlay. Used by terrain abilities like
+      // Motivate Earth. Zone-based walls (e.g. Wall of Fire) leave it unset.
+      const persistStructure = Boolean(request.targetConfig?.structure);
       pendingAutomationArea = null;
       if (typeof templateTool?.startWallPlacementForAutomation !== 'function') {
         request.resolve?.({ canceled: true });
         updateStatus('Wall placement is not available (template tool missing).');
         return;
       }
-      templateTool.startWallPlacementForAutomation(length, { wallColor }).then((result) => {
+      templateTool.startWallPlacementForAutomation(length, { wallColor, persistStructure }).then((result) => {
         if (!result || result.canceled) {
           request.resolve?.({ canceled: true });
           updateStatus('Wall placement canceled.');
@@ -21755,13 +21760,13 @@ function createTemplateTool() {
   // Used by ability automation (persistent-zone walls) to drive the same
   // wall-placement UI the GM uses for templates, but capture the result
   // through a callback instead of writing a permanent template shape.
-  function startWallPlacementForAutomation(squareCount, { wallColor } = {}) {
+  function startWallPlacementForAutomation(squareCount, { wallColor, persistStructure } = {}) {
     return new Promise((resolve) => {
       const total = Math.max(1, Number.parseInt(squareCount, 10) || 1);
       cancelPlacement();
       placementState = {
         type: 'wall',
-        values: { squares: total, wallColor: wallColor || undefined },
+        values: { squares: total, wallColor: wallColor || undefined, persistStructure: Boolean(persistStructure) },
         stage: 'wall-select',
         pointerId: null,
         start: null,
@@ -22251,6 +22256,25 @@ function createTemplateTool() {
     activateTemplate(shape);
     render(viewState);
     commitShapes();
+  }
+
+  // Create a real, permanent wall structure (the textured wall-tile template,
+  // same visual as the manual wall tool) from a list of placed squares. Used by
+  // automation walls that opt in via the target block's `structure` flag, so
+  // terrain-creating abilities like Motivate Earth leave an actual wall on the
+  // board instead of a transient persistent-zone overlay. Unlike addShape this
+  // does NOT select/activate the new shape, so it won't hijack the board's
+  // selection or open the template editor mid-automation.
+  function createPermanentWallFromSquares(squares, wallColor) {
+    const clamped = clampWallSquares(squares, viewState);
+    if (!clamped.length) return null;
+    const levelId = getActiveTokenPlacementLevelId() ?? BASE_MAP_LEVEL_ID;
+    const shape = createShape('wall', { squares: clamped, wallColor, levelId });
+    shapes.push(shape);
+    layer.appendChild(shape.elements.root);
+    render(viewState);
+    commitShapes();
+    return shape;
   }
 
   function createShape(type, data, options = {}) {
@@ -23758,15 +23782,23 @@ function createTemplateTool() {
     if (remaining <= 0) {
       const finalSquares = placementState.squares.slice();
       const wallColor = placementState.values?.wallColor;
+      const persistStructure = Boolean(placementState.values?.persistStructure);
       // If this placement was started for an ability automation, deliver
       // the squares to the callback INSTEAD of adding a permanent template
-      // shape to the scene state. The zone overlay handles its own visuals.
+      // shape to the scene state — the persistent-zone overlay handles its own
+      // visuals. EXCEPTION: when the target block opts in with `structure:true`
+      // (terrain-creating abilities like Motivate Earth), also materialize a
+      // real wall template so the placed wall persists on the board with the
+      // proper textured visual instead of vanishing after the last square.
       if (typeof placementState.automationCallback === 'function') {
         const cb = placementState.automationCallback;
         placementState = null;
         clearPreview();
         restoreTemplateStatus();
         updateLayerVisibility();
+        if (persistStructure) {
+          createPermanentWallFromSquares(finalSquares, wallColor);
+        }
         try {
           cb({ squares: finalSquares, wallColor });
         } catch (err) {


### PR DESCRIPTION
## Summary

Automation walls (ability-automation `shape: "wall"` area targets) were wired to the persistent-zone overlay system — the translucent tiles with the ⚡ badge and **End** button — and never created the textured wall template that the **manual** wall tool produces. The two paths share the same cell-by-cell placement UI but diverge at the final square: the manual path calls `finalizePlacement` → `createShape('wall')`, while the automation path handed squares to a callback and explicitly skipped creating a permanent shape.

The visible symptom: terrain-creating abilities like the elementalist's **Motivate Earth** appeared to "flip" to a different template type and the wall seemed to vanish right after the last square was placed.

## What changed

- **`dnd/vtt/assets/js/ui/board-interactions.js`**
  - New `createPermanentWallFromSquares(squares, wallColor)` helper — builds a real `vtt-template--wall` shape from placed squares and commits it to scene state, *without* selecting/activating it (so it doesn't hijack board selection or open the template editor mid-automation).
  - Threaded a new opt-in flag through `handleAutomationAreaRequest` → `startWallPlacementForAutomation` → `handleWallPlacement`. When a wall area target block sets `structure: true`, completing placement now also materializes the permanent wall template.
- **`dnd/character_sheet/ability-automation/AUTHORING.md`**
  - Documented the `structure` and `wallColor` fields for `shape: "wall"` area target blocks.

## Why gated

`structure` is opt-in so only terrain walls (Motivate Earth) create a lasting structure. Zone-based walls that apply ongoing effects (e.g. Wall of Fire) still rely on a `persistent` block for their visuals and are unaffected.

## Reviewer notes

- `structure: true` walls do **not** need a `persistent` block; the wall template persists until manually deleted with the normal template tool.
- `wallColor` supports material variants already defined in `board.css`: `stone`/`gray`, `dirt`/`brown`/`green`, `metal`/`purple`, `ice`/`blue`/`cyan`, `fire`/`red`.
- `node --check` passes on the edited file. Not yet exercised in the live VTT — needs a hard refresh and a manual Motivate Earth placement to confirm the wall renders as a persistent dirt structure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)